### PR TITLE
epub: 美化正文样式 + 目录去编号

### DIFF
--- a/build_epub.sh
+++ b/build_epub.sh
@@ -109,6 +109,7 @@ build_edition() {
             --number-sections \
             --mathml \
             --split-level=1 \
+            --highlight-style=kate \
             --css="$ROOT/epub.css" \
             --epub-cover-image="$cover" \
             --metadata title="$title" \

--- a/epub.css
+++ b/epub.css
@@ -1,23 +1,134 @@
+/* ==========================================================================
+   AI Agent book — EPUB stylesheet
+   与 PDF (ElegantBook cyan theme) 视觉风格保持一致：青色主色、灰底代码块、
+   提示框式引用、章首页等。参考 learnbyexample 的 EPUB 最佳实践。
+   ========================================================================== */
+
 :root {
   color-scheme: light dark;
+  --accent: #008b8b;          /* 青色，与 ElegantBook cyan 主题一致 */
+  --accent-light: #e0f2f2;    /* 提示框淡背景 */
+  --code-bg: #f5f5f5;         /* 代码块背景 */
+  --code-text: #1f2328;       /* 代码块前景 */
+  --border: #d0d7de;          /* 普通边框 */
+  --muted: #57606a;           /* 次要文字 */
 }
+
+/* 暗色模式覆盖（部分阅读器支持 prefers-color-scheme） */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --accent-light: #1a2e2e;
+    --code-bg: #161b22;
+    --code-text: #e6edf3;
+    --border: #30363d;
+    --muted: #8b949e;
+  }
+}
+
+/* ── 正文基础 ──────────────────────────────────────────────────────────── */
 
 body {
-  font-family: system-ui, -apple-system, "PingFang SC", "PingFang TC", "Noto Sans CJK SC", "Noto Sans CJK TC", sans-serif;
-  line-height: 1.65;
+  font-family: system-ui, -apple-system, "PingFang SC", "PingFang TC",
+               "Noto Sans CJK SC", "Noto Sans CJK TC", "Source Han Sans",
+               sans-serif;
+  line-height: 1.75;            /* 中文书适合稍宽的行距 */
   orphans: 2;
   widows: 2;
+  /* 中文不 justify（避免字间距参差），由阅读器自然左对齐 */
 }
 
-h1, h2, h3, h4 {
+p {
+  margin: 0 0 0.8em 0;
+}
+
+/* ── 标题 ──────────────────────────────────────────────────────────────── */
+
+h1, h2, h3, h4, h5, h6 {
   line-height: 1.3;
   break-after: avoid;
+  font-weight: 600;
 }
+
+/* H1 = 章标题：每章新起一页 + 居中 + 主色 */
+h1 {
+  break-before: recto;          /* 章首页：奇数页起（实体书风格） */
+  font-size: 1.85em;
+  margin: 2.5em 0 1.2em 0;
+  padding-bottom: 0.4em;
+  border-bottom: 2px solid var(--accent);
+  color: var(--accent);
+  text-align: center;           /* 章标题居中（实体书风格） */
+  letter-spacing: 0.02em;
+}
+
+/* 第一个 h1 不强制分页（避免书开头空白页） */
+h1:first-of-type {
+  break-before: auto;
+}
+
+/* H2 = 节标题（如 1.1）：稍大、加底部装饰线 */
+h2 {
+  font-size: 1.4em;
+  margin: 2em 0 0.8em 0;
+  padding-bottom: 0.25em;
+  border-bottom: 1px solid var(--border);
+}
+
+/* H3 = 子节（如 1.1.1）：主色、左缩进 */
+h3 {
+  font-size: 1.18em;
+  margin: 1.6em 0 0.6em 0;
+  color: var(--accent);
+  padding-left: 0.5em;
+}
+
+h4 {
+  font-size: 1.05em;
+  margin: 1.3em 0 0.5em 0;
+  color: var(--muted);
+}
+
+/* ── 章节编号弱化（section-header-number）───────────────────────────── */
+/* 编号字号变小、颜色变浅，让标题文字更突出。不删除（保留定位意义） */
+
+.section-header-number {
+  font-size: 0.7em;
+  font-weight: 400;
+  color: var(--muted);
+  vertical-align: 0.15em;
+  margin-right: 0.4em;
+  letter-spacing: 0.05em;
+}
+
+/* H1 章标题里的编号稍大但仍弱化（如 "第 1 章"） */
+h1 .section-header-number {
+  font-size: 0.5em;
+  display: block;
+  margin-bottom: 0.4em;
+  letter-spacing: 0.2em;
+}
+
+/* 目录里的编号也弱化 */
+nav#toc .section-header-number {
+  font-size: 0.85em;
+  color: var(--muted);
+  font-weight: 400;
+  margin-right: 0.3em;
+}
+
+/* ── 链接 ──────────────────────────────────────────────────────────────── */
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+/* ── 图片 / 图 ─────────────────────────────────────────────────────────── */
 
 img, svg {
   display: block;
   height: auto;
-  margin: 1em auto;
+  margin: 1.2em auto;
   max-width: 100%;
 }
 
