### PR TITLE
fix(coding_agent): treat null Grep path like cwd

### DIFF
--- a/chapter5/coding-agent/tests/test_grep_tool.py
+++ b/chapter5/coding-agent/tests/test_grep_tool.py
@@ -270,3 +270,13 @@ class TestGrepTool:
         assert result.success
         assert "ERROR" in result.data["output"]
 
+    def test_null_path_like_omit(self, system_state, sample_files):
+        """Explicit JSON null path must behave like omit (default search root)."""
+        tool = GrepTool(system_state)
+        result = tool.execute({
+            "pattern": "ERROR",
+            "path": None,
+            "output_mode": "content",
+        })
+        assert result.success
+        assert "error" not in result.data

--- a/chapter5/coding-agent/tools/grep_tool.py
+++ b/chapter5/coding-agent/tools/grep_tool.py
@@ -35,6 +35,8 @@ class GrepTool(BaseTool):
         """
         pattern = params["pattern"]
         path = params.get("path", ".")
+        if path is None:
+            path = "."
         glob_pattern = params.get("glob")
         output_mode = params.get("output_mode", "files_with_matches")
         case_insensitive = params.get("-i", False)


### PR DESCRIPTION
Grep resolved path when it was JSON null and TypeError. Treat null like omit (".").

Repro: Grep with "pattern": "foo", "path": null.