### PR TITLE
fix(video_editor): correct atempo upper bound to 2.0

### DIFF
--- a/chapter5/video-edit/video_editor.py
+++ b/chapter5/video-edit/video_editor.py
@@ -93,7 +93,7 @@ def _apply_edit_ffmpeg(source: str, plan: dict, out_path: str) -> str:
             factor = float(eff.get("factor", 2.0))
             vf_chain.append(f"setpts={factor}*PTS")
             # atempo 只支持 0.5~2.0，用 1/factor 放慢音频。
-            af_chain.append(f"atempo={max(0.5, min(1.0, 1.0 / factor))}")
+            af_chain.append(f"atempo={max(0.5, min(2.0, 1.0 / factor))}")
 
     cmd = ["ffmpeg", "-y", "-ss", f"{start:.3f}", "-to", f"{end:.3f}", "-i", source]
     if vf_chain:


### PR DESCRIPTION
ffmpeg atempo supports 0.5-2.0, not 0.5-1.0. The clamp max(0.5, min(1.0, 1.0/factor)) silently caps speed-up at 1.0 (no effect) instead of the correct 2.0.