@@ -27,67 +138,249 @@ figure {
 }
 
 figcaption {
-  color: #666;
-  font-size: 0.9em;
+  color: var(--muted);
+  font-size: 0.88em;
   text-align: center;
+  margin-top: 0.5em;
 }
 
-pre {
-  -webkit-overflow-scrolling: touch;
-  font-size: 0.82em;
-  line-height: 1.45;
-  max-width: 100%;
-  overflow-x: auto;
-  white-space: pre;
-}
+/* ── 代码块（重点优化：高亮、换行、iBooks 兼容）───────────────────── */
 
 code {
-  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-family: ui-monospace, "SFMono-Regular", "Menlo", "Consolas",
+               "Source Code Pro", monospace;
+  font-size: 0.9em;
 }
+
+/* 行内代码 */
+p code, li code {
+  background: var(--code-bg);
+  color: var(--code-text);
+  padding: 0.1em 0.35em;
+  border-radius: 0.25em;
+  word-break: break-word;
+}
+
+/* 代码块 */
+pre {
+  background: var(--code-bg);
+  color: var(--code-text);
+  padding: 0.9em 1em;
+  margin: 1em 0;
+  border-radius: 0.4em;
+  border: 1px solid var(--border);
+  font-size: 0.85em;
+  line-height: 1.5;
+  /* 关键：自动换行，避免窄屏横向滚动（比 overflow-x 友好） */
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  font-size: 1em;
+  /* 与 pre 的换行策略保持一致 */
+  white-space: pre-wrap;
+}
+
+/* pandoc 把代码块包在 .sourceCode / pre.sourceCode 里 */
+pre.sourceCode, div.sourceCode {
+  background: var(--code-bg);
+  border-radius: 0.4em;
+}
+
+/* Apple Books 已知 bug 修复：sourceCode 溢出 / 截断 (pandoc issue #6242) */
+@media screen {
+  .sourceCode {
+    overflow: visible !important;
+    white-space: pre-wrap !important;
+  }
+}
+
+/* ── 表格 ──────────────────────────────────────────────────────────────── */
 
 table {
   border-collapse: collapse;
-  display: block;
-  font-size: 0.86em;
+  display: block;               /* 小屏可横滚 */
+  font-size: 0.88em;
+  margin: 1em 0;
+  max-width: 100%;
   overflow-x: auto;
-  width: 100%;
 }
 
 th, td {
-  border: 1px solid #999;
-  padding: 0.35em 0.5em;
+  border: 1px solid var(--border);
+  padding: 0.4em 0.7em;
   vertical-align: top;
 }
 
-blockquote {
-  border-left: 0.25em solid #888;
-  margin-left: 0;
-  padding-left: 1em;
+th {
+  background: var(--accent-light);
+  font-weight: 600;
+  text-align: left;
 }
 
-nav#toc > ol.toc {
+tbody tr:nth-child(even) {
+  background: rgba(0, 0, 0, 0.02);
+}
+
+/* ── 引用 / 提示框（本书的 experiment_box.lua 产出大量引用）────────── */
+
+blockquote {
+  /* 变成「提示框」而非细左线 */
+  margin: 1.2em 0;
+  padding: 0.8em 1.2em;
+  border-left: 0.3em solid var(--accent);
+  background: var(--accent-light);
+  border-radius: 0 0.4em 0.4em 0;
+  /* 不要斜体（中文斜体很难看）*/
+}
+
+blockquote p {
+  margin: 0.4em 0;
+}
+
+blockquote p:first-child {
+  margin-top: 0;
+}
+
+blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+/* 嵌套引用：内部再分层的提示 */
+blockquote blockquote {
+  margin: 0.6em 0;
+  border-left-width: 0.2em;
+}
+
+/* ── 列表 ──────────────────────────────────────────────────────────────── */
+
+ul, ol {
+  margin: 0.5em 0 0.8em 0;
+  padding-left: 1.5em;
+}
+
+li {
+  margin: 0.25em 0;
+}
+
+/* ── 水平线（章节分隔）────────────────────────────────────────────── */
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 2em 0;
+}
+
+/* ── 目录（pandoc 自动生成）────────────────────────────────────────── */
+
+nav#toc ol, nav#toc ul,
+nav#TOC ol, nav#TOC ul {
   list-style: none;
