### PR TITLE
fix(wiki_enhanced): reject incomplete dates before indexing date_parts

### DIFF
--- a/chapter4/perception-tools/src/wiki_enhanced.py
+++ b/chapter4/perception-tools/src/wiki_enhanced.py
@@ -196,8 +196,12 @@ async def get_article_history(
     try:
         logging.info(f"📚 Getting historical version: {title} at {date}")
         
-        # Parse date
+        # Parse date (YYYY/MM or YYYY/MM/DD)
+        if not isinstance(date, str) or "/" not in date:
+            raise ValueError("date must be YYYY/MM/DD or YYYY/MM")
         date_parts = date.split("/")
+        if len(date_parts) < 2:
+            raise ValueError("date must be YYYY/MM/DD or YYYY/MM")
         year = int(date_parts[0])
         month = int(date_parts[1])
         day = int(date_parts[2]) if len(date_parts) > 2 else calendar.monthrange(year, month)[1]

--- a/chapter4/perception-tools/test_wiki_article_history_date.py
+++ b/chapter4/perception-tools/test_wiki_article_history_date.py
@@ -1,0 +1,31 @@
+import asyncio
+import json
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
+# Optional runtime deps for importing the chapter module in unit tests.
+sys.modules.setdefault("wikipedia", types.ModuleType("wikipedia"))
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+mcp = types.ModuleType("mcp")
+mcp_types = types.ModuleType("mcp.types")
+
+class TextContent:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+mcp_types.TextContent = TextContent
+sys.modules["mcp"] = mcp
+sys.modules["mcp.types"] = mcp_types
+
+from wiki_enhanced import get_article_history
+
+
+def test_year_only_date_returns_error_payload():
+    result = asyncio.run(get_article_history("Python", "2025"))
+    payload = json.loads(result.text)
+    assert payload["success"] is False
+    msg = str(payload["message"])
+    assert "date must be" in msg or "Failed" in msg


### PR DESCRIPTION
Year-only strings like "2025" made date_parts[1] raise IndexError inside get_article_history. Validate YYYY/MM[/DD] before indexing.