### PR TITLE
fix(coding_agent): treat null Bash timeout like omit

### DIFF
--- a/chapter5/coding-agent/tests/test_bash_tool.py
+++ b/chapter5/coding-agent/tests/test_bash_tool.py
@@ -174,3 +174,14 @@ class TestBashTool:
         assert result.success
         assert "working_directory" in result.data
 
+    def test_null_timeout_like_omit(self, system_state):
+        """Explicit JSON null timeout must behave like omit (default 120s)."""
+        tool = BashTool(system_state)
+        result = tool.execute({
+            "command": "echo ok",
+            "timeout": None,
+        })
+        assert result.success
+        assert "ok" in result.data["output"]
+        assert result.data["exit_code"] == 0
+

--- a/chapter5/coding-agent/tools/bash_tool.py
+++ b/chapter5/coding-agent/tools/bash_tool.py
@@ -27,7 +27,10 @@ class BashTool(BaseTool):
         - Output truncated if exceeds 30000 characters
         """
         command = params["command"]
-        timeout = params.get("timeout", 120000) / 1000  # Convert ms to seconds
+        timeout_ms = params.get("timeout")
+        if timeout_ms is None:
+            timeout_ms = 120000
+        timeout = timeout_ms / 1000  # Convert ms to seconds
         run_in_background = params.get("run_in_background", False)
         
         # Get or create shell session


### PR DESCRIPTION
Bash did params.get("timeout", 120000) / 1000, so timeout: null became None/1000 and TypeError. Default null to 120000 ms.

Repro: Bash {"command":"echo hi","timeout":null}.