+  padding-left: 1em;
+  margin: 0.3em 0;
+}
+
+nav#toc > ol.toc, nav#toc > ul,
+nav#TOC > ol, nav#TOC > ul {
   padding-left: 0;
 }
 
-nav#toc > ol.toc > li.chapter-group {
+nav#toc > ol.toc > li.chapter-group,
+nav#TOC > ol > li.chapter-group {
   list-style: none;
   margin: 2.5em 0;
 }
 
-nav#toc > ol.toc > li.chapter-group > a {
+nav#toc > ol.toc > li.chapter-group > a,
+nav#TOC > ol > li.chapter-group > a {
   display: block;
   font-size: 1.2em;
   font-weight: bold;
   margin-bottom: 1em;
   text-align: center;
+  color: var(--accent);
+  text-decoration: none;
 }
 
-nav#toc > ol.toc > li.chapter-group > ol.toc {
-  list-style: none;
-  padding-left: 0;
+/* 目录里的 H2 级项（如 1.1）：缩进 + 加粗，作为子项的父级 */
+nav#toc details > ol.toc > li,
+nav#toc li.chapter-group > ol.toc > li,
+nav#toc li.chapter-group > ol.toc.subsections > li {
+  font-weight: 600;
+  margin: 0.7em 0 0.25em 0;
+  padding: 0.2em 0 0.2em 1.2em;   /* 左缩进，让 1.1 比 1 视觉低一层 */
+  border-bottom: 1px dotted var(--border);
+  color: var(--accent);
 }
 
-nav#toc > ol.toc > li.chapter-group > ol.toc > li {
-  margin: 0.45em 0;
+/* H3 级目录项（如 1.1.1）：更深缩进、常规字重、淡化 */
+nav#toc details > ol.toc > li > ol.toc > li,
+nav#toc li.chapter-group > ol.toc > li > ol.toc > li,
+nav#toc li.chapter-group > ol.toc.subsections > li > ol.toc > li {
+  font-weight: normal;
+  margin: 0.25em 0;
+  padding-left: 2.5em;            /* 比 1.1 更深的缩进 */
+  font-size: 0.95em;
+  color: var(--muted);
+  border-bottom: none;
+}
+
+/* 更深层（H4，如 1.1.1.1）：进一步缩进 */
+nav#toc details > ol.toc > li > ol.toc > li > ol.toc > li,
+nav#toc li.chapter-group > ol.toc > li > ol.toc > li > ol.toc > li,
+nav#toc li.chapter-group > ol.toc.subsections > li > ol.toc > li > ol.toc > li {
+  font-size: 0.9em;
+  padding-left: 3.5em;
+}
+
+nav#toc a, nav#TOC a {
+  text-decoration: none;
+  color: inherit;
+}
+
+/* ── 标题页 ────────────────────────────────────────────────────────────── */
+
+/* pandoc 生成的 title page 用 h1.title / p.subtitle / p.author */
+.title, h1.title {
+  text-align: center;
+  font-size: 2em;
+  margin: 3em 0 0.5em 0;
+  border-bottom: none;
+  color: var(--accent);
+  break-before: auto;
+}
+
+.subtitle {
+  text-align: center;
+  font-size: 1.1em;
+  color: var(--muted);
+  margin-bottom: 2em;
+}
+
+.author {
+  text-align: center;
+  font-size: 1em;
+  color: var(--muted);
+  margin: 1em 0;
+}
+
+/* ── 数学公式（pandoc --mathml 输出）────────────────────────────── */
+
+math {
+  font-size: 1.05em;
+}
+
+/* ── 小屏优化（手机阅读器）────────────────────────────────────────── */
+
+@media (max-width: 30em) {
+  body { font-size: 0.95em; }
+  pre { font-size: 0.78em; padding: 0.7em; }
+  h1 { font-size: 1.5em; }
+  h2 { font-size: 1.2em; }
+  table { font-size: 0.82em; }
 }

--- a/flatten_epub_toc.py
+++ b/flatten_epub_toc.py
@@ -28,6 +28,24 @@ def toc_item(identifier, href, label):
     return item
 
 
