### PR TITLE
fix(coding_agent): treat null Glob path like cwd

### DIFF
--- a/chapter5/coding-agent/tests/test_glob_tool.py
+++ b/chapter5/coding-agent/tests/test_glob_tool.py
@@ -119,3 +119,13 @@ class TestGlobTool:
         finally:
             os.chdir(original_cwd)
 
+    def test_null_path_like_omit(self, system_state, sample_files):
+        """Explicit JSON null path must behave like omit (cwd / search root)."""
+        tool = GlobTool(system_state)
+        result = tool.execute({
+            "pattern": "*.py",
+            "path": None,
+        })
+        assert result.success
+        assert "error" not in result.data
+        assert isinstance(result.data["matches"], list)

--- a/chapter5/coding-agent/tools/glob_tool.py
+++ b/chapter5/coding-agent/tools/glob_tool.py
@@ -25,6 +25,8 @@ class GlobTool(BaseTool):
         """
         pattern = params["pattern"]
         path = params.get("path", ".")
+        if path is None:
+            path = "."
         
         # Resolve search path
         search_path = Path(path).expanduser().resolve()


### PR DESCRIPTION
Glob resolved path when it was JSON null and TypeError. Treat null like omit (".").

Repro: Glob with "pattern": "*.py", "path": null.