### PR TITLE
fix(browser_tools): await page.title() instead of reading the method

### DIFF
--- a/chapter4/collaboration-tools/src/browser_tools.py
+++ b/chapter4/collaboration-tools/src/browser_tools.py
@@ -86,7 +86,7 @@ async def browser_navigate(url: str, new_tab: bool = False) -> Dict[str, Any]:
         return {
             "success": True,
             "url": url,
-            "title": page.title if hasattr(page, 'title') else "N/A",
+            "title": await page.title() if hasattr(page, 'title') else "N/A",
             "message": f"Successfully navigated to {url}"
         }
         
@@ -120,7 +120,7 @@ async def browser_get_content(selector: Optional[str] = None) -> Dict[str, Any]:
                 try:
                     text = await elem.get_text()
                     content.append(text)
-                except:
+                except Exception:
                     pass
             
             return {
@@ -264,7 +264,7 @@ async def browser_list_tabs() -> Dict[str, Any]:
             tabs.append({
                 "index": idx,
                 "url": page.url if hasattr(page, 'url') else "N/A",
-                "title": page.title if hasattr(page, 'title') else "N/A"
+                "title": await page.title() if hasattr(page, 'title') else "N/A"
             })
         
         return {

--- a/chapter4/collaboration-tools/test_browser_title.py
+++ b/chapter4/collaboration-tools/test_browser_title.py
@@ -1,0 +1,40 @@
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
+
+@pytest.mark.asyncio
+async def test_browser_navigate_awaits_title():
+    mock_page = AsyncMock()
+    mock_page.title.return_value = "Test Page Title"
+    mock_page.url = "http://example.com"
+    mock_browser = AsyncMock()
+    mock_browser.get_current_page.return_value = mock_page
+    with patch("browser_tools.init_browser", return_value=mock_browser):
+        from browser_tools import browser_navigate
+        res = await browser_navigate("http://example.com")
+    assert res["success"]
+    assert res["title"] == "Test Page Title"
+    mock_page.title.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_browser_list_tabs_awaits_title():
+    mock_page1 = AsyncMock()
+    mock_page1.title.return_value = "Title 1"
+    mock_page1.url = "http://example.com/1"
+    mock_page2 = AsyncMock()
+    mock_page2.title.return_value = "Title 2"
+    mock_page2.url = "http://example.com/2"
+    mock_browser = AsyncMock()
+    mock_browser.get_pages.return_value = [mock_page1, mock_page2]
+    with patch("browser_tools.init_browser", return_value=mock_browser):
+        from browser_tools import browser_list_tabs
+        res = await browser_list_tabs()
+    assert res["success"]
+    assert res["tabs"][0]["title"] == "Title 1"
+    assert res["tabs"][1]["title"] == "Title 2"


### PR DESCRIPTION
Playwright page.title is async; using page.title as a property returned a bound method and broke JSON tool results. Await page.title() in navigate and list_tabs.