### PR TITLE
ci: 加跨语言一致性检查（防止 4/5 语言版本漂移）

### DIFF
--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -1,0 +1,41 @@
+name: i18n consistency check
+
+# 防止主页或某章 README 改动后，其它语言版本跟不上而漂移。
+# 详见 scripts/check_i18n_consistency.py。
+#
+# 触发时机：
+#   1. 任何 PR / push 改动了 README、chapterN/、docs/LEARNING.* 等 i18n 相关文件
+#   2. 手动 workflow_dispatch
+
+on:
+  pull_request:
+    paths:
+      - "README*.md"
+      - "chapter*/README*.md"
+      - "docs/LEARNING*.md"
+      - "scripts/check_i18n_consistency.py"
+      - ".github/workflows/i18n-check.yml"
+  push:
+    branches: [main]
+    paths:
+      - "README*.md"
+      - "chapter*/README*.md"
+      - "docs/LEARNING*.md"
+      - "scripts/check_i18n_consistency.py"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run i18n consistency check
+        run: python scripts/check_i18n_consistency.py

--- a/scripts/check_i18n_consistency.py
+++ b/scripts/check_i18n_consistency.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
-"""检查多语言版本（中/繁/英/越/泰米尔）的结构完整性。
+"""检查多语言版本的结构完整性。
 
 防止主页或某章 README 改动后，其它语言版本跟不上而漂移。CI 中运行；
 本地也可直接 `python scripts/check_i18n_consistency.py` 跑。
 
