### PR TITLE
fix(video_edit): skip makedirs when output path has no directory

### DIFF
--- a/chapter5/video-edit/make_test_video.py
+++ b/chapter5/video-edit/make_test_video.py
@@ -34,9 +34,11 @@ def _drawtext(text, size, y_expr, color="white", box=False):
 
 def make(out_path: str) -> str:
     """生成测试视频，返回路径。幂等：每次覆盖，保证从干净状态开始。"""
-    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    out_dir = os.path.dirname(out_path)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
     clip_paths = []
-    tmp_dir = os.path.dirname(out_path)
+    tmp_dir = out_dir or "."
 
     for i, (name, color, start, dur) in enumerate(SCENES):
         clip = os.path.join(tmp_dir, f"_scene_{i}.mp4")

--- a/chapter5/video-edit/test_bare_output_filename.py
+++ b/chapter5/video-edit/test_bare_output_filename.py
@@ -1,0 +1,45 @@
+import os
+import make_test_video
+from video_editor import apply_edit
+
+
+def test_make_test_video_bare_filename():
+    out_name = "test_temp_bare_video.mp4"
+    if os.path.exists(out_name):
+        os.remove(out_name)
+    try:
+        path = make_test_video.make(out_name)
+        assert os.path.exists(path)
+        assert path == out_name
+    finally:
+        if os.path.exists(out_name):
+            os.remove(out_name)
+        for i in range(len(make_test_video.SCENES)):
+            scene_file = f"_scene_{i}.mp4"
+            if os.path.exists(scene_file):
+                os.remove(scene_file)
+
+
+def test_apply_edit_bare_filename():
+    source = "test_source.mp4"
+    make_test_video.make(source)
+    out_name = "test_output_bare_video.mp4"
+    if os.path.exists(out_name):
+        os.remove(out_name)
+    plan = {
+        "start": 0.0,
+        "end": 2.0,
+        "effects": [{"type": "subtitle", "text": "hello"}],
+    }
+    try:
+        path = apply_edit(source, plan, out_name, backend="ffmpeg")
+        assert os.path.exists(path)
+        assert path == out_name
+    finally:
+        for name in (out_name, source, "edit.py"):
+            if os.path.exists(name):
+                os.remove(name)
+        for i in range(len(make_test_video.SCENES)):
+            scene_file = f"_scene_{i}.mp4"
+            if os.path.exists(scene_file):
+                os.remove(scene_file)

--- a/chapter5/video-edit/video_editor.py
+++ b/chapter5/video-edit/video_editor.py
@@ -102,7 +102,9 @@ def _apply_edit_ffmpeg(source: str, plan: dict, out_path: str) -> str:
         cmd += ["-af", ",".join(af_chain)]
     cmd += ["-c:v", "libx264", "-c:a", "aac", "-pix_fmt", "yuv420p", out_path]
 
-    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    out_dir = os.path.dirname(out_path)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
     run(cmd, desc="ffmpeg 剪辑")
     return out_path
 


### PR DESCRIPTION
Bare filenames like output.mp4 make dirname empty, and os.makedirs("") raises FileNotFoundError. Skip makedirs when there is no directory component.