### PR TITLE
fix(log_diagnosis): handle null latency_ms and missing threshold

### DIFF
--- a/chapter5/log-diagnosis/replay.py
+++ b/chapter5/log-diagnosis/replay.py
@@ -72,10 +72,25 @@ def _eval_assertion(assertion: Dict[str, Any], traj: Dict[str, Any]) -> Tuple[bo
     if a_type == "latency_under":
         tool = params.get("tool")
         thr = params.get("threshold_ms") or params.get("threshold")
+        if thr is None:
+            return False, "latency_under 断言缺失阈值设置"
+        try:
+            thr = float(thr)
+        except (TypeError, ValueError):
+            return False, f"latency_under 阈值非法: {thr!r}"
         calls = _tool_turns(traj, tool)
         if not calls:
             return False, f"{tool} 未被调用"
-        worst = max(c.get("latency_ms", 0) for c in calls)
+        latencies = []
+        for c in calls:
+            lat = c.get("latency_ms")
+            if lat is None:
+                lat = 0
+            try:
+                latencies.append(float(lat))
+            except (TypeError, ValueError):
+                latencies.append(0.0)
+        worst = max(latencies) if latencies else 0.0
         ok = worst < thr
         return ok, f"{tool} 最大延迟 {worst}ms, 阈值 {thr}ms"
 

--- a/chapter5/log-diagnosis/test_replay_latency.py
+++ b/chapter5/log-diagnosis/test_replay_latency.py
@@ -1,0 +1,25 @@
+from replay import _eval_assertion
+
+
+def test_latency_under_null_latency_ms():
+    assertion = {
+        "type": "latency_under",
+        "params": {"tool": "test_tool", "threshold": 150},
+    }
+    traj = {
+        "turns": [
+            {"tool": "test_tool", "latency_ms": None},
+            {"tool": "test_tool", "latency_ms": 120},
+        ]
+    }
+    ok, msg = _eval_assertion(assertion, traj)
+    assert ok
+    assert "最大延迟 120.0ms" in msg
+
+
+def test_latency_under_missing_threshold():
+    assertion = {"type": "latency_under", "params": {"tool": "test_tool"}}
+    traj = {"turns": [{"tool": "test_tool", "latency_ms": 100}]}
+    ok, msg = _eval_assertion(assertion, traj)
+    assert not ok
+    assert "断言缺失阈值设置" in msg


### PR DESCRIPTION
latency_under compared worst < thr when thr was None, and max() raised TypeError when latency_ms was explicitly null. Coerce and guard those cases.