### PR TITLE
fix(paper_to_ppt): treat null review issues like empty list

### DIFF
--- a/chapter5/paper-to-ppt/demo.py
+++ b/chapter5/paper-to-ppt/demo.py
@@ -54,12 +54,18 @@ def save_text(name, text):
     return path
 
 
+def _review_issues(review: dict) -> list:
+    """JSON null issues must behave like omit ([])."""
+    issues = review.get("issues")
+    return issues if issues is not None else []
+
+
 def summarize_review(review: dict) -> str:
-    n_high = sum(1 for x in review.get("issues", []) if x.get("severity") == "high")
-    n_med = sum(1 for x in review.get("issues", []) if x.get("severity") == "medium")
-    n_low = sum(1 for x in review.get("issues", []) if x.get("severity") == "low")
+    n_high = sum(1 for x in _review_issues(review) if x.get("severity") == "high")
+    n_med = sum(1 for x in _review_issues(review) if x.get("severity") == "medium")
+    n_low = sum(1 for x in _review_issues(review) if x.get("severity") == "low")
     return (f"score={review.get('overall_score')} pass={review.get('pass')} "
-            f"issues={len(review.get('issues', []))} (high={n_high}, med={n_med}, low={n_low})")
+            f"issues={len(_review_issues(review))} (high={n_high}, med={n_med}, low={n_low})")
 
 
 # --------------------------------------------------------------------------- #
@@ -93,7 +99,7 @@ def run_proposer_reviewer(paper_md, figures, max_rounds=MAX_ROUNDS):
                   json.dumps(review, ensure_ascii=False, indent=2))
         history.append((review.get("overall_score", 0), review))
 
-        blocking = [i for i in review.get("issues", [])
+        blocking = [i for i in _review_issues(review)
                     if i.get("severity") in ("high", "medium")]
         if review.get("pass") and not blocking:
             print("  ✓ Reviewer 判定达标（无 high/medium 问题），提前结束迭代。")

--- a/chapter5/paper-to-ppt/test_null_issues.py
+++ b/chapter5/paper-to-ppt/test_null_issues.py
@@ -1,0 +1,25 @@
+"""Null review issues must summarize without TypeError."""
+import sys
+from unittest.mock import MagicMock
+
+# demo.py imports heavy optional deps at module import time.
+sys.modules.setdefault("dotenv", MagicMock())
+sys.modules.setdefault("agents", MagicMock())
+sys.modules.setdefault("make_figures", MagicMock())
+sys.modules.setdefault("renderer", MagicMock())
+
+from demo import summarize_review, _review_issues
+
+
+def test_null_issues_like_empty():
+    assert _review_issues({"issues": None}) == []
+    text = summarize_review({"overall_score": 90, "pass": True, "issues": None})
+    assert "issues=0" in text
+    assert "high=0" in text
+
+
+def test_issues_preserved():
+    issues = [{"severity": "high"}]
+    assert _review_issues({"issues": issues}) == issues
+    text = summarize_review({"overall_score": 50, "pass": False, "issues": issues})
+    assert "high=1" in text


### PR DESCRIPTION
summarize_review iterated issues when Vision JSON had issues:null and TypeError. Treat null like omit ([]).

Repro: summarize_review({"issues": null}).