### PR TITLE
chore: upgrade actions/checkout from v4 to v5 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install build tools
         run: |

--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -31,7 +31,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -17,7 +17,7 @@ jobs:
   update-chart:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
GitHub Actions runners now run Node.js 24 by default, and Node.js 20 is deprecated.
Upgrading to actions/checkout@v5 resolves the deprecation warning.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
