### PR TITLE
fix(coding_agent): treat null MultiEdit edits like empty list

### DIFF
--- a/chapter5/coding-agent/tests/test_multi_edit_tool.py
+++ b/chapter5/coding-agent/tests/test_multi_edit_tool.py
@@ -204,3 +204,16 @@ def old_function():
         assert result.success
         assert result.data["old_size"] < result.data["new_size"]
 
+    def test_null_edits_like_empty(self, system_state, temp_dir):
+        """Explicit JSON null edits must behave like an empty list."""
+        tool = MultiEditTool(system_state)
+        file_path = temp_dir / "null_edits.py"
+        file_path.write_text("x = 1\n")
+        result = tool.execute({
+            "file_path": str(file_path),
+            "edits": None,
+        })
+        assert result.success
+        assert "error" not in result.data
+        assert result.data["total_edits"] == 0
+        assert file_path.read_text() == "x = 1\n"

--- a/chapter5/coding-agent/tools/multi_edit_tool.py
+++ b/chapter5/coding-agent/tools/multi_edit_tool.py
@@ -26,7 +26,9 @@ class MultiEditTool(BaseTool):
         - The edits are atomic - either all succeed or none are applied
         """
         file_path = Path(params["file_path"]).expanduser().resolve()
-        edits = params["edits"]
+        edits = params.get("edits")
+        if edits is None:
+            edits = []
         
         if not file_path.exists():
             # Check if this is a file creation (first edit has empty old_string)


### PR DESCRIPTION
MultiEdit iterated edits when it was JSON null and TypeError. Treat null like omit ([]).

Repro: MultiEdit with "edits": null on an existing file.