### PR TITLE
fix(multilang): default null language to python

### DIFF
--- a/chapter4/execution-tools/execution_tools.py
+++ b/chapter4/execution-tools/execution_tools.py
@@ -89,6 +89,8 @@ class ExecutionTools:
         Returns:
             Result dictionary with output and analysis
         """
+        if language is None:
+            language = "python"
         language = language.lower()
         
         # Verify syntax first (only for Python for now)

--- a/chapter4/execution-tools/multilang_executor.py
+++ b/chapter4/execution-tools/multilang_executor.py
@@ -98,6 +98,8 @@ class LanguageExecutor:
         Returns:
             Execution result dictionary
         """
+        if language is None:
+            language = "python"
         language = language.lower()
         
         # Map language to executor

--- a/chapter4/execution-tools/server.py
+++ b/chapter4/execution-tools/server.py
@@ -216,7 +216,7 @@ async def handle_call_tool(
         elif name == "code_interpreter":
             result = await execution_tools.code_interpreter(
                 code=arguments["code"],
-                language=arguments.get("language", "python"),
+                language=arguments.get("language") or "python",
                 timeout=arguments.get("timeout", 30.0),
                 stdin=arguments.get("stdin"),
                 files=arguments.get("files")

--- a/chapter4/execution-tools/test_null_language.py
+++ b/chapter4/execution-tools/test_null_language.py
@@ -1,15 +1,45 @@
-"""Null optional language must default to python."""
+"""Null optional language must default to python on public paths."""
 import asyncio
 import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from multilang_executor import LanguageExecutor
+from execution_tools import ExecutionTools
 
 
-def test_null_language_like_python():
+def test_null_language_executor_defaults_to_python():
     le = LanguageExecutor(workspace_dir=Path(tempfile.mkdtemp()))
     result = asyncio.run(le.execute_code("print(42)", language=None, timeout=10))
-    assert result.get("language") == "python" or "42" in str(result.get("stdout", "")) or result.get("success") is not False
-    # Must not AttributeError; executor returns a dict
     assert isinstance(result, dict)
-    assert "error" not in result or "Unsupported language" not in str(result.get("error", ""))
+    assert result.get("language") == "python"
+    assert "42" in (result.get("stdout") or "")
+
+
+def test_null_language_code_interpreter_defaults(monkeypatch):
+    """Public MCP path: ExecutionTools.code_interpreter(language=None)."""
+    helper = MagicMock()
+    et = ExecutionTools(helper)
+    seen = {}
+
+    async def fake_exec(code, language, timeout=30.0, stdin=None, files=None):
+        seen["language"] = language
+        return {
+            "success": True,
+            "stdout": "ok\n",
+            "stderr": "",
+            "language": language,
+            "returncode": 0,
+            "status": "ok",
+        }
+
+    monkeypatch.setattr(et.lang_executor, "execute_code", fake_exec)
+    import config as cfg
+    monkeypatch.setattr(cfg.Config, "AUTO_VERIFY_CODE", False, raising=False)
+    monkeypatch.setattr(cfg.Config, "REQUIRE_APPROVAL_FOR_DANGEROUS_OPS", False, raising=False)
+    monkeypatch.setattr(cfg.Config, "AUTO_SUMMARIZE_OUTPUT", False, raising=False)
+
+    out = asyncio.run(et.code_interpreter("print(1)", language=None))
+    assert seen["language"] == "python"
+    assert out["language"] == "python"
+    assert out.get("error") in (None, "")

--- a/chapter4/execution-tools/test_null_language.py
+++ b/chapter4/execution-tools/test_null_language.py
@@ -1,0 +1,15 @@
+"""Null optional language must default to python."""
+import asyncio
+import tempfile
+from pathlib import Path
+
+from multilang_executor import LanguageExecutor
+
+
+def test_null_language_like_python():
+    le = LanguageExecutor(workspace_dir=Path(tempfile.mkdtemp()))
+    result = asyncio.run(le.execute_code("print(42)", language=None, timeout=10))
+    assert result.get("language") == "python" or "42" in str(result.get("stdout", "")) or result.get("success") is not False
+    # Must not AttributeError; executor returns a dict
+    assert isinstance(result, dict)
+    assert "error" not in result or "Unsupported language" not in str(result.get("error", ""))


### PR DESCRIPTION
code_interpreter called language.lower() when language was JSON null and AttributeError. Default null to "python" on the MCP path.

Repro: execute_code / code_interpreter with language=None.