### PR TITLE
fix(self-evolving): default null num_results to 6

### DIFF
--- a/chapter8/self-evolving-tools/base_tools.py
+++ b/chapter8/self-evolving-tools/base_tools.py
@@ -41,6 +41,8 @@ def web_search(query: str, num_results: int = 6) -> dict:
     if not query:
         return {"success": False, "error": "search query is empty", "results": []}
 
+    if num_results is None:
+        num_results = 6
     num_results = max(1, min(int(num_results), 10))
     headers = {
         "User-Agent": (

--- a/chapter8/self-evolving-tools/test_null_num_results.py
+++ b/chapter8/self-evolving-tools/test_null_num_results.py
@@ -1,0 +1,23 @@
+"""Null optional num_results must use default 6."""
+import base_tools
+
+
+def test_null_num_results_like_omit(monkeypatch):
+    seen = {}
+
+    def fake_parse(endpoint, html, num_results):
+        seen["n"] = num_results
+        return [{"title": "t", "url": "https://example.com", "snippet": ""}]
+
+    class Resp:
+        status_code = 200
+        text = "<html></html>"
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(base_tools.requests, "post", lambda *a, **k: Resp())
+    monkeypatch.setattr(base_tools, "_parse_ddg", fake_parse)
+    monkeypatch.setattr(base_tools.time, "sleep", lambda *_: None)
+    out = base_tools.web_search("python", num_results=None)
+    assert out["success"] is True
+    assert seen["n"] == 6


### PR DESCRIPTION
web_search called int(num_results) when the optional was JSON null and TypeError. Default null to 6.

Repro: web_search("python", num_results=None).