### PR TITLE
fix(coding_agent): treat null Grep -B/-A/-C like omit

### DIFF
--- a/chapter5/coding-agent/tests/test_grep_tool.py
+++ b/chapter5/coding-agent/tests/test_grep_tool.py
@@ -234,3 +234,27 @@ class TestGrepTool:
         assert result.success
         assert "ERROR" in result.data["output"]
 
+    def test_null_context_before_like_omit(self, system_state, sample_files):
+        """Explicit JSON null -B must behave like omit (default 0)."""
+        tool = GrepTool(system_state)
+        result = tool.execute({
+            "pattern": "ERROR",
+            "path": str(sample_files["text_file1"]),
+            "output_mode": "content",
+            "-B": None,
+        })
+        assert result.success
+        assert "ERROR" in result.data["output"]
+
+    def test_null_context_after_like_omit(self, system_state, sample_files):
+        """Explicit JSON null -A must behave like omit (default 0)."""
+        tool = GrepTool(system_state)
+        result = tool.execute({
+            "pattern": "ERROR",
+            "path": str(sample_files["text_file1"]),
+            "output_mode": "content",
+            "-A": None,
+        })
+        assert result.success
+        assert "ERROR" in result.data["output"]
+

--- a/chapter5/coding-agent/tests/test_grep_tool.py
+++ b/chapter5/coding-agent/tests/test_grep_tool.py
@@ -258,3 +258,15 @@ class TestGrepTool:
         assert result.success
         assert "ERROR" in result.data["output"]
 
+    def test_null_context_around_like_omit(self, system_state, sample_files):
+        """Explicit JSON null -C must behave like omit (default 0)."""
+        tool = GrepTool(system_state)
+        result = tool.execute({
+            "pattern": "ERROR",
+            "path": str(sample_files["text_file1"]),
+            "output_mode": "content",
+            "-C": None,
+        })
+        assert result.success
+        assert "ERROR" in result.data["output"]
+

--- a/chapter5/coding-agent/tools/grep_tool.py
+++ b/chapter5/coding-agent/tools/grep_tool.py
@@ -38,9 +38,9 @@ class GrepTool(BaseTool):
         glob_pattern = params.get("glob")
         output_mode = params.get("output_mode", "files_with_matches")
         case_insensitive = params.get("-i", False)
-        context_before = params.get("-B", 0)
-        context_after = params.get("-A", 0)
-        context_around = params.get("-C", 0)
+        context_before = params.get("-B") or 0
+        context_after = params.get("-A") or 0
+        context_around = params.get("-C") or 0
         show_line_numbers = params.get("-n", False)
         multiline = params.get("multiline", False)
         head_limit = params.get("head_limit")

--- a/chapter5/coding-agent/tools/grep_tool.py
+++ b/chapter5/coding-agent/tools/grep_tool.py
@@ -38,9 +38,15 @@ class GrepTool(BaseTool):
         glob_pattern = params.get("glob")
         output_mode = params.get("output_mode", "files_with_matches")
         case_insensitive = params.get("-i", False)
-        context_before = params.get("-B") or 0
-        context_after = params.get("-A") or 0
-        context_around = params.get("-C") or 0
+        context_before = params.get("-B")
+        if context_before is None:
+            context_before = 0
+        context_after = params.get("-A")
+        if context_after is None:
+            context_after = 0
+        context_around = params.get("-C")
+        if context_around is None:
+            context_around = 0
         show_line_numbers = params.get("-n", False)
         multiline = params.get("multiline", False)
         head_limit = params.get("head_limit")


### PR DESCRIPTION
Grep content mode did line_num - context_before when -B/-A/-C were JSON null, raising TypeError. Treat null like omit (0).

Repro: Grep with pattern match and "-B": null.