### PR TITLE
feat(context): add DeepSeek provider and fix ReAct loop for plain replies

### DIFF
--- a/chapter1/context/README.md
+++ b/chapter1/context/README.md
@@ -1,6 +1,6 @@
 # Context-Aware AI Agent with Ablation Studies
 
-An advanced AI agent implementation supporting multiple LLM providers (SiliconFlow Qwen, ByteDance Doubao, and Moonshot Kimi), designed to demonstrate the critical importance of context components through systematic ablation studies.
+An advanced AI agent implementation supporting multiple LLM providers (SiliconFlow Qwen, ByteDance Doubao, Moonshot Kimi, and DeepSeek), designed to demonstrate the critical importance of context components through systematic ablation studies.
 
 ## 🎯 Overview
 
@@ -8,7 +8,7 @@ This project implements a context-aware AI agent with multiple tools (PDF parsin
 
 ### Key Features
 
-- **Multi-provider Support**: Works with SiliconFlow (Qwen), Doubao (ByteDance), and Kimi (Moonshot) LLMs
+- **Multi-provider Support**: Works with SiliconFlow (Qwen), Doubao (ByteDance), Kimi (Moonshot), and DeepSeek LLMs
 - **Multi-tool Agent**: PDF parsing, currency conversion, calculations, and Python code execution
 - **Context Modes**: Five different context configurations for ablation studies
 - **Interactive & Batch Modes**: Run single tasks or comprehensive test suites
@@ -32,6 +32,12 @@ This project implements a context-aware AI agent with multiple tools (PDF parsin
 - **API**: OpenAI-compatible via Moonshot platform
 - **Best for**: Advanced reasoning, multi-turn conversations, both English and Chinese tasks
 - **Features**: Context caching for cost optimization
+
+### DeepSeek
+- **Model**: deepseek-v4-flash (default; use `--model deepseek-v4-pro` for the stronger tier)
+- **API**: OpenAI-compatible via [DeepSeek Platform](https://platform.deepseek.com/)
+- **Best for**: Cost-effective tool-calling agents; thinking mode enabled so the `no_reasoning` ablation can strip `reasoning_content`
+- **Note**: Legacy aliases `deepseek-chat` / `deepseek-reasoner` are deprecated (2026-07-24); prefer the V4 ids
 
 ## 🏗️ Architecture
 
@@ -57,6 +63,7 @@ This project implements a context-aware AI agent with multiple tools (PDF parsin
   - **SiliconFlow**: Get from [SiliconFlow](https://siliconflow.cn)
   - **Doubao (ByteDance)**: Get from [Volcano Engine](https://www.volcengine.com/)
   - **Kimi (Moonshot)**: Get from [Moonshot Platform](https://platform.moonshot.cn/)
+  - **DeepSeek**: Get from [DeepSeek Platform](https://platform.deepseek.com/api_keys)
 
 ## 📝 Sample Tasks
 
@@ -101,19 +108,26 @@ python main.py --provider siliconflow
 export MOONSHOT_API_KEY=your_key_here
 python main.py --provider kimi
 
+# For DeepSeek
+export DEEPSEEK_API_KEY=your_key_here
+python main.py --provider deepseek
+# Optional stronger model:
+python main.py --provider deepseek --model deepseek-v4-pro
+
 # Or specify a custom model
 python main.py --model doubao-seed-1-6-thinking-250715
 
 # Universal OpenRouter fallback: if the provider key above is missing/invalid
 # but OPENROUTER_API_KEY is set, requests are routed through OpenRouter and the
 # model id is mapped automatically (bare gpt-*/o1-* -> openai/*, claude-* ->
-# anthropic/*, other native ids -> OPENROUTER_MODEL or openai/gpt-5.6-luna).
+# anthropic/*, deepseek-* -> deepseek/*, other native ids -> OPENROUTER_MODEL
+# or openai/gpt-5.6-luna).
 export OPENROUTER_API_KEY=sk-or-v1-your-key-here
 python main.py                       # falls back to OpenRouter when ARK_API_KEY is unset
 python main.py --provider openrouter # or use OpenRouter directly
 ```
 
-### 3. Testing Kimi Integration
+### 3. Testing Kimi / DeepSeek Integration
 
 ```bash
 # Quick test of Kimi K3 model
@@ -125,6 +139,15 @@ python main.py --provider kimi --mode interactive
 
 # Run ablation study with Kimi
 python main.py --provider kimi --mode ablation
+
+# Quick test of DeepSeek V4
+export DEEPSEEK_API_KEY=your_key_here
+python test_deepseek.py
+# or: python quick_test_deepseek.py
+
+# Use DeepSeek in main script / ablation study
+python main.py --provider deepseek --mode interactive
+python main.py --provider deepseek --mode ablation
 ```
 
 ### 4. Run Interactive Mode (Recommended)
@@ -401,6 +424,7 @@ MIT License - See LICENSE file for details
 ## 🙏 Acknowledgments
 
 - SiliconFlow for providing the Qwen model API
+- DeepSeek for the OpenAI-compatible V4 API
 - OpenAI for the client library
 - The AI agent research community
 

--- a/chapter1/context/agent.py
+++ b/chapter1/context/agent.py
@@ -325,7 +325,8 @@ class ContextAwareAgent:
         Args:
             api_key: API key for the LLM provider
             context_mode: Context mode for ablation studies
-            provider: LLM provider ('siliconflow', 'doubao', 'kimi', or 'moonshot')
+            provider: LLM provider ('siliconflow', 'doubao', 'kimi', 'moonshot',
+                'deepseek', or 'openrouter')
             model: Optional model override
             verbose: If True, log full HTTP requests and responses (default: True)
         """
@@ -333,17 +334,21 @@ class ContextAwareAgent:
         self.verbose = verbose
 
         # Provider -> (base_url, default_model)
+        deepseek_base = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
         provider_defaults = {
             "siliconflow": ("https://api.siliconflow.cn/v1", "Qwen/Qwen3.5-397B-A17B"),
             "doubao": ("https://ark.cn-beijing.volces.com/api/v3", "doubao-seed-1-6-thinking-250715"),
             "kimi": ("https://api.moonshot.cn/v1", "kimi-k3"),
             "moonshot": ("https://api.moonshot.cn/v1", "kimi-k3"),
+            # V4 Flash: OpenAI-compatible; tool calling + thinking mode.
+            # Legacy deepseek-chat / deepseek-reasoner aliases deprecated 2026-07-24.
+            "deepseek": (deepseek_base, "deepseek-v4-flash"),
             "openrouter": ("https://openrouter.ai/api/v1", "openai/gpt-5.6-luna"),
         }
         if self.provider not in provider_defaults:
             raise ValueError(
                 f"Unsupported provider: {provider}. Use 'siliconflow', 'doubao', "
-                "'kimi', 'moonshot', or 'openrouter'"
+                "'kimi', 'moonshot', 'deepseek', or 'openrouter'"
             )
         base_url, default_model = provider_defaults[self.provider]
         resolved_model = model or default_model
@@ -620,17 +625,39 @@ Important: When you have gathered all necessary information and computed the fin
             windowed.extend(tail[assistant_rel[-1]:])
         return windowed
 
-    def execute_task(self, task: str, max_iterations: int = 10) -> Dict[str, Any]:
+    @staticmethod
+    def _extract_final_answer(content: str) -> Optional[str]:
+        """Extract text after FINAL ANSWER: if present; otherwise None."""
+        if not content or "FINAL ANSWER:" not in content:
+            return None
+        return content.split("FINAL ANSWER:", 1)[1].strip()
+
+    def execute_task(self, task: str, max_iterations: Optional[int] = None) -> Dict[str, Any]:
         """
-        Execute a task using available tools
-        
+        Execute a task using available tools (ReAct loop).
+
+        Stops when:
+          1. The model emits a text-only reply (no tool_calls) — conversational
+             or task complete, including plain replies like "hi" that omit the
+             FINAL ANSWER: marker; or
+          2. max_iterations is hit (safety cap for tool-call loops, e.g. the
+             no_tool_results ablation).
+
         Args:
             task: The task to execute
-            max_iterations: Maximum number of tool calls
-            
+            max_iterations: Maximum ReAct steps (default: Config.MAX_ITERATIONS
+                or 10). This is a safety ceiling, not a target round count.
+
         Returns:
             Task execution result
         """
+        if max_iterations is None:
+            try:
+                from config import Config
+                max_iterations = Config.MAX_ITERATIONS
+            except Exception:
+                max_iterations = 10
+
         # Add user message to conversation history
         self.conversation_history.append({"role": "user", "content": task})
         
@@ -662,77 +689,97 @@ Important: When you have gathered all necessary information and computed the fin
                     request_data["tools"] = self._get_tools_description()
                     request_data["tool_choice"] = "auto"
 
+                # DeepSeek V4: enable thinking so reasoning_content is present
+                # for the no_reasoning ablation (parity with thinking defaults of
+                # Doubao/Kimi). Skip when routed via OpenRouter, which may not
+                # accept the same extra body shape.
+                create_kwargs = {
+                    "model": self.model,
+                    "messages": api_messages,
+                    "tools": self._get_tools_description() if self.context_mode != ContextMode.NO_TOOL_CALLS else None,
+                    "tool_choice": "auto" if self.context_mode != ContextMode.NO_TOOL_CALLS else None,
+                    "temperature": _reasoning_safe_temperature(self.model, 0.3),
+                    "max_tokens": 8192,
+                    "timeout": 180,  # 180 second timeout for main execution
+                }
+                if self.provider == "deepseek" and not getattr(self, "using_openrouter", False):
+                    create_kwargs["extra_body"] = {"thinking": {"type": "enabled"}}
+                    request_data["thinking"] = {"type": "enabled"}
+
                 logger.info(f"Sending request to {self.provider} API")
 
                 # Call the model with tools
-                response = self.client.chat.completions.create(
-                    model=self.model,
-                    messages=api_messages,
-                    tools=self._get_tools_description() if self.context_mode != ContextMode.NO_TOOL_CALLS else None,
-                    tool_choice="auto" if self.context_mode != ContextMode.NO_TOOL_CALLS else None,
-                    temperature=_reasoning_safe_temperature(self.model, 0.3),
-                    max_tokens=8192,
-                    timeout=180  # Add 180 second timeout for main execution
-                )
+                response = self.client.chat.completions.create(**create_kwargs)
                 
                 # Log response if verbose
                 if self.verbose:
                     self._log_request_response(request_data, response, iteration)
                 
                 message = response.choices[0].message
-                
-                # Check for final answer
-                if message.content and "FINAL ANSWER:" in message.content:
-                    final_answer = message.content.split("FINAL ANSWER:")[1].strip()
-                    logger.info(f"Final answer found: {final_answer}")
-                    # Add the message to conversation history
+                has_tool_calls = bool(getattr(message, "tool_calls", None))
+
+                # --- Terminal path: text reply with no tool calls ---
+                # A normal chat turn ("hi" -> "Hello!") or a task answer without
+                # the FINAL ANSWER: marker must end the ReAct loop. Previously
+                # only "FINAL ANSWER:" broke the loop, so plain replies were
+                # re-sent for up to max_iterations (wasted API calls).
+                if not has_tool_calls:
                     assistant_msg = self._prepare_assistant_message(message)
                     messages.append(assistant_msg)
-                    break
-                
-                # Handle tool calls
-                if hasattr(message, 'tool_calls') and message.tool_calls:
-                    # Add the assistant message with tool calls
-                    assistant_msg = self._prepare_assistant_message(message)
-                    messages.append(assistant_msg)
-                    for tool_call in message.tool_calls:
-                        function_name = tool_call.function.name
-                        function_args = json.loads(tool_call.function.arguments)
-                        
-                        logger.info(f"Executing tool: {function_name} with args: {function_args}")
-                        
-                        # Execute the tool
-                        result = self._execute_tool(function_name, function_args)
-                        
-                        # Record the tool call
-                        tool_call_record = ToolCall(
-                            tool_name=function_name,
-                            arguments=function_args,
-                            result=result
+                    content = (message.content or "").strip()
+                    if content:
+                        marked = self._extract_final_answer(content)
+                        final_answer = marked if marked is not None else content
+                        logger.info(
+                            "Terminal text response (no tool calls); "
+                            f"stopping after iteration {iteration}"
                         )
-                        self.trajectory.tool_calls.append(tool_call_record)
-                        
-                        # Add tool result to messages (if not disabled)
-                        if self.context_mode != ContextMode.NO_TOOL_RESULTS:
-                            tool_msg = {
-                                "role": "tool",
-                                "tool_call_id": tool_call.id,
-                                "content": json.dumps(result)
-                            }
-                            messages.append(tool_msg)
-                        else:
-                            # Add a placeholder message if tool results are disabled
-                            tool_msg = {
-                                "role": "tool",
-                                "tool_call_id": tool_call.id,
-                                "content": "[Tool result hidden due to context mode]"
-                            }
-                            messages.append(tool_msg)
-                elif message.content:
-                    # No tool calls, but there's content - add the message
-                    assistant_msg = self._prepare_assistant_message(message)
-                    messages.append(assistant_msg)
-                
+                    else:
+                        logger.warning(
+                            "Empty model response with no tool calls; "
+                            "stopping to avoid burning remaining iterations"
+                        )
+                    break
+
+                # --- Continue path: model requested tool execution ---
+                assistant_msg = self._prepare_assistant_message(message)
+                messages.append(assistant_msg)
+                for tool_call in message.tool_calls:
+                    function_name = tool_call.function.name
+                    function_args = json.loads(tool_call.function.arguments)
+
+                    logger.info(f"Executing tool: {function_name} with args: {function_args}")
+
+                    result = self._execute_tool(function_name, function_args)
+
+                    tool_call_record = ToolCall(
+                        tool_name=function_name,
+                        arguments=function_args,
+                        result=result
+                    )
+                    self.trajectory.tool_calls.append(tool_call_record)
+
+                    if self.context_mode != ContextMode.NO_TOOL_RESULTS:
+                        tool_msg = {
+                            "role": "tool",
+                            "tool_call_id": tool_call.id,
+                            "content": json.dumps(result)
+                        }
+                    else:
+                        tool_msg = {
+                            "role": "tool",
+                            "tool_call_id": tool_call.id,
+                            "content": "[Tool result hidden due to context mode]"
+                        }
+                    messages.append(tool_msg)
+
+                # If the same turn also tagged FINAL ANSWER: (unusual with tools),
+                # still prefer extracting it after tools are recorded.
+                if message.content and "FINAL ANSWER:" in message.content:
+                    final_answer = self._extract_final_answer(message.content)
+                    logger.info(f"Final answer found alongside tool calls: {final_answer}")
+                    break
+
                 # Note: We do NOT modify the system prompt anymore.
                 # The context is already built into the conversation through tool history
                     
@@ -771,13 +818,13 @@ Important: When you have gathered all necessary information and computed the fin
         self._init_system_prompt()  # Reinitialize conversation with system prompt
         logger.info("Agent trajectory and conversation history reset")
     
-    def process(self, query: str, max_iterations: int = 10) -> str:
+    def process(self, query: str, max_iterations: Optional[int] = None) -> str:
         """
         Process a query and return the final answer as a string
         
         Args:
             query: The query to process
-            max_iterations: Maximum number of tool calls
+            max_iterations: Maximum ReAct steps (default from Config)
             
         Returns:
             The final answer as a string

--- a/chapter1/context/config.py
+++ b/chapter1/context/config.py
@@ -23,6 +23,7 @@ def map_model_to_openrouter(model: str) -> str:
     - ids already containing '/' -> left as-is
     - gpt-*/o1-*/o3-*/o4-* -> 'openai/<id>'
     - claude-* -> anthropic Claude (opus/sonnet/haiku)
+    - deepseek-* -> deepseek/<id> (OpenRouter hosts official DeepSeek ids)
     - other native ids (kimi-*, doubao-*, ...) are NOT reliably on OpenRouter,
       so fall back to OPENROUTER_MODEL or a safe default that always works.
     """
@@ -41,6 +42,9 @@ def map_model_to_openrouter(model: str) -> str:
     if ml.startswith("kimi"):
         # kimi-k3 is not on OpenRouter; moonshotai/kimi-k2.6 is the closest hosted id.
         return "moonshotai/kimi-k2.6"
+    if ml.startswith("deepseek"):
+        # OpenRouter hosts deepseek/deepseek-v4-flash, deepseek-chat, etc.
+        return "deepseek/" + m
     return os.getenv("OPENROUTER_MODEL", "openai/gpt-5.6-luna")
 
 
@@ -66,7 +70,7 @@ def resolve_llm_backend(primary_key: str, primary_base_url: str, model: str):
         return openrouter_key, base_url, map_model_to_openrouter(model), True
     raise ValueError(
         "No API key found. Set a provider key "
-        "(SILICONFLOW_API_KEY/ARK_API_KEY/MOONSHOT_API_KEY) or "
+        "(SILICONFLOW_API_KEY/ARK_API_KEY/MOONSHOT_API_KEY/DEEPSEEK_API_KEY) or "
         "OPENROUTER_API_KEY (universal fallback)."
     )
 
@@ -86,6 +90,11 @@ class Config:
     
     MOONSHOT_API_KEY: str = os.getenv("MOONSHOT_API_KEY", "")
     MOONSHOT_BASE_URL: str = "https://api.moonshot.cn/v1"
+
+    DEEPSEEK_API_KEY: str = os.getenv("DEEPSEEK_API_KEY", "")
+    DEEPSEEK_BASE_URL: str = os.getenv(
+        "DEEPSEEK_BASE_URL", "https://api.deepseek.com"
+    )
     
     # Model Configuration (defaults based on provider)
     MODEL_NAME: str = os.getenv("MODEL_NAME", "")  # Will be set based on provider if not specified
@@ -145,6 +154,8 @@ class Config:
             return cls.ARK_API_KEY
         elif provider == "kimi" or provider == "moonshot":
             return cls.MOONSHOT_API_KEY
+        elif provider == "deepseek":
+            return cls.DEEPSEEK_API_KEY
         else:
             return ""
     
@@ -171,6 +182,10 @@ class Config:
             return "doubao-seed-1-6-thinking-250715"
         elif provider == "kimi" or provider == "moonshot":
             return "kimi-k3"
+        elif provider == "deepseek":
+            # V4 Flash: tool calling + thinking mode (legacy deepseek-chat /
+            # deepseek-reasoner aliases are deprecated 2026-07-24).
+            return "deepseek-v4-flash"
         else:
             return ""
     
@@ -195,6 +210,8 @@ class Config:
                 print("ERROR: ARK_API_KEY is not set")
             elif provider == "kimi" or provider == "moonshot":
                 print("ERROR: MOONSHOT_API_KEY is not set")
+            elif provider == "deepseek":
+                print("ERROR: DEEPSEEK_API_KEY is not set")
             else:
                 print(f"ERROR: No API key configured for provider: {provider}")
             

--- a/chapter1/context/demo_conversation.py
+++ b/chapter1/context/demo_conversation.py
@@ -12,13 +12,22 @@ load_dotenv()
 
 def main():
     # Get API key (use any available provider)
-    api_key = os.getenv("ARK_API_KEY") or os.getenv("MOONSHOT_API_KEY") or os.getenv("SILICONFLOW_API_KEY")
-    provider = "doubao" if os.getenv("ARK_API_KEY") else ("kimi" if os.getenv("MOONSHOT_API_KEY") else "siliconflow")
+    if os.getenv("ARK_API_KEY"):
+        api_key, provider = os.getenv("ARK_API_KEY"), "doubao"
+    elif os.getenv("MOONSHOT_API_KEY"):
+        api_key, provider = os.getenv("MOONSHOT_API_KEY"), "kimi"
+    elif os.getenv("DEEPSEEK_API_KEY"):
+        api_key, provider = os.getenv("DEEPSEEK_API_KEY"), "deepseek"
+    elif os.getenv("SILICONFLOW_API_KEY"):
+        api_key, provider = os.getenv("SILICONFLOW_API_KEY"), "siliconflow"
+    else:
+        api_key, provider = None, None
     
     if not api_key:
         print("❌ No API key found. Please set one of:")
         print("  - ARK_API_KEY")
         print("  - MOONSHOT_API_KEY")
+        print("  - DEEPSEEK_API_KEY")
         print("  - SILICONFLOW_API_KEY")
         return
     

--- a/chapter1/context/env.example
+++ b/chapter1/context/env.example
@@ -1,21 +1,26 @@
-# LLM Provider Configuration (siliconflow, doubao, kimi, or moonshot)
+# LLM Provider Configuration (siliconflow, doubao, kimi, moonshot, or deepseek)
 LLM_PROVIDER=doubao
 
 # API Keys (set the appropriate one for your provider)
 SILICONFLOW_API_KEY=your_siliconflow_api_key_here
 ARK_API_KEY=your_ark_api_key_here
 MOONSHOT_API_KEY=your_moonshot_api_key_here
+DEEPSEEK_API_KEY=your_deepseek_api_key_here
+# Optional: override DeepSeek base URL (default: https://api.deepseek.com)
+# DEEPSEEK_BASE_URL=https://api.deepseek.com
 
 # Universal fallback: if the provider key above is missing/invalid but
 # OPENROUTER_API_KEY is set, requests are routed through OpenRouter and the
 # model id is mapped automatically (bare gpt-*/o1-* -> openai/*, claude-* ->
-# anthropic/*, other native ids -> OPENROUTER_MODEL or openai/gpt-5.6-luna).
+# anthropic/*, deepseek-* -> deepseek/*, other native ids -> OPENROUTER_MODEL
+# or openai/gpt-5.6-luna).
 # You can also pass --provider openrouter to use OpenRouter directly.
 OPENROUTER_API_KEY=sk-or-v1-your-openrouter-key-here
 # OPENROUTER_MODEL=openai/gpt-5.6-luna  # model used when falling back for non-OpenRouter native ids
 
 # Optional: Model Configuration
 # MODEL_NAME=  # Leave empty to use provider default
+# For DeepSeek: deepseek-v4-flash (default) or deepseek-v4-pro
 # MODEL_TEMPERATURE=0.3
 # MODEL_MAX_TOKENS=1000
 

--- a/chapter1/context/main.py
+++ b/chapter1/context/main.py
@@ -795,7 +795,7 @@ def interactive_mode(api_key: str, provider: str = "siliconflow", model: str = N
     current_api_key = api_key
     
     # Available providers
-    available_providers = ["siliconflow", "doubao", "kimi", "moonshot"]
+    available_providers = ["siliconflow", "doubao", "kimi", "moonshot", "deepseek"]
     
     print("\n" + "="*60)
     print("INTERACTIVE MODE - Context-Aware Agent")
@@ -920,6 +920,8 @@ def interactive_mode(api_key: str, provider: str = "siliconflow", model: str = N
                         print(f"  - doubao: ByteDance model{status}")
                     elif p in ["kimi", "moonshot"]:
                         print(f"  - {p}: Moonshot Kimi K3 model{status}")
+                    elif p == "deepseek":
+                        print(f"  - deepseek: DeepSeek V4 model{status}")
             
             elif user_input.lower().startswith('provider '):
                 new_provider = user_input[9:].strip().lower()
@@ -939,6 +941,11 @@ def interactive_mode(api_key: str, provider: str = "siliconflow", model: str = N
                         new_api_key = os.getenv("MOONSHOT_API_KEY")
                         if not new_api_key:
                             print("❌ MOONSHOT_API_KEY not set in environment")
+                            continue
+                    elif new_provider == "deepseek":
+                        new_api_key = os.getenv("DEEPSEEK_API_KEY")
+                        if not new_api_key:
+                            print("❌ DEEPSEEK_API_KEY not set in environment")
                             continue
                     
                     # Update current settings
@@ -998,6 +1005,9 @@ def interactive_mode(api_key: str, provider: str = "siliconflow", model: str = N
                 elif current_provider in ["kimi", "moonshot"]:
                     key_status = "✅ Set" if os.getenv("MOONSHOT_API_KEY") else "❌ Not set"
                     print(f"  API Key (MOONSHOT_API_KEY): {key_status}")
+                elif current_provider == "deepseek":
+                    key_status = "✅ Set" if os.getenv("DEEPSEEK_API_KEY") else "❌ Not set"
+                    print(f"  API Key (DEEPSEEK_API_KEY): {key_status}")
             
             elif user_input:
                 # Execute task
@@ -1077,7 +1087,7 @@ def main():
     )
     parser.add_argument(
         "--provider",
-        choices=["siliconflow", "doubao", "kimi", "moonshot", "openrouter"],
+        choices=["siliconflow", "doubao", "kimi", "moonshot", "deepseek", "openrouter"],
         default="doubao",
         help="LLM 提供商（默认：doubao；openrouter 或缺失主 key 时经 OpenRouter 兜底）"
     )
@@ -1089,7 +1099,7 @@ def main():
     parser.add_argument(
         "--api-key",
         type=str,
-        help="LLM 提供商的 API Key（也可通过环境变量 SILICONFLOW_API_KEY/ARK_API_KEY/MOONSHOT_API_KEY 设置）"
+        help="LLM 提供商的 API Key（也可通过环境变量 SILICONFLOW_API_KEY/ARK_API_KEY/MOONSHOT_API_KEY/DEEPSEEK_API_KEY 设置）"
     )
     parser.add_argument(
         "--output",
@@ -1110,6 +1120,8 @@ def main():
         api_key = os.getenv("SILICONFLOW_API_KEY")
     elif args.provider in ["kimi", "moonshot"]:
         api_key = os.getenv("MOONSHOT_API_KEY")
+    elif args.provider == "deepseek":
+        api_key = os.getenv("DEEPSEEK_API_KEY")
     else:
         logger.error(f"Unknown provider: {args.provider}")
         sys.exit(1)
@@ -1126,7 +1138,7 @@ def main():
         else:
             logger.error(
                 "No API key found. Set the provider key "
-                "(ARK_API_KEY/SILICONFLOW_API_KEY/MOONSHOT_API_KEY) or "
+                "(ARK_API_KEY/SILICONFLOW_API_KEY/MOONSHOT_API_KEY/DEEPSEEK_API_KEY) or "
                 "OPENROUTER_API_KEY (universal fallback)."
             )
             sys.exit(1)

--- a/chapter1/context/quick_test_deepseek.py
+++ b/chapter1/context/quick_test_deepseek.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+Quick smoke test for DeepSeek provider (deepseek-v4-flash).
+"""
+
+import os
+import sys
+import time
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+task = "What is 10 + 5? Provide FINAL ANSWER with just the number."
+
+print("=" * 60)
+print("QUICK TEST - DeepSeek Provider")
+print("=" * 60)
+
+deepseek_key = os.getenv("DEEPSEEK_API_KEY")
+if not deepseek_key:
+    print("❌ DEEPSEEK_API_KEY not set")
+    print("Set it in .env or: export DEEPSEEK_API_KEY=your_key")
+    print("Get a key at: https://platform.deepseek.com/api_keys")
+    sys.exit(1)
+
+from agent import ContextAwareAgent, ContextMode
+
+agent = ContextAwareAgent(deepseek_key, ContextMode.FULL, provider="deepseek")
+print(f"✅ Using: {agent.provider} / {agent.model}")
+print(f"   Base URL: {agent.client.base_url}")
+print(f"\n📝 Task: {task}")
+print("-" * 40)
+
+start = time.time()
+print("Processing...")
+
+try:
+    result = agent.execute_task(task, max_iterations=3)
+    elapsed = time.time() - start
+
+    print(f"\n✅ Completed in {elapsed:.2f} seconds")
+
+    if result.get("success"):
+        print("Success: True")
+        if result.get("final_answer"):
+            print(f"Answer: {result['final_answer']}")
+    else:
+        print("Success: False")
+        if result.get("error"):
+            print(f"Error: {result['error']}")
+
+    print(f"Iterations: {result.get('iterations', 0)}")
+    print(f"Tool calls: {len(result['trajectory'].tool_calls)}")
+
+except KeyboardInterrupt:
+    print("\n⚠️ Interrupted")
+except Exception as e:
+    print(f"\n❌ Error: {str(e)}")
+    sys.exit(1)
+
+print("=" * 60)

--- a/chapter1/context/test_deepseek.py
+++ b/chapter1/context/test_deepseek.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+Test script for DeepSeek model integration.
+Tests deepseek-v4-flash (default) with conversation and tool calling.
+"""
+
+import os
+import sys
+from dotenv import load_dotenv
+from agent import ContextAwareAgent, ContextMode
+from config import Config
+
+# Load environment variables
+load_dotenv()
+
+
+def test_basic_conversation():
+    """Test basic conversation capabilities"""
+    print("\n" + "=" * 60)
+    print("TEST 1: Basic Conversation")
+    print("=" * 60)
+
+    try:
+        api_key = os.getenv("DEEPSEEK_API_KEY")
+        if not api_key:
+            print("❌ ERROR: DEEPSEEK_API_KEY not set in environment")
+            print("Please set it in your .env file or as environment variable")
+            return False
+
+        agent = ContextAwareAgent(
+            api_key=api_key,
+            provider="deepseek",
+            context_mode=ContextMode.FULL,
+            verbose=False,
+        )
+
+        query = "What is 25 * 4 + 10? Reply with FINAL ANSWER: and the number."
+        print(f"\n📝 Query: {query}")
+
+        response = agent.process(query)
+        print(f"\n🤖 Response: {response}")
+
+        if "110" in response:
+            print("\n✅ Basic conversation test passed!")
+            return True
+        else:
+            print("\n❌ Test failed - incorrect answer")
+            return False
+
+    except Exception as e:
+        print(f"\n❌ Error during test: {e}")
+        return False
+
+
+def test_tool_usage():
+    """Test tool calling capabilities"""
+    print("\n" + "=" * 60)
+    print("TEST 2: Tool Usage (Calculator)")
+    print("=" * 60)
+
+    try:
+        api_key = os.getenv("DEEPSEEK_API_KEY")
+        if not api_key:
+            print("❌ ERROR: DEEPSEEK_API_KEY not set")
+            return False
+
+        agent = ContextAwareAgent(
+            api_key=api_key,
+            provider="deepseek",
+            context_mode=ContextMode.FULL,
+            verbose=False,
+        )
+
+        query = (
+            "Calculate: (123.45 * 67.89) / 12.34 + sqrt(144) - 2^8. "
+            "Use the calculate tool. End with FINAL ANSWER:"
+        )
+        print(f"\n📝 Query: {query}")
+
+        response = agent.process(query)
+        print(f"\n🤖 Response: {response}")
+
+        if agent.trajectory.tool_calls:
+            print(f"\n🔧 Tools used: {len(agent.trajectory.tool_calls)}")
+            for call in agent.trajectory.tool_calls:
+                print(f"  - {call.tool_name}: {call.arguments}")
+            print("\n✅ Tool usage test passed!")
+            return True
+        else:
+            print("\n⚠️  No tools were used")
+            return False
+
+    except Exception as e:
+        print(f"\n❌ Error during test: {e}")
+        return False
+
+
+def test_currency_conversion():
+    """Test currency conversion tool"""
+    print("\n" + "=" * 60)
+    print("TEST 3: Currency Conversion")
+    print("=" * 60)
+
+    try:
+        api_key = os.getenv("DEEPSEEK_API_KEY")
+        if not api_key:
+            print("❌ ERROR: DEEPSEEK_API_KEY not set")
+            return False
+
+        agent = ContextAwareAgent(
+            api_key=api_key,
+            provider="deepseek",
+            context_mode=ContextMode.FULL,
+            verbose=False,
+        )
+
+        query = "Convert 100 USD to EUR and JPY. Use convert_currency. FINAL ANSWER: the amounts."
+        print(f"\n📝 Query: {query}")
+
+        response = agent.process(query)
+        print(f"\n🤖 Response: {response}")
+
+        tool_names = [call.tool_name for call in agent.trajectory.tool_calls]
+        if "convert_currency" in tool_names:
+            print("\n🔧 Currency converter was used")
+            print("\n✅ Currency conversion test passed!")
+            return True
+        else:
+            print("\n⚠️  Currency converter was not used")
+            return False
+
+    except Exception as e:
+        print(f"\n❌ Error during test: {e}")
+        return False
+
+
+def test_model_info():
+    """Test and display model information"""
+    print("\n" + "=" * 60)
+    print("TEST 4: Model Information")
+    print("=" * 60)
+
+    try:
+        api_key = os.getenv("DEEPSEEK_API_KEY")
+        if not api_key:
+            print("❌ ERROR: DEEPSEEK_API_KEY not set")
+            return False
+
+        agent = ContextAwareAgent(
+            api_key=api_key,
+            provider="deepseek",
+            context_mode=ContextMode.FULL,
+            verbose=False,
+        )
+
+        expected = Config.get_default_model("deepseek")
+        print("\n📊 Model Configuration:")
+        print(f"  Provider: {agent.provider}")
+        print(f"  Model: {agent.model}")
+        print(f"  Expected default: {expected}")
+        print(f"  Base URL: {agent.client.base_url}")
+        print(f"  Context Mode: {agent.context_mode.value}")
+
+        if agent.provider != "deepseek" or agent.model != expected:
+            print("\n❌ Model config mismatch")
+            return False
+
+        print("\n✅ Model info test completed!")
+        return True
+
+    except Exception as e:
+        print(f"\n❌ Error during test: {e}")
+        return False
+
+
+def main():
+    """Run all tests"""
+    print("\n" + "=" * 60)
+    print("DEEPSEEK MODEL INTEGRATION TEST SUITE")
+    print("=" * 60)
+    print("\nModel: deepseek-v4-flash (default)")
+    print("Provider: DeepSeek")
+    print("API: https://api.deepseek.com")
+
+    if not os.getenv("DEEPSEEK_API_KEY"):
+        print("\n❌ ERROR: DEEPSEEK_API_KEY not found in environment")
+        print("\nPlease set up your .env file with:")
+        print("  DEEPSEEK_API_KEY=your_api_key_here")
+        print("\nYou can get an API key from: https://platform.deepseek.com/api_keys")
+        sys.exit(1)
+
+    results = []
+    results.append(("Model Information", test_model_info()))
+    results.append(("Basic Conversation", test_basic_conversation()))
+    results.append(("Tool Usage", test_tool_usage()))
+    results.append(("Currency Conversion", test_currency_conversion()))
+
+    print("\n" + "=" * 60)
+    print("TEST SUMMARY")
+    print("=" * 60)
+
+    passed = sum(1 for _, result in results if result)
+    total = len(results)
+
+    for test_name, result in results:
+        status = "✅ PASSED" if result else "❌ FAILED"
+        print(f"  {test_name}: {status}")
+
+    print(f"\nTotal: {passed}/{total} tests passed")
+
+    if passed == total:
+        print("\n🎉 All tests passed! DeepSeek integration is working correctly.")
+    else:
+        print(f"\n⚠️  {total - passed} test(s) failed. Please check the errors above.")
+
+    return passed == total
+
+
+if __name__ == "__main__":
+    success = main()
+    sys.exit(0 if success else 1)

--- a/chapter1/context/test_provider.py
+++ b/chapter1/context/test_provider.py
@@ -40,6 +40,20 @@ def test_providers():
             print(f"   ❌ Error: {str(e)}")
     else:
         print("\n⚠️ Doubao/ARK API key not found (ARK_API_KEY)")
+
+    # Test DeepSeek
+    deepseek_key = os.getenv("DEEPSEEK_API_KEY")
+    if deepseek_key:
+        print("\n✅ DeepSeek API key found")
+        try:
+            agent = ContextAwareAgent(deepseek_key, ContextMode.FULL, provider="deepseek")
+            print(f"   Provider: {agent.provider}")
+            print(f"   Model: {agent.model}")
+            print(f"   Base URL: {agent.client.base_url}")
+        except Exception as e:
+            print(f"   ❌ Error: {str(e)}")
+    else:
+        print("\n⚠️ DeepSeek API key not found (DEEPSEEK_API_KEY)")
     
     # Test custom model
     if sf_key:
@@ -69,11 +83,17 @@ def test_providers():
         print("\n# Using Doubao:")
         print("python main.py --provider doubao")
         print("python main.py --provider doubao --model doubao-seed-1-6-thinking-250715")
+
+    if deepseek_key:
+        print("\n# Using DeepSeek:")
+        print("python main.py --provider deepseek")
+        print("python main.py --provider deepseek --model deepseek-v4-pro")
     
-    if not sf_key and not ark_key:
+    if not sf_key and not ark_key and not deepseek_key:
         print("\n⚠️ No API keys found. Please set one of:")
         print("   export SILICONFLOW_API_KEY=your_key")
         print("   export ARK_API_KEY=your_key")
+        print("   export DEEPSEEK_API_KEY=your_key")
     
     print("\n" + "="*60)
 

--- a/chapter1/context/test_provider_switching.py
+++ b/chapter1/context/test_provider_switching.py
@@ -36,12 +36,19 @@ def test_provider_switching():
         print("✅ Kimi API key found")
     else:
         print("⏭️  Skipping Kimi (no API key)")
+
+    if os.getenv("DEEPSEEK_API_KEY"):
+        providers_to_test.append(("deepseek", os.getenv("DEEPSEEK_API_KEY")))
+        print("✅ DeepSeek API key found")
+    else:
+        print("⏭️  Skipping DeepSeek (no API key)")
     
     if not providers_to_test:
         print("\n❌ No API keys configured. Please set at least one:")
         print("  - SILICONFLOW_API_KEY")
         print("  - ARK_API_KEY")
         print("  - MOONSHOT_API_KEY")
+        print("  - DEEPSEEK_API_KEY")
         return
     
     print(f"\nTesting {len(providers_to_test)} provider(s)...")
@@ -89,7 +96,7 @@ def test_provider_switching():
     # Show summary
     print("\n📊 Summary:")
     print(f"  Providers tested: {len(providers_to_test)}")
-    print(f"  Available providers: siliconflow, doubao, kimi, moonshot")
+    print("  Available providers: siliconflow, doubao, kimi, moonshot, deepseek")
     
     if len(providers_to_test) < 3:
         print("\n💡 Tip: Configure more API keys to test all providers")


### PR DESCRIPTION
## Summary

为第一章实验 1-1（`chapter1/context` 上下文消融）增加 **DeepSeek** 提供商支持，并修复 ReAct 循环在普通闲聊（如 `hi`）时跑满 `max_iterations`（默认 10 轮）的问题。

### 1. DeepSeek 适配
- 新增 `deepseek` provider：默认模型 `deepseek-v4-flash`，Base URL `https://api.deepseek.com`
- 官方 API 下默认开启 thinking，便于 `no_reasoning` 消融剥离 `reasoning_content`
- 支持 `DEEPSEEK_API_KEY` / `DEEPSEEK_BASE_URL`；OpenRouter 兜底映射 `deepseek/*`
- CLI / 交互模式切换 / `env.example` / README / 集成测试脚本同步更新

### 2. Bug fix：纯文本回复应结束循环
- **现象**：只发 `hi`，模型正常回复但没有 `FINAL ANSWER:` 也没有 tool_calls 时，仍会空转到 10 轮
- **原因**：旧逻辑仅在内容含字面量 `FINAL ANSWER:` 时 `break`
- **修复**：无 `tool_calls` 的文本回复立即终止；有 tool_calls 时继续 ReAct；撞 `max_iterations` 仍作护栏（消融中 `no_tool_results` 等仍可测出空转）

## Test plan

- [x] 本地 mock：`hi` → 1 次 API 调用后结束
- [x] 本地 mock：tool call → 文本答案 → 2 轮正常结束
- [x] `Config.get_default_model("deepseek") == "deepseek-v4-flash"`
- [x] （可选）配置 `DEEPSEEK_API_KEY` 后运行：
  ```bash
  cd chapter1/context
  python quick_test_deepseek.py
  python main.py --provider deepseek --mode interactive  # 输入 hi，应只 1 轮
  python main.py --provider deepseek --mode ablation --cases 1
  ```

## Notes for reviewers

- 范围仅限 `chapter1/context/`，不改书稿正文
- 默认模型选用 V4 Flash（`deepseek-chat` / `deepseek-reasoner` 将于 2026-07-24 弃用）
- 符合 README 贡献指引中的「代码改进与 Bug 修复」

Related: Experiment 1-1 context ablation (`chapter1/context`)