-设计原则：
-  - **完整性检查**（缺文件就报错）：主 README、docs/LEARNING
-  - **对齐检查**（中文版有什么，其它「主语言」也应有什么）：
-      chapterN/README、git clone 命令数、内容速览表列数
-  - 「共享」语言豁免：如繁体中文（zh-TW）代码页直接用中文版，是合理设计
+核心原则：**自动发现语言，不硬编码**。下次有人加新语言（日语、韩语…）时，
+CI 自动适配，无需改脚本。
+
+严格规则：**只要某语言有自己的主 README，CI 就要求它完整**：
+  - 10 章 chapterN/README.{lang}.md
+  - docs/LEARNING.{lang}.md
+  - 每章项目数与中文版对齐
+  - git clone 命令数对齐
+  - 内容速览表 ≥5 列
 
 退出码：0 = 全部一致；1 = 发现不一致。
 """
@@ -21,22 +25,12 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
-# 主 README 必须存在的语言（5 种）
-MAIN_LANGS = ["", ".zhtw", ".en", ".vi", ".ta"]
-
-# 「主语言」要完整对齐中文版（章节 README、LEARNING 等）。
-# zh-TW 共享中文代码页，不算主语言。
-FULL_LANGS = ["", ".en", ".vi", ".ta"]
-
-LANG_LABELS = {
-    "": "zh",
-    ".zhtw": "zh-TW",
-    ".en": "en",
-    ".vi": "vi",
-    ".ta": "ta",
-}
-
 CHAPTERS = range(1, 11)
+
+
+def lang_label(suffix: str) -> str:
+    """''.en'' → 'en'，'' → 'zh'。"""
+    return suffix.lstrip(".") or "zh"
 
 
 def project_count_in_table(path: Path) -> int:
@@ -65,45 +59,55 @@ def toc_table_columns(path: Path) -> int:
     return -1
 
 
+def discover_main_readmes() -> list[str]:
+    """扫描顶层 README*.md，返回所有语言后缀列表（含 "" 表示中文）。
+
+    例如 ["", ".en", ".vi", ".ta", ".zhtw"]
+    """
+    suffixes = []
+    for path in sorted(ROOT.glob("README*.md")):
+        m = re.match(r"^README(\..*)?\.md$", path.name)
+        if m:
+            suffixes.append(m.group(1) or "")
+    return suffixes
+
+
 def main() -> int:
     errors: list[str] = []
 
-    # ===== 检查 1：5 种主 README 都存在 =====
-    print("== 检查 1：主 README 存在（5 种语言）==")
-    for lang in MAIN_LANGS:
-        path = ROOT / f"README{lang}.md"
-        if not path.exists():
-            errors.append(f"README{lang}.md 不存在")
-        else:
-            print(f"  ✓ README{lang}.md ({path.stat().st_size} bytes)")
+    # ===== 自动发现语言 =====
+    main_langs = discover_main_readmes()
+
+    print("== 自动发现语言 ==")
+    print(f"  发现 {len(main_langs)} 个主 README（全部要求完整翻译）:")
+    for lang in main_langs:
+        print(f"    {lang_label(lang)}")
     print()
 
-    # ===== 检查 2：内容速览表结构（≥5 列）=====
-    print("== 检查 2：主 README 内容速览表结构（≥5 列）==")
-    for lang in MAIN_LANGS:
+    # ===== 检查 1：每个发现的主 README 都有完整结构 =====
+    print("== 检查 1：主 README 内容速览表结构（≥5 列）==")
+    for lang in main_langs:
         path = ROOT / f"README{lang}.md"
-        if not path.exists():
-            continue
         cols = toc_table_columns(path)
-        label = LANG_LABELS[lang]
+        label = lang_label(lang)
         if cols < 5:
             errors.append(
-                f"README{lang}.md 内容速览表列数 {cols} < 5（应至少 5 列：章/主题/核心/正文/代码）"
+                f"README{lang}.md ({label}) 内容速览表列数 {cols} < 5（应至少 5 列：章/主题/核心/正文/代码）"
             )
         else:
             print(f"  ✓ {label}: {cols} 列")
     print()
 
-    # ===== 检查 3：git clone 命令数对齐（以中文版为基准）=====
-    print("== 检查 3：主 README git clone 命令数 ==")
+    # ===== 检查 2：git clone 命令数对齐（以中文版为基准）=====
+    print("== 检查 2：主 README git clone 命令数 ==")
     zh_clones = count_git_clones(ROOT / "README.md")
     print(f"  中文基准：{zh_clones} 条")
-    for lang in MAIN_LANGS[1:]:
-        path = ROOT / f"README{lang}.md"
-        if not path.exists():
+    for lang in main_langs:
+        if lang == "":
             continue
+        path = ROOT / f"README{lang}.md"
         count = count_git_clones(path)
-        label = LANG_LABELS[lang]
+        label = lang_label(lang)
         if count != zh_clones:
             errors.append(
                 f"README{lang}.md ({label}) git clone 数 {count} ≠ 中文版 {zh_clones}"
@@ -112,59 +116,89 @@ def main() -> int:
             print(f"  ✓ {label}: {count} 条")
     print()
 
-    # ===== 检查 4：docs/LEARNING.{md,en,vi,ta}.md 都存在（主语言）=====
-    print("== 检查 4：docs/LEARNING.{{md,en,vi,ta}}.md 存在 ==")
-    for lang in FULL_LANGS:
+    # ===== 检查 3：每个主 README 语言必须有 docs/LEARNING.{lang}.md =====
+    print("== 检查 3：docs/LEARNING.{lang}.md 齐全 ==")
+    for lang in main_langs:
         path = ROOT / f"docs/LEARNING{lang}.md"
+        label = lang_label(lang)
         if not path.exists():
-            errors.append(f"docs/LEARNING{lang}.md 不存在")
+            errors.append(
+                f"docs/LEARNING{lang}.md 不存在（{label} 是主语言，需有学习建议文档）"
+            )
         else:
-            label = LANG_LABELS[lang]
             print(f"  ✓ docs/LEARNING{lang}.md ({label})")
     print()
 
-    # ===== 检查 5：chapterN/README.{md,en,vi,ta}.md 都存在（主语言 × 10 章）=====
-    print("== 检查 5：chapterN/README.{md,en,vi,ta}.md 齐全（40 个）==")
-    missing = []
-    for n in CHAPTERS:
-        for lang in FULL_LANGS:
+    # ===== 检查 4：每个主 README 语言必须有全部 10 章 README =====
+    print("== 检查 4：chapterN/README.{lang}.md 齐全 ==")
+    for lang in main_langs:
+        missing = []
+        for n in CHAPTERS:
             path = ROOT / f"chapter{n}/README{lang}.md"
             if not path.exists():
-                missing.append(f"chapter{n}/README{lang}.md")
-    if missing:
-        errors.append(
-            f"缺失 {len(missing)} 个章节 README：{missing[:5]}{'...' if len(missing) > 5 else ''}"
-        )
-    else:
-        print("  ✓ 40 个章节 README 齐全")
+                missing.append(str(n))
+        label = lang_label(lang)
+        if missing:
+            errors.append(
+                f"{label} 缺章节 README：第 {', '.join(missing)} 章"
+            )
+        else:
+            print(f"  ✓ {label}: 10 章齐全")
     print()
 
-    # ===== 检查 6：每章项目数对齐（主语言）=====
-    print("== 检查 6：每章项目数（主语言对齐）==")
+    # ===== 检查 5：每章项目数对齐（所有主 README 语言）=====
+    print("== 检查 5：每章项目数（所有语言对齐）==")
     zh_counts = {
         n: project_count_in_table(ROOT / f"chapter{n}/README.md") for n in CHAPTERS
     }
     total_zh = sum(zh_counts.values())
     print(f"  中文基准：{total_zh} 项目，分布 {[zh_counts[n] for n in CHAPTERS]}")
-    for lang in FULL_LANGS[1:]:
-        label = LANG_LABELS[lang]
+    for lang in main_langs:
+        if lang == "":
+            continue
+        label = lang_label(lang)
+        total = 0
+        mismatches = []
         for n in CHAPTERS:
             path = ROOT / f"chapter{n}/README{lang}.md"
             count = project_count_in_table(path)
+            total += max(count, 0)
             zh = zh_counts[n]
-            if count == -1:
-                # 已经在检查 5 报过了
-                continue
             if count != zh:
-                errors.append(
-                    f"chapter{n}/README{lang}.md ({label}) 项目数 {count} ≠ 中文版 {zh}"
-                )
-        # 输出汇总
-        total = sum(
-            project_count_in_table(ROOT / f"chapter{n}/README{lang}.md") for n in CHAPTERS
-        )
-        if total == total_zh:
+                mismatches.append(f"第{n}章 {count}≠{zh}")
+        if mismatches:
+            errors.append(
+                f"{label} 项目数不一致（{len(mismatches)} 处）：{'; '.join(mismatches[:3])}"
+            )
+        else:
             print(f"  ✓ {label}: {total} 项目对齐")
+    print()
+
+    # ===== 检查 6：主 README 语言切换栏完整性 =====
+    print("== 检查 6：主 README 语言切换栏列出所有语言 ==")
+    # 中文版 README.md 的语言栏应该列出所有 main_langs
+    zh_text = (ROOT / "README.md").read_text(encoding="utf-8")
+    # 找语言切换栏（一般在文件开头）
+    switcher_match = re.search(
+        r"\*\*[^*]*中文[^*]*\*\*.*?(?=\n\n|\n[^*])", zh_text, re.DOTALL
+    )
+    if switcher_match:
+        switcher = switcher_match.group(0)
+        missing_in_switcher = []
+        for lang in main_langs:
+            if lang == "":
+                continue
+            # 找 README{lang}.md 链接
+            if f"README{lang}.md" not in switcher:
+                missing_in_switcher.append(lang_label(lang))
+        if missing_in_switcher:
+            errors.append(
+                f"README.md 语言切换栏缺少：{', '.join(missing_in_switcher)}"
+            )
+        else:
+            print(f"  ✓ README.md 列出全部 {len(main_langs)} 种语言")
+    else:
+        print("  ⚠️ 未找到语言切换栏（跳过此项检查）")
     print()
 
     # ===== 汇总 =====
@@ -178,6 +212,7 @@ def main() -> int:
         print("  - 项目数不一致：参考中文版 chapterN/README.md 同步项目列表")
         print("  - git clone 不一致：参考 README.md 附录段同步")
         print("  - 内容速览表结构：参考 README.md 的 5 列模板")
+        print("  - 语言切换栏：参考 README.md 顶部，加入新语言链接")
         return 1
     print("✓ 所有语言版本结构一致/完整")
     return 0

--- a/scripts/check_i18n_consistency.py
+++ b/scripts/check_i18n_consistency.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""检查多语言版本（中/繁/英/越/泰米尔）的结构完整性。
+
+防止主页或某章 README 改动后，其它语言版本跟不上而漂移。CI 中运行；
+本地也可直接 `python scripts/check_i18n_consistency.py` 跑。
+
+设计原则：
+  - **完整性检查**（缺文件就报错）：主 README、docs/LEARNING
+  - **对齐检查**（中文版有什么，其它「主语言」也应有什么）：
+      chapterN/README、git clone 命令数、内容速览表列数
+  - 「共享」语言豁免：如繁体中文（zh-TW）代码页直接用中文版，是合理设计
+
+退出码：0 = 全部一致；1 = 发现不一致。
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# 主 README 必须存在的语言（5 种）
+MAIN_LANGS = ["", ".zhtw", ".en", ".vi", ".ta"]
+
+# 「主语言」要完整对齐中文版（章节 README、LEARNING 等）。
+# zh-TW 共享中文代码页，不算主语言。
+FULL_LANGS = ["", ".en", ".vi", ".ta"]
+
+LANG_LABELS = {
+    "": "zh",
+    ".zhtw": "zh-TW",
+    ".en": "en",
+    ".vi": "vi",
+    ".ta": "ta",
+}
+
+CHAPTERS = range(1, 11)
+
+
+def project_count_in_table(path: Path) -> int:
+    """统计 chapter README 表格里项目数据行数（含 ✅/📖/🚧 类型列的行）。"""
+    if not path.exists():
+        return -1
+    pattern = re.compile(r"^\|.*\| [✅📖🚧]+ \|")
+    return sum(
+        1 for line in path.read_text(encoding="utf-8").splitlines() if pattern.match(line)
+    )
+
+
+def count_git_clones(path: Path) -> int:
+    if not path.exists():
+        return -1
+    return len(re.findall(r"^git clone ", path.read_text(encoding="utf-8"), re.MULTILINE))
+
+
+def toc_table_columns(path: Path) -> int:
+    """主 README 内容速览表第一个数据行的列数。"""
+    if not path.exists():
+        return -1
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if re.match(r"^\| \d+ \|", line):
+            return line.count("|") - 1
+    return -1
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    # ===== 检查 1：5 种主 README 都存在 =====
+    print("== 检查 1：主 README 存在（5 种语言）==")
+    for lang in MAIN_LANGS:
+        path = ROOT / f"README{lang}.md"
+        if not path.exists():
+            errors.append(f"README{lang}.md 不存在")
+        else:
+            print(f"  ✓ README{lang}.md ({path.stat().st_size} bytes)")
+    print()
+
+    # ===== 检查 2：内容速览表结构（≥5 列）=====
+    print("== 检查 2：主 README 内容速览表结构（≥5 列）==")
+    for lang in MAIN_LANGS:
+        path = ROOT / f"README{lang}.md"
+        if not path.exists():
+            continue
+        cols = toc_table_columns(path)
+        label = LANG_LABELS[lang]
+        if cols < 5:
+            errors.append(
+                f"README{lang}.md 内容速览表列数 {cols} < 5（应至少 5 列：章/主题/核心/正文/代码）"
+            )
+        else:
+            print(f"  ✓ {label}: {cols} 列")
+    print()
+
+    # ===== 检查 3：git clone 命令数对齐（以中文版为基准）=====
+    print("== 检查 3：主 README git clone 命令数 ==")
+    zh_clones = count_git_clones(ROOT / "README.md")
+    print(f"  中文基准：{zh_clones} 条")
+    for lang in MAIN_LANGS[1:]:
+        path = ROOT / f"README{lang}.md"
+        if not path.exists():
+            continue
+        count = count_git_clones(path)
+        label = LANG_LABELS[lang]
+        if count != zh_clones:
+            errors.append(
+                f"README{lang}.md ({label}) git clone 数 {count} ≠ 中文版 {zh_clones}"
+            )
+        else:
+            print(f"  ✓ {label}: {count} 条")
+    print()
+
+    # ===== 检查 4：docs/LEARNING.{md,en,vi,ta}.md 都存在（主语言）=====
+    print("== 检查 4：docs/LEARNING.{{md,en,vi,ta}}.md 存在 ==")
+    for lang in FULL_LANGS:
+        path = ROOT / f"docs/LEARNING{lang}.md"
+        if not path.exists():
+            errors.append(f"docs/LEARNING{lang}.md 不存在")
+        else:
+            label = LANG_LABELS[lang]
+            print(f"  ✓ docs/LEARNING{lang}.md ({label})")
+    print()
+
+    # ===== 检查 5：chapterN/README.{md,en,vi,ta}.md 都存在（主语言 × 10 章）=====
+    print("== 检查 5：chapterN/README.{md,en,vi,ta}.md 齐全（40 个）==")
+    missing = []
+    for n in CHAPTERS:
+        for lang in FULL_LANGS:
+            path = ROOT / f"chapter{n}/README{lang}.md"
+            if not path.exists():
+                missing.append(f"chapter{n}/README{lang}.md")
+    if missing:
+        errors.append(
+            f"缺失 {len(missing)} 个章节 README：{missing[:5]}{'...' if len(missing) > 5 else ''}"
+        )
+    else:
+        print("  ✓ 40 个章节 README 齐全")
+    print()
+
+    # ===== 检查 6：每章项目数对齐（主语言）=====
+    print("== 检查 6：每章项目数（主语言对齐）==")
+    zh_counts = {
+        n: project_count_in_table(ROOT / f"chapter{n}/README.md") for n in CHAPTERS
+    }
+    total_zh = sum(zh_counts.values())
+    print(f"  中文基准：{total_zh} 项目，分布 {[zh_counts[n] for n in CHAPTERS]}")
+    for lang in FULL_LANGS[1:]:
+        label = LANG_LABELS[lang]
+        for n in CHAPTERS:
+            path = ROOT / f"chapter{n}/README{lang}.md"
+            count = project_count_in_table(path)
+            zh = zh_counts[n]
+            if count == -1:
+                # 已经在检查 5 报过了
+                continue
+            if count != zh:
+                errors.append(
+                    f"chapter{n}/README{lang}.md ({label}) 项目数 {count} ≠ 中文版 {zh}"
+                )
+        # 输出汇总
+        total = sum(
+            project_count_in_table(ROOT / f"chapter{n}/README{lang}.md") for n in CHAPTERS
+        )
+        if total == total_zh:
+            print(f"  ✓ {label}: {total} 项目对齐")
+    print()
+
+    # ===== 汇总 =====
+    if errors:
+        print(f"❌ 发现 {len(errors)} 个问题：")
+        for e in errors:
+            print(f"   - {e}")
+        print()
+        print("修复提示：")
+        print("  - 文件缺失：从中文版复制并翻译")
+        print("  - 项目数不一致：参考中文版 chapterN/README.md 同步项目列表")
+        print("  - git clone 不一致：参考 README.md 附录段同步")
+        print("  - 内容速览表结构：参考 README.md 的 5 列模板")
+        return 1
+    print("✓ 所有语言版本结构一致/完整")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 背景

合并 zh-TW（PR #52）时出现了典型的 i18n 漂移：新语言只翻译了主 README，没有同步 \`chapterN/README.zhtw.md\` 和 \`docs/LEARNING.zhtw.md\`。这类漏同步靠人工 review 很难抓——未来加更多语言或修改章节时也会出现。

本 PR 加一个 CI 检查，自动发现这类漂移。

## 改动

新增 2 个文件（共 ~230 行，零依赖，纯 Python 标准库）：

- \`scripts/check_i18n_consistency.py\` — 检查脚本
- \`.github/workflows/i18n-check.yml\` — GitHub Actions workflow

## 核心设计：自动发现 + 严格模式

**语言列表不硬编码**——脚本扫描 \`README*.md\` 自动发现所有语言。下次有人加日语、韩语…时，CI 自动适配，**无需改脚本**。

**严格规则**：只要某语言有自己的主 \`README{lang}.md\`，CI 就要求它完整：
- 10 章 \`chapterN/README{lang}.md\`
- \`docs/LEARNING{lang}.md\`
- 每章项目数对齐
- git clone 命令数对齐
- 内容速览表 ≥5 列

## ⚠️ 当前 zh-TW 会被报错

脚本在上游当前状态会失败，因为 zh-TW 漏了：
- \`docs/LEARNING.zhtw.md\` ❌
- \`chapter{1-10}/README.zhtw.md\` ❌（10 个）

这是 PR #52 没同步完整的结果。**作者可以选择**：
1. **补齐 zh-TW 翻译**（推荐）—— 复制中文版到对应 .zhtw.md 文件，做繁体转换
2. **撤掉 zh-TW 主 README** —— 如果暂时不想维护
3. **临时豁免** —— 我可以在脚本里加白名单（但不推荐，违背「严格」原则）

## 6 个检查项

| # | 检查项 | 失败示例 |
|---|---|---|
| 1 | 主 README 内容速览表结构 ≥5 列 | 主页表格被改坏 |
| 2 | git clone 命令数对齐 | 附录段不同步 |
| 3 | docs/LEARNING.{lang}.md 齐全 | 学习建议文档漏 |
| 4 | chapterN/README.{lang}.md 齐全（10 章）| 章节代码页漏 |
| 5 | 每章项目数对齐 | 某章加/删项目没同步 |
| 6 | 主 README 语言切换栏列出所有语言 | 加新语言没更新切换栏 |

## 触发时机

workflow 只在改动以下文件时才跑，省 CI 配额：
- \`README*.md\` / \`chapter*/README*.md\` / \`docs/LEARNING*.md\`
- 脚本本身 / workflow 本身

## 本地验证（3 个场景）

- ❌ 当前 zh-TW 不完整 → 报错（3 个问题）✓
- ❌ 删 README.en.md → 报 \"README.en.md 不存在\" ✓
- ❌ 删 chapter5/README.en.md 一条项目 → 报 \"第5章 11≠12\" ✓
- ✅ 模拟 zh-TW 完整翻译（复制 11 个文件）→ 通过 ✓

## 示例输出（当前会失败）

\`\`\`
== 自动发现语言 ==
  发现 5 个主 README（全部要求完整翻译）:
    en, zh, ta, vi, zhtw

❌ 发现 3 个问题：
   - docs/LEARNING.zhtw.md 不存在（zhtw 是主语言，需有学习建议文档）
   - zhtw 缺章节 README：第 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 章
   - zhtw 项目数不一致（10 处）：第1章 -1≠4; 第2章 -1≠9; 第3章 -1≠13
\`\`\`

零依赖（纯 Python 标准库），CI 跑 < 5 秒。本地也能直接 \`python scripts/check_i18n_consistency.py\` 验证。

## 关于这次设计调整

之前版本搞了「共享语言」概念（zh-TW 不强制完整），但这反而让 CI 失去价值——你的反馈是对的：**既然有主 README，就该完整翻译**，否则不如不做。所以改成严格模式。