### PR TITLE
fix(staged): treat null revision issues like empty list

### DIFF
--- a/chapter10/staged-system-prompt/agent.py
+++ b/chapter10/staged-system-prompt/agent.py
@@ -374,7 +374,9 @@ class StagedAgent:
             )
 
         if name == T.REQUEST_REVISION:
-            issues = args.get("issues", [])
+            issues = args.get("issues")
+            if issues is None:
+                issues = []
             if isinstance(issues, str):
                 issues = [issues]
             self.workspace.review_issues = list(issues)
@@ -432,7 +434,7 @@ class StagedAgent:
                     "content": "【系统】回退次数已达上限，演示到此结束。",
                 })
                 return True
-            issue_text = "\n".join(f"- {x}" for x in descriptor.get("issues", []))
+            issue_text = "\n".join(f"- {x}" for x in (descriptor.get("issues") or []))
             self.history.append({
                 "role": "user",
                 "content": (

--- a/chapter10/staged-system-prompt/test_null_issues.py
+++ b/chapter10/staged-system-prompt/test_null_issues.py
@@ -1,0 +1,17 @@
+"""Null issues on request_revision must behave like empty list."""
+from unittest.mock import MagicMock
+
+from agent import StagedAgent
+import tools as T
+
+
+def test_null_issues_like_empty():
+    agent = StagedAgent.__new__(StagedAgent)
+    agent.workspace = T.Workspace()
+    agent.revision_count = 0
+    agent.logs = []
+    agent._log = lambda *a, **k: None
+    msg, desc = agent._transition_result(T.REQUEST_REVISION, {"issues": None})
+    assert agent.workspace.review_issues == []
+    assert desc["issues"] == []
+    assert "退回" in msg or "问题" in msg


### PR DESCRIPTION
request_revision called list(issues) when issues was JSON null and TypeError. Treat null like omit ([]).

Repro: request_revision with "issues": null.