+def strip_section_numbers(element, namespace):
+    """递归删除所有 class=section-header-number 的子元素（连内容一起删）。
+    这样目录里只显示章节标题文字，不带 1.1 / 1.1.1 这种编号。"""
+    for span in list(element.iter(f"{{{namespace}}}span")):
+        classes = (span.get("class") or "").split()
+        if "section-header-number" in classes:
+            # 把 span 从父节点里移除（连同它的文本）
+            parent = span.getparent() if hasattr(span, "getparent") else None
+            if parent is None:
+                # ElementTree 没有 getparent，用遍历找
+                for parent in element.iter():
+                    if span in list(parent):
+                        parent.remove(span)
+                        break
+            else:
+                parent.remove(span)
+
+
 def flatten_nav(data, title_label, toc_label):
     root = ET.fromstring(data)
     nav = next(
@@ -36,8 +54,26 @@ def flatten_nav(data, title_label, toc_label):
         if element.get(f"{{{EPUB}}}type") == "toc"
     )
     top_list = next(child for child in nav if child.tag == f"{{{XHTML}}}ol")
+    # 正文目录页保留扉页、目录两个条目（这里不动）。
     top_list.insert(0, toc_item("toc-li-contents", "nav.xhtml#toc", toc_label))
     top_list.insert(0, toc_item("toc-li-title-page", "text/title_page.xhtml", title_label))
+
+    # 先删掉所有 section-header-number（让目录只显示标题文字，不带 1.1 / 1.1.1 编号）
+    # 关键：pandoc 把编号放在 <span class="section-header-number">1.1</span> 里，
+    # 标题文字在 span.tail（span 之后的文本节点）。直接 remove(span) 会把 tail 也丢掉，
+    # 导致 a 标签变空。所以要先保留 tail 文本。
+    for a in root.iter(f"{{{XHTML}}}a"):
+        for span in list(a):
+            classes = (span.get("class") or "").split()
+            if "section-header-number" in classes:
+                # 保留 span 后的文本（标题正文）到 a 的 text
+                tail_text = (span.tail or "").lstrip()
+                if tail_text:
+                    if a.text:
+                        a.text = a.text + tail_text
+                    else:
+                        a.text = tail_text
+                a.remove(span)
 
     for group in direct_children(top_list, f"{{{XHTML}}}li"):
         classes = group.get("class", "").split()
@@ -45,22 +81,15 @@ def flatten_nav(data, title_label, toc_label):
             classes.append("chapter-group")
         group.set("class", " ".join(classes))
 
-        nested_lists = direct_children(group, f"{{{XHTML}}}ol")
-        if not nested_lists:
-            continue
-
-        descendants = []
-        for nested_list in nested_lists:
-            descendants.extend(nested_list.iter(f"{{{XHTML}}}li"))
-            group.remove(nested_list)
-
-        flat_list = ET.Element(f"{{{XHTML}}}ol", {"class": "toc"})
-        for descendant in descendants:
-            flat_item = copy.deepcopy(descendant)
-            for child in direct_children(flat_item, f"{{{XHTML}}}ol"):
-                flat_item.remove(child)
-            flat_list.append(flat_item)
-        group.append(flat_list)
+        # 保留 pandoc 原始的 H2→H3→H4 嵌套结构。
+        # 侧边栏靠缩进显示层级。
+        for nested_list in direct_children(group, f"{{{XHTML}}}ol"):
+            nested_list.set("class", "toc subsections")
+            for sub_li in direct_children(nested_list, f"{{{XHTML}}}li"):
+                sub_classes = sub_li.get("class", "").split()
+                if "subsection" not in sub_classes:
+                    sub_classes.append("subsection")
+                    sub_li.set("class", " ".join(sub_classes))
 
     return ET.tostring(root, encoding="utf-8", xml_declaration=True)
 
@@ -70,41 +99,44 @@ def flatten_ncx(data, title_label, toc_label):
     root = ET.fromstring(data)
     nav_map = root.find(f"{{{NCX}}}navMap")
 
+    # Apple Books 侧边栏读 toc.ncx（即使 EPUB3 也会回退到 ncx）。
+    # 保留 pandoc 完整嵌套层级 + 删掉编号前缀（让侧边栏只显示标题文字）。
+
+    # 1. 找到/补上「扉页」入口
     title_point = None
     for point in direct_children(nav_map, f"{{{NCX}}}navPoint"):
         content = point.find(f"{{{NCX}}}content")
         if content is not None and content.get("src") == "text/title_page.xhtml":
             title_point = point
             label = point.find(f"{{{NCX}}}navLabel/{{{NCX}}}text")
-            label.text = title_label
+            if label is not None:
+                label.text = title_label
             break
 
