### PR TITLE
fix(coding_agent): allow notebook delete without new_source

### DIFF
--- a/chapter5/coding-agent/tests/test_notebook_edit_tool.py
+++ b/chapter5/coding-agent/tests/test_notebook_edit_tool.py
@@ -229,3 +229,14 @@ class TestNotebookEditTool:
         assert "error" in result.data
         assert "cell_id required" in result.data["error"]
 
+    def test_delete_without_new_source(self, system_state, sample_notebook):
+        """Delete must work when new_source is omitted."""
+        tool = NotebookEditTool(system_state)
+        result = tool.execute({
+            "notebook_path": str(sample_notebook),
+            "cell_id": "cell-1",
+            "edit_mode": "delete",
+        })
+        assert result.success
+        assert result.data["action"] == "deleted"
+

--- a/chapter5/coding-agent/tools/notebook_edit_tool.py
+++ b/chapter5/coding-agent/tools/notebook_edit_tool.py
@@ -27,7 +27,7 @@ class NotebookEditTool(BaseTool):
         """
         notebook_path = Path(params["notebook_path"]).expanduser().resolve()
         cell_id = params.get("cell_id")
-        new_source = params["new_source"]
+        new_source = params.get("new_source")
         cell_type = params.get("cell_type", "code")
         edit_mode = params.get("edit_mode", "replace")
         
@@ -42,6 +42,8 @@ class NotebookEditTool(BaseTool):
             cells = notebook.get('cells', [])
             
             if edit_mode == "insert":
+                if new_source is None:
+                    return {"error": "new_source required for insert mode"}
                 # Insert new cell
                 new_cell = {
                     "cell_type": cell_type,
@@ -83,6 +85,8 @@ class NotebookEditTool(BaseTool):
                 action = "deleted"
                 
             else:  # replace
+                if new_source is None:
+                    return {"error": "new_source required for replace mode"}
                 # Replace cell contents
                 if cell_id:
                     for cell in cells:


### PR DESCRIPTION
params["new_source"] raised KeyError on edit_mode=delete even though delete does not use new_source. Use .get and require new_source only for insert/replace.