### PR TITLE
fix(coding_agent): default null Read offset and limit

### DIFF
--- a/chapter5/coding-agent/tests/test_read_tool.py
+++ b/chapter5/coding-agent/tests/test_read_tool.py
@@ -191,3 +191,17 @@ class TestReadTool:
         assert "error" in result.data
         assert "not a file" in result.data["error"].lower()
 
+
+    def test_null_offset_and_limit(self, system_state, sample_files):
+        """JSON null offset/limit must use defaults (agent omits optional numbers)."""
+        tool = ReadTool(system_state)
+        path = sample_files["python_file"]
+        result = tool.execute({
+            "file_path": str(path),
+            "offset": None,
+            "limit": None,
+        })
+        assert result.success
+        assert "error" not in result.data
+        assert "def hello" in result.data["content"]
+        assert result.data["total_lines"] > 0

--- a/chapter5/coding-agent/tools/read_tool.py
+++ b/chapter5/coding-agent/tools/read_tool.py
@@ -27,8 +27,12 @@ class ReadTool(BaseTool):
         - Supports images, PDFs, Jupyter notebooks
         """
         file_path = Path(params["file_path"]).expanduser().resolve()
-        offset = params.get("offset", 0)
-        limit = params.get("limit", 2000)
+        offset = params.get("offset")
+        if offset is None:
+            offset = 0
+        limit = params.get("limit")
+        if limit is None:
+            limit = 2000
         
         if not file_path.exists():
             return {"error": f"File not found: {file_path}"}


### PR DESCRIPTION
Read sliced with offset/limit when those optionals were JSON null and TypeError. Default null offset to 0 and null limit to 2000.

Repro: Read with "offset": null, "limit": 10.