### PR TITLE
fix(prompt_distillation): avoid ZeroDivisionError on empty compare inputs

### DIFF
--- a/chapter8/prompt-distillation/compare.py
+++ b/chapter8/prompt-distillation/compare.py
@@ -132,10 +132,22 @@ def compare(
         student_input_total += s_tok
         per_text_tokens.append((t_tok, s_tok))
 
-    teacher_avg = teacher_input_total / n
-    student_avg = student_input_total / n
-    reduction_pct = 100.0 * (1 - student_input_total / teacher_input_total)
-    ratio = teacher_input_total / student_input_total if student_input_total else float("inf")
+    if n == 0:
+        teacher_avg = student_avg = reduction_pct = 0.0
+        ratio = float("inf")
+    else:
+        teacher_avg = teacher_input_total / n
+        student_avg = student_input_total / n
+        reduction_pct = (
+            100.0 * (1 - student_input_total / teacher_input_total)
+            if teacher_input_total
+            else 0.0
+        )
+        ratio = (
+            teacher_input_total / student_input_total
+            if student_input_total
+            else float("inf")
+        )
 
     # 学生预测（与 test_file 逐行对齐）
     student_preds: Optional[List[Optional[str]]] = None

--- a/chapter8/prompt-distillation/test_compare_empty.py
+++ b/chapter8/prompt-distillation/test_compare_empty.py
@@ -1,0 +1,16 @@
+from compare import compare
+
+
+def test_compare_empty_texts():
+    result = compare(
+        prompt_template="Classify: {text}",
+        texts=[],
+        teacher_labels={},
+        eval_results=None,
+        count_tokens=lambda s: max(1, len(s) // 4),
+        token_method="test",
+        num_examples=3,
+    )
+    assert result["teacher_input_avg"] == 0.0
+    assert result["student_input_avg"] == 0.0
+    assert result["input_token_reduction_pct"] == 0.0


### PR DESCRIPTION
compare() divided token totals by len(texts) with no empty-list guard. Return zero averages when texts is empty.