### PR TITLE
fix(coding_agent): treat null LS ignore as empty list

### DIFF
--- a/chapter5/coding-agent/tests/test_ls_tool.py
+++ b/chapter5/coding-agent/tests/test_ls_tool.py
@@ -196,3 +196,15 @@ class TestLSTool:
         finally:
             restricted_dir.chmod(0o755)  # Restore permissions for cleanup
 
+
+    def test_ignore_null_lists_directory(self, system_state, temp_dir):
+        """JSON null ignore must not break listing (agent omits optional array)."""
+        tool = LSTool(system_state)
+        (temp_dir / "keep.txt").write_text("keep")
+        result = tool.execute({
+            "path": str(temp_dir),
+            "ignore": None,
+        })
+        assert result.success
+        assert "error" not in result.data
+        assert any(e["name"] == "keep.txt" for e in result.data["entries"])

--- a/chapter5/coding-agent/tools/ls_tool.py
+++ b/chapter5/coding-agent/tools/ls_tool.py
@@ -24,7 +24,7 @@ class LSTool(BaseTool):
         - You can optionally provide an array of glob patterns to ignore
         """
         path = Path(params["path"]).expanduser().resolve()
-        ignore_patterns = params.get("ignore", [])
+        ignore_patterns = params.get("ignore") or []
         
         if not path.exists():
             return {"error": f"Path not found: {path}"}

--- a/chapter5/coding-agent/tools/ls_tool.py
+++ b/chapter5/coding-agent/tools/ls_tool.py
@@ -24,7 +24,9 @@ class LSTool(BaseTool):
         - You can optionally provide an array of glob patterns to ignore
         """
         path = Path(params["path"]).expanduser().resolve()
-        ignore_patterns = params.get("ignore") or []
+        ignore_patterns = params.get("ignore")
+        if ignore_patterns is None:
+            ignore_patterns = []
         
         if not path.exists():
             return {"error": f"Path not found: {path}"}


### PR DESCRIPTION
LS iterated ignore when it was JSON null and TypeError. Treat null like omit ([]).

Repro: LS with "ignore": null on a nonempty directory.