### PR TITLE
fix(coding_agent): treat null TodoWrite todos like empty list

### DIFF
--- a/chapter5/coding-agent/tests/test_todo_write_tool.py
+++ b/chapter5/coding-agent/tests/test_todo_write_tool.py
@@ -126,3 +126,11 @@ class TestTodoWriteTool:
         assert result.data["in_progress"] == 1
         assert result.data["completed"] == 3
 
+    def test_null_todos_like_empty(self, system_state):
+        """Explicit JSON null todos must behave like an empty list."""
+        tool = TodoWriteTool(system_state)
+        result = tool.execute({"todos": None})
+        assert result.success
+        assert "error" not in result.data
+        assert result.data["total_todos"] == 0
+

--- a/chapter5/coding-agent/tools/todo_write_tool.py
+++ b/chapter5/coding-agent/tools/todo_write_tool.py
@@ -21,7 +21,11 @@ class TodoWriteTool(BaseTool):
         - Track progress, organize complex tasks
         - Helps user understand progress
         """
-        todos = params["todos"]
+        todos = params.get("todos")
+        if todos is None:
+            todos = []
+        if not isinstance(todos, list):
+            return {"error": "todos must be a list of todo items"}
         
         # Validate todo format
         for todo in todos:

--- a/chapter5/coding-agent/tools/todo_write_tool.py
+++ b/chapter5/coding-agent/tools/todo_write_tool.py
@@ -21,12 +21,11 @@ class TodoWriteTool(BaseTool):
         - Track progress, organize complex tasks
         - Helps user understand progress
         """
-        todos = params.get("todos")
+        # JSON null for required todos: same as empty list (LLM omit-as-null).
+        todos = params["todos"]
         if todos is None:
             todos = []
-        if not isinstance(todos, list):
-            return {"error": "todos must be a list of todo items"}
-        
+
         # Validate todo format
         for todo in todos:
             if not all(k in todo for k in ["id", "content", "status"]):


### PR DESCRIPTION
TodoWrite raised TypeError when todos was JSON null. Treat null as an empty todo list.

Repro: TodoWrite {"todos": null}.