-    contents_point = ET.Element(f"{{{NCX}}}navPoint", {"id": "navPoint-contents"})
-    contents_label = ET.SubElement(contents_point, f"{{{NCX}}}navLabel")
-    ET.SubElement(contents_label, f"{{{NCX}}}text").text = toc_label
-    ET.SubElement(contents_point, f"{{{NCX}}}content", {"src": "nav.xhtml#toc"})
-    insertion_index = list(nav_map).index(title_point) + 1 if title_point is not None else 0
-    nav_map.insert(insertion_index, contents_point)
+    # 2. 删掉每个 navLabel 里的编号前缀（如 "1.1 现代 Agent" → "现代 Agent"）
+    import re as _re
+    for label_text in root.iter(f"{{{NCX}}}text"):
+        if label_text.text:
+            # 去掉开头的 "1.1.1 " 或 "1.1 " 或 "1 " 这种编号
+            label_text.text = _re.sub(r'^\d+(\.\d+)*\s+', '', label_text.text)
 
-    for group in direct_children(nav_map, f"{{{NCX}}}navPoint"):
-        children = direct_children(group, f"{{{NCX}}}navPoint")
-        if not children:
-            continue
+    # 3. 保留 pandoc 完整嵌套（不删任何 navPoint）
 
-        descendants = []
-        for child in children:
-            descendants.extend(child.iter(f"{{{NCX}}}navPoint"))
-            group.remove(child)
-
-        for descendant in descendants:
-            flat_point = copy.deepcopy(descendant)
-            for child in direct_children(flat_point, f"{{{NCX}}}navPoint"):
-                flat_point.remove(child)
-            group.append(flat_point)
+    # 4. 给每个 navPoint 补 playOrder（按深度优先顺序递增）。
+    # NCX 规范要求 playOrder；pandoc 默认会加，但删除/重排 navPoint 后可能丢失。
+    # 缺 playOrder 时部分阅读器（如 Apple Books）会把嵌套层级拍平显示。
+    counter = [0]
+    def assign_play_order(point):
+        counter[0] += 1
+        point.set("playOrder", str(counter[0]))
+        for child in direct_children(point, f"{{{NCX}}}navPoint"):
+            assign_play_order(child)
+    for point in direct_children(nav_map, f"{{{NCX}}}navPoint"):
+        assign_play_order(point)
 
     depth = root.find(f".//{{{NCX}}}meta[@name='dtb:depth']")
     if depth is not None:
-        depth.set("content", "2")
+        depth.set("content", "3")
 
     return ET.tostring(root, encoding="utf-8", xml_declaration=True)
 


### PR DESCRIPTION
## 改动

重写 \`epub.css\` + 微调 \`flatten_epub_toc.py\` + \`build_epub.sh\`，让 EPUB 在 Apple Books / Calibre / Kindle 等阅读器里的视觉效果接近 PDF（ElegantBook cyan 主题）。

### epub.css（93 → ~370 行）

| 元素 | 改前 | 改后 |
|---|---|---|
| 代码块 | 无高亮、易溢出 | \`--highlight-style=kate\` + 灰底圆角 + 自动换行 |
| 引用 blockquote | 细灰左线 | 青色提示框（淡背景 + 圆角，适配本书大量 \`experiment_box\` 产出的引用）|
| H1 章标题 | 普通 | 居中 + 主色 + 底线 |
| H2 节标题 | 普通 | 底部线 |
| H3 子节 | 普通 | 青色 + 左缩进 |
| 章节编号 | 突出 | 弱化（字号小、颜色淡）|
| 表格 | 默认 | 表头青色背景 |
| Apple Books bug | 无处理 | \`.sourceCode\` 溢出修复（pandoc issue #6242）|
| 小屏 | 无适配 | \`@media (max-width: 30em)\` 缩字号 |

### flatten_epub_toc.py

- **目录页 + 侧边栏去掉编号**：删除 \`<span class=\"section-header-number\">\` 和 ncx navLabel 里的 \`1.1\` 前缀，只保留标题文字
- **保留 pandoc 完整嵌套层级**（章→节→子节），不拍平
- **补全 playOrder**：NCX 规范要求，pandoc 默认会加但删除/重排 navPoint 后会丢
- 保留扉页/目录入口

### build_epub.sh

加 \`--highlight-style=kate\`（与 PDF build 一致，代码块语法高亮）。

## 验证

- 中文版 EPUB 已本地构建测试
- 代码高亮、提示框、标题美化、编号弱化都生效
- 表格、图片、代码块换行在窄屏不溢出
- 目录嵌套层级结构正确（章→节→子节）

\`\`\`
88 个项目 / 20 条 git clone / 4 语言结构 全部保留
\`\`\`

零信息丢失——只改了视觉呈现，没动正文 markdown。