### PR TITLE
i18n(zhtw): fix i18n CI drift + normalize terminology

### DIFF
--- a/README.zhtw.md
+++ b/README.zhtw.md
@@ -50,7 +50,7 @@
 | 6 | 🎯 **Agent 的評估** | 把表現變成可比較訊號：評估環境、指標、統計顯著性、評估驅動選型 | [讀](book-zhtw/chapter6.zhtw.md) | [10](chapter6/README.md) |
 | 7 | 🧠 **模型後訓練** | 預訓練/SFT/RL 三階段：何時選 SFT、何時選 RL，工具呼叫內化、樣本效率 | [讀](book-zhtw/chapter7.zhtw.md) | [14](chapter7/README.md) |
 | 8 | 🔄 **Agent 的自我進化** | 不改權重也能成長：經驗學習、從工具使用者到創造者 | [讀](book-zhtw/chapter8.zhtw.md) | [6](chapter8/README.md) |
-| 9 | 🎙️ **多模態與實時互動** | 從文字擴充套件到語音、GUI、物理世界：語音三典範、Computer Use、機器人 | [讀](book-zhtw/chapter9.zhtw.md) | [7](chapter9/README.md) |
+| 9 | 🎙️ **多模態與即時互動** | 從文字擴充套件到語音、GUI、物理世界：語音三典範、Computer Use、機器人 | [讀](book-zhtw/chapter9.zhtw.md) | [7](chapter9/README.md) |
 | 10 | 🤝 **多 Agent 協作** | 群體智慧高於個體：協作框架、上下文共享/隔離、湧現的「Agent 社會」 | [讀](book-zhtw/chapter10.zhtw.md) | [6](chapter10/README.md) |
 
 > 💡 **讀** = 在 GitHub 網頁直接讀章節正文（markdown）；**N** = 該章配套專案數，點選檢視程式碼。專案型別說明（✅ 可執行 / 📖 復現 / 🚧 設計）見各章 README。
@@ -154,4 +154,4 @@ git clone https://github.com/joonspk-research/generative_agents.git    chapter10
   </picture>
 </a>
 
-<sub>由 [`scripts/gen_star_history.py`](scripts/gen_star_history.py) 生成，[GitHub Actions](.github/workflows/star-history.yml) 每日自動更新 · 點選圖片檢視實時資料</sub>
+<sub>由 [`scripts/gen_star_history.py`](scripts/gen_star_history.py) 生成，[GitHub Actions](.github/workflows/star-history.yml) 每日自動更新 · 點選圖片檢視即時資料</sub>

--- a/chapter1/README.zhtw.md
+++ b/chapter1/README.zhtw.md
@@ -6,16 +6,16 @@
 
 ## 配套專案
 
-| 專案 | 類型 | 一句話說明 |
+| 專案 | 型別 | 一句話說明 |
 | --- | :--: | --- |
 | [learning-from-experience](learning-from-experience/) | ✅ | 對比 Q-learning 與基於 LLM 的上下文學習，復現 Shunyu Yao 的 "The Second Half"：LLM 以 250–400 倍樣本效率超越傳統 RL |
 | [web-search-agent](web-search-agent/) | ✅ | Kimi K2 模型即 Agent，具備基礎深度搜尋能力，能進行多輪搜尋和資訊整合 |
 | [search-codegen](search-codegen/) | ✅ | GPT-5 原生工具整合，綜合利用網路搜尋與程式碼沙箱實現複雜分析 |
 | [context](context/) | ✅ | 系統性消融實驗展示 Agent 上下文各元件的重要性；支援 SiliconFlow Qwen、字節 Doubao、月之暗面 Kimi 等多提供商 |
 
-## 專案類型說明
+## 專案型別說明
 
-| 圖示 | 類型 | 含義 |
+| 圖示 | 型別 | 含義 |
 | :--: | --- | --- |
 | ✅ | **可獨立執行** | 本倉庫自帶完整程式碼，配置好 API Key 即可執行 |
 | 📖 | **復現指南** | 依賴需自行 `git clone` 的**外部倉庫**（訓練框架、評測基準等） |

--- a/chapter2/README.zhtw.md
+++ b/chapter2/README.zhtw.md
@@ -6,7 +6,7 @@
 
 ## 配套專案
 
-| 專案 | 類型 | 一句話說明 |
+| 專案 | 型別 | 一句話說明 |
 | --- | :--: | --- |
 | [local_llm_serving](local_llm_serving/) | ✅ | 跨平台本地 LLM 部署，自動選 vLLM/Ollama 後端，展示 0.6B 小模型也能有出色工具呼叫 |
 | [attention_visualization](attention_visualization/) | ✅ | 視覺化 LLM 完整 token 序列與注意力權重分佈，理解模型如何處理上下文、推理與呼叫工具 |
@@ -18,9 +18,9 @@
 | [prompt-injection](prompt-injection/) | ✅ | 3 種攻擊場景 × 4 種防禦設定的對照實驗，直觀展示逐層疊加防禦後注入成功率下降 |
 | [agent-skills-ppt](agent-skills-ppt/) | ✅ | 復現 Agent Skills「漸進式揭露」，按需載入完整流程後用 python-pptx 產生真實 `.pptx` |
 
-## 專案類型說明
+## 專案型別說明
 
-| 圖示 | 類型 | 含義 |
+| 圖示 | 型別 | 含義 |
 | :--: | --- | --- |
 | ✅ | **可獨立執行** | 本倉庫自帶完整程式碼，設定好 API Key 即可執行 |
 | 📖 | **復現指南** | 依賴需自行 `git clone` 的**外部倉庫**（訓練框架、評測基準等） |

--- a/chapter4/README.zhtw.md
+++ b/chapter4/README.zhtw.md
@@ -6,20 +6,21 @@
 
 ## 配套專案
 
-| 專案 | 類型 | 一句話說明 |
+| 專案 | 型別 | 一句話說明 |
 | --- | :--: | --- |
 | [perception-tools](perception-tools/) | ✅ | 感知工具 MCP：網路搜尋、多模態理解、檔案系統、公共資料來源（DuckDuckGo/Open-Meteo/Yahoo/OpenStreetMap），大多無需 API Key |
 | [execution-tools](execution-tools/) | ✅ | 執行工具 MCP：檔案操作、程式碼直譯器、虛擬終端機、外部系統整合，LLM 二次審批防誤操作 |
 | [collaboration-tools](collaboration-tools/) | ✅ | 協作工具 MCP：瀏覽器自動化、HITL、Email/Telegram/Slack/Discord 通知、計時器，支援管理員審批 |
 | [agent-with-event-trigger](agent-with-event-trigger/) | ✅ | FastAPI 事件驅動 Agent，原生非同步整合前三組 MCP 工具，透過 HTTP API 接收 Web/IM/GitHub/計時器事件 |
 | [active-tool-selection](active-tool-selection/) | ✅ | 讓 Agent 根據任務需求主動選擇最合適的工具組合，而非被動接受預定義工具集 |
+| [active-tool-discovery](active-tool-discovery/) | ✅ | 對比「全量注入 120+ 工具 schema」與「少量基礎工具 + discover_tools 元工具按需檢索」，省 token 防錯選 |
 | [async-agent](async-agent/) | ✅ | asyncio 單執行緒事件驅動框架 Flux：事件佇列按緊急度分派、非同步工具並行、執行中打斷、長任務取消與狀態查詢 |
 
 > 此外，[`chapter4/docker-compose.yml`](docker-compose.yml) 與 [`chapter4/DOCKER_DEPLOYMENT.md`](DOCKER_DEPLOYMENT.md) 提供了將上述 MCP 工具伺服器容器化部署的參考方案。
 
-## 專案類型說明
+## 專案型別說明
 
-| 圖示 | 類型 | 含義 |
+| 圖示 | 型別 | 含義 |
 | :--: | --- | --- |
 | ✅ | **可獨立執行** | 本倉庫自帶完整程式碼，設定好 API Key 即可執行 |
 | 📖 | **復現指南** | 依賴需自行 `git clone` 的**外部倉庫**（訓練框架、評測基準等） |

--- a/chapter8/README.zhtw.md
+++ b/chapter8/README.zhtw.md
@@ -1,24 +1,23 @@
 # 第 8 章 · Agent 的自我進化
 
-> 不改權重也能成長：經驗學習、主動工具發現、從使用者到創造者
+> 不改權重也能成長：經驗學習、從工具使用者到創造者
 
 ← [返回主目錄](../README.md) · 📖 [讀本章正文](../book/chapter8.md)
 
 ## 配套專案
 
-| 專案 | 類型 | 一句話說明 |
+| 專案 | 型別 | 一句話說明 |
 | --- | :--: | --- |
 | [gaia-experience](gaia-experience/) | ✅ | 基於 AWorld + GAIA 的「學習-應用」閉環：自動總結成功軌跡為結構化經驗，在新任務中檢索應用 |
 | [browser-use-rpa](browser-use-rpa/) | ✅ | 瀏覽器工作流錄製系統，把重複操作封裝為引數化工具，從 LLM 推理切換到自動化執行可加速 3–5 倍 |
 | [prompt-distillation](prompt-distillation/) | ✅ | 將複雜提示的效果蒸餾進模型引數，減少推理提示長度，把上下文經驗固化為引數化知識 |
 | [prompt-auto-optimization](prompt-auto-optimization/) | ✅ | 以 tau-bench 航空客服「過度轉接」為例，Coding Agent 讀/改 prompt 檔案 → 重新評測 → 驗證閉環 |
-| [active-tool-discovery](active-tool-discovery/) | ✅ | 對比「全量注入 120+ 工具 schema」與「少量基礎工具 + discover_tools 元工具按需檢索」，省 token 防錯選 |
 | [self-evolving-tools](self-evolving-tools/) | ✅ | Alita 式「最小預定義，最大自我進化」：五個通用元工具，自己上網找庫/讀文件/沙箱測試並封裝複用 |
 | [self-evolution-eval](self-evolution-eval/) | ✅ | 20 個跨領域任務 + 四層分層驗證 harness + 可控參考 Agent，考察發現/創造/複用品質 |
 
-## 專案類型說明
+## 專案型別說明
 
-| 圖示 | 類型 | 含義 |
+| 圖示 | 型別 | 含義 |
 | :--: | --- | --- |
 | ✅ | **可獨立執行** | 本倉庫自帶完整程式碼，配置好 API Key 即可執行 |
 | 📖 | **復現指南** | 依賴需自行 `git clone` 的**外部倉庫**（訓練框架、評測基準等） |

--- a/chapter9/README.zhtw.md
+++ b/chapter9/README.zhtw.md
@@ -1,4 +1,4 @@
-# 第 9 章 · 多模態與實時互動
+# 第 9 章 · 多模態與即時互動
 
 > 從文字擴充套件到語音、GUI、物理世界：語音三典範、Computer Use、機器人
 
@@ -8,7 +8,7 @@
 
 | 專案 | 型別 | 一句話說明 |
 | --- | :--: | --- |
-| [live-audio](live-audio/) | ✅ | 實時語音聊天，整合 VAD + ASR（Whisper/SenseVoice）+ LLM（GPT-4o/Gemini/Doubao）+ TTS（Fish Audio），WebSocket 低延遲 |
+| [live-audio](live-audio/) | ✅ | 即時語音聊天，整合 VAD + ASR（Whisper/SenseVoice）+ LLM（GPT-4o/Gemini/Doubao）+ TTS（Fish Audio），WebSocket 低延遲 |
 | `browser-use/` | 📖 | LLM 驅動的瀏覽器自動化框架，表單填寫/網頁導航/資料提取，支援多種 LLM 與雲/沙箱部署 |
 | `claude-quickstarts/` | 📖 | Claude API 快速入門示例與最佳實踐，涵蓋各種使用場景 |
 | [phone-agent](phone-agent/) | ✅ | 標準 ReAct Agent 自行想清號碼與目標，呼叫 `make_phone_call`（電話語音 API 抽象）完成通話並按需追問再撥 |


### PR DESCRIPTION
## Background

While verifying the zh-TW fill-in from `bee31cd`, I found the i18n consistency check has been **failing on `main`** and that the zh-TW edition had two classes of inconsistency. This PR fixes both and turns the check green again.

## 1. Complete the ch8 → ch4 restructure in the zh-TW READMEs (fixes red CI)

Upstream `2d474ff` moved the `active-tool-discovery` project from chapter 8 to chapter 4 (Simplified / en / ta / vi), and `be2391a` mirrored it to the editions — but the **zh-TW mirror was incomplete**: the project was never actually moved.

| | ch4 | ch8 |
|---|---|---|
| Simplified (correct) | 7 | 6 |
| zh-TW (before) | 6 ❌ | 7 ❌ |
| zh-TW (after) | 7 ✅ | 6 ✅ |

- Move `active-tool-discovery` into `chapter4/README.zhtw.md` (after `active-tool-selection`, matching Simplified order) and out of `chapter8/README.zhtw.md`.
- Update the stale chapter 8 tagline (`…經驗學習、主動工具發現、從使用者到創造者` → `…經驗學習、從工具使用者到創造者`) to match Simplified.

## 2. Normalize terminology to the edition-wide convention

The `book-zhtw/` body established these; the per-chapter READMEs drifted from them:

| Term | Convention | Drift | Fix |
|---|---|---|---|
| real-time | **即時** (body 142×, 實時 0×; afterword calls ch9 "即時互動") | ch9 README + main README used **實時** (4×) | → 即時 |
| type | **型別** (body 105×, 類型 0×; OpenCC `s2twp` default) | fill-in mixed forms: ch1/2/4/8 used **類型** | → 型別 (all 10 chapters aligned) |

## Verification

- `python scripts/check_i18n_consistency.py` now passes.
- I regenerated the fill-in files from Simplified via the canonical OpenCC `s2twp` + zhtw-mcp pipeline and diffed; everything else in `bee31cd` verified as correct (e.g. `典範`, `字節` for ByteDance, `python-pptx` casing all handled well). `擴充套件` is the `s2twp` default and is used uniformly edition-wide (100+×), so it is intentionally left as-is — consistency wins.

Pure terminology/structure alignment; no content-meaning changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)