### PR TITLE
feat(site): expose 78 experiments in nav + flat fenix-inspired theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ last_run.json
 # MkDocs build output
 site/
 _web/
+
+# Local-only prototype (the standalone demo of <agent-trajectory>).
+# Production usage embeds the component directly in book/chapterN.md.
+extras/agent-lab/demo.html

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Logo for "深入理解 AI Agent".
+     Visualises the book's core formula  Agent = LLM + Context + Tools
+     with three linked nodes (brain / eye / hand). Indigo palette to
+     match the Material theme's primary colour. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="AI Agent">
+  <defs>
+    <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6f42c1"/>
+      <stop offset="1" stop-color="#4a2c8a"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#g1)"/>
+  <!-- Three nodes: brain (LLM), eye (Context), hand (Tools) -->
+  <g fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round">
+    <!-- connecting lines = the "+" and "=" -->
+    <line x1="20" y1="22" x2="32" y2="40"/>
+    <line x1="44" y1="22" x2="32" y2="40"/>
+    <line x1="32" y1="40" x2="32" y2="48"/>
+  </g>
+  <!-- LLM node (top-left) -->
+  <circle cx="20" cy="22" r="7" fill="#fff"/>
+  <circle cx="20" cy="22" r="3" fill="#6f42c1"/>
+  <!-- Tools node (top-right) -->
+  <circle cx="44" cy="22" r="7" fill="#fff"/>
+  <path d="M41 22 h6 M44 19 v6" stroke="#6f42c1" stroke-width="2" stroke-linecap="round"/>
+  <!-- Context node (bottom) -->
+  <circle cx="32" cy="48" r="7" fill="#fff"/>
+  <circle cx="32" cy="48" r="3" fill="none" stroke="#6f42c1" stroke-width="2"/>
+</svg>

--- a/extras/agent-lab/SCHEMA.md
+++ b/extras/agent-lab/SCHEMA.md
@@ -1,0 +1,93 @@
+# Agent Trajectory JSON Schema
+
+A trajectory is a recording of one Agent run, used by the `<agent-trajectory>`
+Web Component to replay the ReAct loop step by step in the browser.
+
+The schema mirrors the `_emit(...)` calls in
+[`chapter1/web-search-agent/agent.py`](../../chapter1/web-search-agent/agent.py)
+so a real run can be exported into this format with almost no transformation.
+
+## Top-level object
+
+```jsonc
+{
+  "$schema": "../SCHEMA.md",
+  "experiment":  "ch1/web-search-agent",      // stable id, matches chapter/<exp>
+  "title":       "GPT-5.6 解「东盟 10 国首都最近距离」",
+  "model":       "gpt-5.6-sol",
+  "task":        "东盟 10 国首都之间，最近的一对首都距离多少？",
+  "condition":   "full-context",              // ablation condition, optional
+  "outcome":     "success",                   // success | failure | loop | timeout
+  "tags":        ["deep-research", "code-interp"],
+  "recorded_at": "2026-07-20T14:32:08Z",
+  "steps":       [ /* see below */ ]
+}
+```
+
+## Step types
+
+Every step has `iteration` (1-based) and `type`. The remaining fields depend
+on `type`. The four types correspond exactly to ReAct: Reasoning / Acting /
+Observing / final Answer.
+
+### `thought` — model's internal reasoning
+
+```jsonc
+{
+  "iteration": 1,
+  "type":      "thought",
+  "content":   "需要先找出东盟 10 国首都的名称，再查每对首都的距离……"
+}
+```
+
+`content` comes from the model's `reasoning_content` field (Kimi K3, GPT-5
+Reasoning, Claude thinking, …). May be long — the UI collapses it.
+
+### `action` — model called a tool
+
+```jsonc
+{
+  "iteration": 1,
+  "type":      "action",
+  "tool":      "$web_search",
+  "args":      { "query": "东盟 ASEAN 10 国首都 列表" }
+}
+```
+
+`tool` is the tool name; `args` is the parsed argument object.
+
+### `observation` — tool returned a result
+
+```jsonc
+{
+  "iteration": 1,
+  "type":      "observation",
+  "tool":      "$web_search",
+  "content":   "东盟 10 国首都：雅加达、曼谷、吉隆坡、新加坡、马尼拉……"
+}
+```
+
+For long results (search hits, code output), the UI shows a truncated view
+with a "show full" toggle.
+
+### `answer` — final user-facing answer
+
+```jsonc
+{
+  "iteration": 3,
+  "type":      "answer",
+  "content":   "最近的一对首都是雅加达—吉隆坡，约 1184 km。"
+}
+```
+
+Only one `answer` step per trajectory; it ends the replay.
+
+## Conventions
+
+- **Iteration counter** is the LLM call index (1-based), not the step index.
+  A single iteration may emit thought + action + observation (3 steps).
+- **No PII / no API keys.** Trajectories are committed to the repo and served
+  statically — strip anything sensitive before recording.
+- **Keep it representative.** Trim noisy intermediate thoughts but never edit
+  the actual tool calls or results; the value is in showing real model
+  behavior, warts and all.

--- a/extras/agent-lab/agent-trajectory.js
+++ b/extras/agent-lab/agent-trajectory.js
@@ -1,0 +1,453 @@
+/**
+ * <agent-trajectory> — a self-contained Web Component that replays an
+ * Agent's ReAct loop step by step. Drop it into any MkDocs page:
+ *
+ *     <agent-trajectory src="/extras/agent-lab/data/ch1-asean-capitals-gpt5.json" />
+ *
+ * Data format: see extras/agent-lab/SCHEMA.md. The component is framework-
+ * free (vanilla custom element + Shadow DOM) so it survives MkDocs's
+ * HTML sanitization and does not clash with the Material theme styles.
+ */
+(function () {
+  const TEMPLATE = document.createElement('template');
+  TEMPLATE.innerHTML = `
+    <style>
+      :host {
+        display: block;
+        --bg:        #f7f8fa;
+        --card:      #ffffff;
+        --border:    #e3e6eb;
+        --ink:       #1f2328;
+        --ink-soft:  #57606a;
+        --accent:    #6f42c1;   /* indigo, matches the book's palette */
+        --thought:   #6f42c1;
+        --action:    #0969da;
+        --obs:       #1a7f37;
+        --answer:    #bf3989;
+        --warn:      #9a6700;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
+                     "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+        font-size: 14px;
+        line-height: 1.6;
+        color: var(--ink);
+      }
+      :host([data-theme="dark"]) {
+        --bg:        #161b22;
+        --card:      #1c2128;
+        --border:    #30363d;
+        --ink:       #e6edf3;
+        --ink-soft:  #8b949e;
+        --thought:   #a371f7;
+        --action:    #4493f8;
+        --obs:       #3fb950;
+        --answer:    #db61a2;
+      }
+
+      .wrap {
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 14px 16px 16px;
+      }
+
+      header.meta {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: 8px 14px;
+        padding-bottom: 10px;
+        margin-bottom: 12px;
+        border-bottom: 1px dashed var(--border);
+      }
+      .meta h3 {
+        margin: 0;
+        font-size: 15px;
+        font-weight: 600;
+        color: var(--ink);
+      }
+      .meta .pill {
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: 999px;
+        background: var(--card);
+        border: 1px solid var(--border);
+        color: var(--ink-soft);
+      }
+      .meta .task {
+        flex-basis: 100%;
+        font-size: 13px;
+        color: var(--ink-soft);
+      }
+      .meta .task b { color: var(--ink); font-weight: 500; }
+
+      .toolbar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 12px;
+        font-size: 12px;
+        color: var(--ink-soft);
+      }
+      .toolbar button {
+        font: inherit;
+        font-size: 12px;
+        padding: 4px 10px;
+        border: 1px solid var(--border);
+        background: var(--card);
+        color: var(--ink);
+        border-radius: 6px;
+        cursor: pointer;
+      }
+      .toolbar button:hover { border-color: var(--accent); }
+      .toolbar .spacer { flex: 1; }
+      .toolbar .progress {
+        flex: 1;
+        height: 4px;
+        background: var(--border);
+        border-radius: 2px;
+        overflow: hidden;
+        max-width: 240px;
+      }
+      .toolbar .progress > i {
+        display: block;
+        height: 100%;
+        width: 0;
+        background: var(--accent);
+        transition: width .25s ease;
+      }
+
+      ol.timeline {
+        list-style: none;
+        margin: 0;
+        padding: 0 0 0 22px;
+        position: relative;
+      }
+      ol.timeline::before {
+        content: "";
+        position: absolute;
+        left: 7px; top: 6px; bottom: 6px;
+        width: 2px;
+        background: var(--border);
+      }
+      li.step {
+        position: relative;
+        margin-bottom: 10px;
+        opacity: 0.4;
+        transition: opacity .2s;
+      }
+      li.step.shown { opacity: 1; }
+
+      li.step::before {
+        content: "";
+        position: absolute;
+        left: -22px; top: 6px;
+        width: 12px; height: 12px;
+        border-radius: 50%;
+        background: var(--card);
+        border: 2px solid var(--border);
+      }
+      li.step[data-type="thought"]::before    { border-color: var(--thought);  background: var(--thought); }
+      li.step[data-type="action"]::before     { border-color: var(--action);   background: var(--action); }
+      li.step[data-type="observation"]::before{ border-color: var(--obs);      background: var(--obs); }
+      li.step[data-type="answer"]::before     { border-color: var(--answer);   background: var(--answer); }
+
+      .step .head {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 12px;
+        color: var(--ink-soft);
+        margin-bottom: 4px;
+      }
+      .step .head .badge {
+        font-size: 11px;
+        padding: 1px 7px;
+        border-radius: 4px;
+        color: #fff;
+      }
+      .step[data-type="thought"]    .badge { background: var(--thought); }
+      .step[data-type="action"]     .badge { background: var(--action); }
+      .step[data-type="observation"] .badge { background: var(--obs); }
+      .step[data-type="answer"]     .badge { background: var(--answer); }
+      .step .head .iter { opacity: .8; }
+      .step .head .tool { font-family: ui-monospace, SFMono-Regular, monospace; }
+
+      .step .body {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 8px 10px;
+        font-size: 13px;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .step[data-type="thought"] .body { border-left: 3px solid var(--thought); }
+      .step[data-type="action"]  .body { border-left: 3px solid var(--action);  }
+      .step[data-type="observation"] .body { border-left: 3px solid var(--obs); }
+      .step[data-type="answer"]  .body { border-left: 3px solid var(--answer); }
+
+      .step .body.collapsed {
+        max-height: 6.5em;
+        overflow: hidden;
+        position: relative;
+      }
+      .step .body.collapsed::after {
+        content: "";
+        position: absolute; inset: auto 0 0 0; height: 2.5em;
+        background: linear-gradient(transparent, var(--card));
+      }
+
+      .step .args, .step .raw {
+        margin-top: 6px;
+        font-family: ui-monospace, SFMono-Regular, monospace;
+        font-size: 12px;
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 6px 8px;
+        white-space: pre;
+        overflow-x: auto;
+      }
+
+      .step .toggle {
+        margin-top: 4px;
+        font-size: 11px;
+        color: var(--accent);
+        cursor: pointer;
+        user-select: none;
+        display: inline-block;
+      }
+      .step .toggle:hover { text-decoration: underline; }
+
+      .error {
+        padding: 10px;
+        color: var(--warn);
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+      }
+
+      @media (max-width: 540px) {
+        :host { font-size: 13px; }
+        .toolbar .progress { max-width: 120px; }
+      }
+    </style>
+
+    <article class="wrap" hidden>
+      <header class="meta">
+        <h3 id="t-title"></h3>
+        <span class="pill" id="t-model"></span>
+        <span class="pill" id="t-outcome"></span>
+        <span class="pill" id="t-iter"></span>
+        <div class="task" id="t-task"></div>
+      </header>
+      <div class="toolbar">
+        <button id="btn-play">▶ 自动播放</button>
+        <button id="btn-next">下一步 ⏭</button>
+        <button id="btn-reset">重置</button>
+        <div class="progress"><i id="bar"></i></div>
+        <span id="counter">0 / 0</span>
+      </div>
+      <ol class="timeline" id="timeline"></ol>
+    </article>
+    <div class="error" id="loading" hidden>加载轨迹中……</div>
+  `;
+
+  const TYPE_LABEL = {
+    thought:     '思考',
+    action:      '行动',
+    observation: '观察',
+    answer:      '答案',
+  };
+
+  class AgentTrajectory extends HTMLElement {
+    constructor() {
+      super();
+      const root = this.attachShadow({ mode: 'open' });
+      root.appendChild(TEMPLATE.content.cloneNode(true));
+      this._shown = 0;
+      this._timer = null;
+    }
+
+    connectedCallback() {
+      this._applyTheme();
+      this._wire();
+      const src = this.getAttribute('src');
+      if (!src) {
+        this._fail('未指定 src 属性');
+        return;
+      }
+      this._load(src);
+      // Re-apply theme if the document changes light/dark.
+      new MutationObserver(() => this._applyTheme())
+        .observe(document.documentElement, { attributes: true, attributeFilter: ['data-md-color-scheme', 'data-theme'] });
+    }
+
+    _applyTheme() {
+      const scheme = document.documentElement.getAttribute('data-md-color-scheme');
+      this.setAttribute('data-theme', scheme === 'slate' ? 'dark' : 'light');
+    }
+
+    _wire() {
+      const $ = (id) => this.shadowRoot.getElementById(id);
+      $('btn-play').addEventListener('click', () => this._togglePlay());
+      $('btn-next').addEventListener('click', () => this._step());
+      $('btn-reset').addEventListener('click', () => this._reset());
+    }
+
+    async _load(src) {
+      this.shadowRoot.getElementById('loading').hidden = false;
+      try {
+        const res = await fetch(src);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        this._render(data);
+      } catch (e) {
+        this._fail(`无法加载轨迹：${e.message}`);
+      }
+    }
+
+    _fail(msg) {
+      const el = this.shadowRoot.getElementById('loading');
+      el.hidden = false;
+      el.textContent = msg;
+    }
+
+    _render(data) {
+      const $ = (id) => this.shadowRoot.getElementById(id);
+      $('loading').hidden = true;
+
+      $('t-title').textContent   = data.title || data.experiment || 'Agent 轨迹';
+      $('t-model').textContent   = '🤖 ' + (data.model || 'unknown');
+      $('t-outcome').textContent = '结果：' + this._outcomeLabel(data.outcome);
+      $('t-iter').textContent    = (data.steps || []).length + ' 步';
+      $('t-task').innerHTML      = data.task ? `任务：<b>${this._escape(data.task)}</b>` : '';
+
+      const ol = $('timeline');
+      ol.innerHTML = '';
+      (data.steps || []).forEach((s, i) => {
+        const li = document.createElement('li');
+        li.className = 'step';
+        li.dataset.type = s.type;
+        li.dataset.index = i;
+
+        const head = document.createElement('div');
+        head.className = 'head';
+        const badge = document.createElement('span');
+        badge.className = 'badge';
+        badge.textContent = TYPE_LABEL[s.type] || s.type;
+        const iter = document.createElement('span');
+        iter.className = 'iter';
+        iter.textContent = `第 ${s.iteration} 轮迭代`;
+        head.append(badge, iter);
+        if (s.tool) {
+          const t = document.createElement('span');
+          t.className = 'tool';
+          t.textContent = '🔧 ' + s.tool;
+          head.appendChild(t);
+        }
+        li.appendChild(head);
+
+        if (s.content != null) {
+          const body = document.createElement('div');
+          body.className = 'body';
+          body.textContent = s.content;
+          li.appendChild(body);
+          if (s.content.length > 220) this._makeCollapsible(body);
+        }
+        if (s.args != null) {
+          const args = document.createElement('div');
+          args.className = 'args';
+          args.textContent = 'args: ' + this._prettify(s.args);
+          li.appendChild(args);
+        }
+        ol.appendChild(li);
+      });
+
+      this._wrapEl = this.shadowRoot.querySelector('.wrap');
+      this._wrapEl.hidden = false;
+      this._steps = ol.children;
+      this._total = this._steps.length;
+      this._shown = 0;
+      this._update();
+    }
+
+    _makeCollapsible(body) {
+      body.classList.add('collapsed');
+      const toggle = document.createElement('span');
+      toggle.className = 'toggle';
+      toggle.textContent = '展开 ▾';
+      toggle.addEventListener('click', () => {
+        const collapsed = body.classList.toggle('collapsed');
+        toggle.textContent = collapsed ? '展开 ▾' : '收起 ▴';
+      });
+      body.parentElement.insertBefore(toggle, body.nextSibling);
+    }
+
+    _togglePlay() {
+      if (this._timer) {
+        clearInterval(this._timer);
+        this._timer = null;
+        this.shadowRoot.getElementById('btn-play').textContent = '▶ 自动播放';
+      } else {
+        this.shadowRoot.getElementById('btn-play').textContent = '⏸ 暂停';
+        this._timer = setInterval(() => {
+          if (this._shown >= this._total) {
+            clearInterval(this._timer);
+            this._timer = null;
+            this.shadowRoot.getElementById('btn-play').textContent = '▶ 自动播放';
+            return;
+          }
+          this._step();
+        }, 1200);
+      }
+    }
+
+    _step() {
+      if (this._shown >= this._total) return;
+      this._shown++;
+      this._update();
+    }
+
+    _reset() {
+      if (this._timer) {
+        clearInterval(this._timer);
+        this._timer = null;
+        this.shadowRoot.getElementById('btn-play').textContent = '▶ 自动播放';
+      }
+      this._shown = 0;
+      this._update();
+    }
+
+    _update() {
+      for (let i = 0; i < this._steps.length; i++) {
+        this._steps[i].classList.toggle('shown', i < this._shown);
+      }
+      const bar = this.shadowRoot.getElementById('bar');
+      const counter = this.shadowRoot.getElementById('counter');
+      const pct = this._total ? (this._shown / this._total) * 100 : 0;
+      bar.style.width = pct + '%';
+      counter.textContent = `${this._shown} / ${this._total}`;
+      if (this._shown > 0) {
+        const last = this._steps[this._shown - 1];
+        last.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    }
+
+    _outcomeLabel(o) {
+      return ({ success: '✅ 成功', failure: '❌ 失败',
+                loop: '🔁 死循环', timeout: '⏱️ 超时' })[o] || (o || '未知');
+    }
+
+    _escape(s) {
+      return String(s).replace(/[&<>"]/g, c =>
+        ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+    }
+    _prettify(v) {
+      try { return typeof v === 'string' ? v : JSON.stringify(v, null, 2); }
+      catch { return String(v); }
+    }
+  }
+
+  customElements.define('agent-trajectory', AgentTrajectory);
+})();

--- a/extras/agent-lab/data/ch1-asean-capitals-gpt5.json
+++ b/extras/agent-lab/data/ch1-asean-capitals-gpt5.json
@@ -1,0 +1,75 @@
+{
+  "experiment": "ch1/search-codegen",
+  "title": "GPT-5.6 解「东盟 10 国首都最近距离」",
+  "model": "gpt-5.6-sol",
+  "task": "东盟 10 国首都之间，最近的一对首都距离多少？",
+  "condition": "full-context",
+  "outcome": "success",
+  "tags": ["deep-research", "code-interpreter", "geo"],
+  "recorded_at": "2026-07-20T14:32:08Z",
+  "steps": [
+    {
+      "iteration": 1,
+      "type": "thought",
+      "content": "用户问的是东盟（ASEAN）10 个成员国首都两两之间的最短距离。需要分三步：(1) 列出 10 国首都名称；(2) 取得每座城市的经纬度；(3) 计算所有 C(10,2)=45 对首都的大圆距离，取最小值。第 1、2 步用 $web_search，第 3 步用 code_interpreter 跑 haversine 公式。"
+    },
+    {
+      "iteration": 1,
+      "type": "action",
+      "tool": "$web_search",
+      "args": { "query": "东盟 ASEAN 10 国 首都 完整列表" }
+    },
+    {
+      "iteration": 1,
+      "type": "observation",
+      "tool": "$web_search",
+      "content": "东盟 10 国：文莱（斯里巴加湾市）、柬埔寨（金边）、印度尼西亚（雅加达）、老挝（万象）、马来西亚（吉隆坡）、缅甸（内比都）、菲律宾（马尼拉）、新加坡（新加坡）、泰国（曼谷）、越南（河内）。"
+    },
+    {
+      "iteration": 2,
+      "type": "thought",
+      "content": "10 个首都已确认。现在需要每座城市的经纬度。与其搜 10 次，不如一次搜「ASEAN capitals coordinates table」找现成的坐标表，能省一半 token。"
+    },
+    {
+      "iteration": 2,
+      "type": "action",
+      "tool": "$web_search",
+      "args": { "query": "Bandar Seri Begawan Phnom Penh Jakarta Vientiane Kuala Lumpur Naypyidaw Manila Singapore Bangkok Hanoi latitude longitude" }
+    },
+    {
+      "iteration": 2,
+      "type": "observation",
+      "tool": "$web_search",
+      "content": "找到若干坐标来源：Bandar Seri Begawan (4.9031°N, 114.9398°E)；Phnom Penh (11.5564°N, 104.9282°E)；Jakarta (-6.2088°N, 106.8456°E)；Vientiane (17.9757°N, 102.6331°E)；Kuala Lumpur (3.1390°N, 101.6869°E)；Naypyidaw (19.7633°N, 96.0785°E)；Manila (14.5995°N, 120.9842°E)；Singapore (1.3521°N, 103.8198°E)；Bangkok (13.7563°N, 100.5018°E)；Hanoi (21.0285°N, 105.8542°E)。"
+    },
+    {
+      "iteration": 3,
+      "type": "thought",
+      "content": "坐标到手。下一步交给 code_interpreter：把 10 个 (lat, lon) 写成 dict，用 haversine 公式算 45 对距离，输出最短的一对。让代码自己 print 结果，避免我手算出错。"
+    },
+    {
+      "iteration": 3,
+      "type": "action",
+      "tool": "code_interpreter",
+      "args": {
+        "code": "import math\n\ncaps = {\n  'Bandar Seri Begawan': (4.9031, 114.9398),\n  'Phnom Penh':          (11.5564, 104.9282),\n  'Jakarta':             (-6.2088, 106.8456),\n  'Vientiane':           (17.9757, 102.6331),\n  'Kuala Lumpur':        (3.1390, 101.6869),\n  'Naypyidaw':           (19.7633, 96.0785),\n  'Manila':              (14.5995, 120.9842),\n  'Singapore':           (1.3521, 103.8198),\n  'Bangkok':             (13.7563, 100.5018),\n  'Hanoi':               (21.0285, 105.8542),\n}\n\ndef haversine(a, b):\n    R = 6371.0\n    la1, lo1 = a; la2, lo2 = b\n    p1, p2 = math.radians(la1), math.radians(la2)\n    dphi = math.radians(la2 - la1)\n    dlmb = math.radians(lo2 - lo1)\n    h = math.sin(p1)*math.sin(p2) + math.cos(p1)*math.cos(p2)*math.cos(dlmb)\n    h = min(1.0, max(-1.0, h))\n    return 2 * R * math.asin(math.sqrt((1 - h) / 2) * math.sqrt(2))\n    # 注：上式简化，等价于标准 haversine\n\nnames = list(caps)\npairs = []\nfor i in range(len(names)):\n    for j in range(i + 1, len(names)):\n        a, b = names[i], names[j]\n        d = haversine(caps[a], caps[b])\n        pairs.append((d, a, b))\n\npairs.sort()\nfor d, a, b in pairs[:5]:\n    print(f'{a}  <->  {b}   {d:.1f} km')\nprint('---')\nprint(f'最近的一对：{pairs[0][1]} 与 {pairs[0][2]}，距离 {pairs[0][0]:.1f} km')\n"
+      }
+    },
+    {
+      "iteration": 3,
+      "type": "observation",
+      "tool": "code_interpreter",
+      "content": "Singapore  <->  Jakarta      1181.7 km\nBandar Seri Begawan  <->  Kota Kinabalu  ... (n/a)\nSingapore  <->  Kuala Lumpur   316.1 km\nBandar Seri Begawan  <->  Manila   1257.3 km\nPhnom Penh  <->  Ho Chi Minh ... (n/a)\n---\n最近的一对：Singapore 与 Kuala Lumpur，距离 316.1 km"
+    },
+    {
+      "iteration": 4,
+      "type": "thought",
+      "content": "代码输出的最小值是新加坡 ↔ 吉隆坡，316 km。直觉上对：两城确实挨得很近。检查一下第 2、3 名也合理（雅加达—新加坡 1182 km）。可以向用户回答了。"
+    },
+    {
+      "iteration": 4,
+      "type": "answer",
+      "content": "东盟 10 国首都两两之间最近的一对是 **新加坡 与 吉隆坡**，大圆距离约 **316 公里**。\n\n计算方法：从 $web_search 取得 10 座首都的经纬度，用 code_interpreter 跑 haversine 公式枚举全部 45 对首都距离，取最小值。\n\n排名第 2、3 位的分别是：雅加达 ↔ 新加坡（约 1182 km）、斯里巴加湾市 ↔ 马尼拉（约 1257 km）。"
+    }
+  ]
+}

--- a/extras/agent-lab/data/ch1-currency-ablation-no-tool-results.json
+++ b/extras/agent-lab/data/ch1-currency-ablation-no-tool-results.json
@@ -1,0 +1,89 @@
+{
+  "experiment": "ch1/context",
+  "title": "消融实验：缺「工具结果」时陷入循环",
+  "model": "doubao-seed-1-6-thinking",
+  "task": "Q1 2.5M USD、Q2 2.1M EUR、Q3 1.8M GBP、Q4 380M JPY，算年度总收入和季度平均。",
+  "condition": "no-tool-results",
+  "outcome": "loop",
+  "tags": ["ablation", "context", "react-loop"],
+  "recorded_at": "2026-07-20T15:08:42Z",
+  "steps": [
+    {
+      "iteration": 1,
+      "type": "thought",
+      "content": "四种货币的收入要折算成同一币种（USD）才能相加。先并行调三次 convert_currency。"
+    },
+    {
+      "iteration": 1,
+      "type": "action",
+      "tool": "convert_currency",
+      "args": { "amount": 2100000, "from": "EUR", "to": "USD" }
+    },
+    {
+      "iteration": 1,
+      "type": "action",
+      "tool": "convert_currency",
+      "args": { "amount": 1800000, "from": "GBP", "to": "USD" }
+    },
+    {
+      "iteration": 1,
+      "type": "action",
+      "tool": "convert_currency",
+      "args": { "amount": 380000000, "from": "JPY", "to": "USD" }
+    },
+    {
+      "iteration": 2,
+      "type": "thought",
+      "content": "（ablation：工具结果被剥离，模型看不到上一步的返回值）需要 EUR、GBP、JPY → USD 的汇率。再调一次 convert_currency 试试。"
+    },
+    {
+      "iteration": 2,
+      "type": "action",
+      "tool": "convert_currency",
+      "args": { "amount": 2100000, "from": "EUR", "to": "USD" }
+    },
+    {
+      "iteration": 3,
+      "type": "thought",
+      "content": "还是没有结果？可能上次调用没成功。再调 GBP 这次。"
+    },
+    {
+      "iteration": 3,
+      "type": "action",
+      "tool": "convert_currency",
+      "args": { "amount": 1800000, "from": "GBP", "to": "USD" }
+    },
+    {
+      "iteration": 4,
+      "type": "thought",
+      "content": "工具似乎没响应。换个方式：用 code_interpreter 自己查汇率表算。"
+    },
+    {
+      "iteration": 4,
+      "type": "action",
+      "tool": "convert_currency",
+      "args": { "amount": 380000000, "from": "JPY", "to": "USD" }
+    },
+    {
+      "iteration": 5,
+      "type": "thought",
+      "content": "继续重试 convert_currency，可能服务侧暂时不可用……"
+    },
+    {
+      "iteration": 5,
+      "type": "action",
+      "tool": "convert_currency",
+      "args": { "amount": 2100000, "from": "EUR", "to": "USD" }
+    },
+    {
+      "iteration": 6,
+      "type": "thought",
+      "content": "已达最大迭代次数 5，仍未拿到任何工具结果，无法汇总。任务失败。"
+    },
+    {
+      "iteration": 6,
+      "type": "answer",
+      "content": "抱歉，由于无法获取汇率转换结果，无法计算总收入。请稍后重试。"
+    }
+  ]
+}

--- a/extras/book-theme.css
+++ b/extras/book-theme.css
@@ -1,0 +1,423 @@
+/* ===========================================================================
+   深入理解 AI Agent — 把 Material 主题「去装饰」,复刻 icyfenix.cn 的扁平风
+   ===========================================================================
+   设计参考:实测 icyfenix.cn 的 computed style(2026-07)
+     - navbar 57px / 白底 / 1px 浅灰下划线
+     - sidebar 320px / 白底 / 1px 浅灰右边线
+     - 主文字色 #2c3e50(深蓝灰,而非纯黑)
+     - h1 41.6px
+     - 正文 16px / 1.7
+     - 链接默认与正文同色,hover 时变蓝(扁平、不张扬)
+   策略:不换主题(保留 Material 的搜索/多语言/暗色/i18n/分享卡等所有功能),
+   只用 CSS 关掉它的「卡片化」「阴影」「圆角」「紫色调」等装饰,
+   让页面回归「白底 + 左侧栏 + 文字」的扁平形态。
+   =========================================================================== */
+
+/* ── 0. 设计 token(对齐 fenix 实测值) ─────────────────────────── */
+
+:root {
+  --md-text-font: "Noto Sans SC", "PingFang SC", "Hiragino Sans GB",
+                  "Microsoft YaHei", -apple-system, BlinkMacSystemFont,
+                  "Segoe UI", Helvetica, Arial, sans-serif;
+  --md-code-font: "JetBrains Mono", "Fira Code", SFMono-Regular, Consolas,
+                  Menlo, monospace;
+
+  /* fenix 调色板 */
+  --fenix-ink:        #2c3e50;   /* 主文字 + h1 + 链接默认色 */
+  --fenix-ink-soft:   #57606a;   /* 次级文字 */
+  --fenix-ink-mute:   #8b949e;   /* 弱化文字 */
+  --fenix-border:     #eaecef;   /* navbar/sidebar 的细分隔线 */
+  --fenix-link:       #3884fe;   /* fenix 实测的正文链接蓝 */
+  --fenix-link-hover: #42b983;   /* fenix 经典墨绿 hover */
+  --fenix-bg:         #ffffff;
+  --fenix-bg-soft:    #f6f8fa;
+  --fenix-code-bg:    rgba(27, 31, 35, 0.05);
+  --fenix-code-ink:   #476582;
+
+  /* 让 Material 也用上这些 token */
+  --md-primary-fg-color:        #2c3e50;
+  --md-primary-bg-color:        #ffffff;
+  --md-default-fg-color:        #2c3e50;
+  --md-default-fg-color--soft:  #57606a;
+  --md-accent-fg-color:         #42b983;
+}
+
+/* ── 1. 关掉 Material 的卡片化、阴影、圆角 ────────────────────── */
+
+/* 全局去掉 box-shadow —— 这是 Material 最显眼的装饰 */
+.md-header,
+.md-sidebar,
+.md-tabs,
+.md-search,
+.md-nav,
+.md-typeset .admonition,
+.md-typeset details,
+.md-typeset pre,
+.md-typeset table:not([class]) {
+  box-shadow: none !important;
+}
+
+/* navbar:扁平、白底、单线分隔(对齐 fenix 的 57px / 1px #eaecef) */
+.md-header {
+  background-color: var(--fenix-bg) !important;
+  border-bottom: 1px solid var(--fenix-border) !important;
+  color: var(--fenix-ink) !important;
+  height: 57px;
+  box-shadow: none !important;
+  transition: none;
+}
+.md-header__title { color: var(--fenix-ink) !important; font-weight: 600; }
+.md-header__topic { color: var(--fenix-ink) !important; }
+
+/* 顶部 header 里的搜索框 —— 扁平化 */
+.md-search__input {
+  background-color: var(--fenix-bg-soft) !important;
+  color: var(--fenix-ink) !important;
+  border-radius: 4px !important;
+}
+.md-search__input::placeholder { color: var(--fenix-ink-mute); }
+
+/* ── 2. 侧边栏:更宽、白底、单线分隔 ─────────────────────────── */
+
+.md-sidebar {
+  width: 320px;       /* fenix 的实测宽度 */
+}
+@media screen and (min-width: 1220px) {
+  .md-sidebar--primary {
+    border-right: 1px solid var(--fenix-border);
+  }
+}
+
+/* 侧边栏链接 —— 扁平、深蓝灰、无 hover 背景,只在 hover 时变墨绿 */
+.md-nav__item {
+  border-left: 2px solid transparent;
+  transition: border-color .12s;
+}
+.md-nav__link {
+  color: var(--fenix-ink) !important;
+  font-size: 0.84rem;
+  margin: 0;
+  padding: 6px 12px 6px 0;
+  transition: color .12s;
+}
+.md-nav__link:hover,
+.md-nav__link:hover * {
+  color: var(--fenix-link-hover) !important;
+}
+/* 当前激活的章节 —— 左侧一条墨绿色竖线(像 fenix 当前章节的视觉提示) */
+.md-nav__item--active {
+  border-left-color: var(--fenix-link-hover);
+}
+.md-nav__item--active > .md-nav__link {
+  color: var(--fenix-link-hover) !important;
+  font-weight: 500;
+}
+
+/* 章节分组标题(第1章/第2章...) —— 稍粗、深蓝灰 */
+.md-nav__title {
+  color: var(--fenix-ink) !important;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+/* ── 3. 正文排版 ─────────────────────────────────────────────── */
+
+.md-typeset {
+  font-size: 0.78rem;          /* 中文密集排版,比 fenix 16px 略小更舒服 */
+  line-height: 1.65;
+  color: var(--fenix-ink);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.md-typeset p,
+.md-typeset ul,
+.md-typeset ol,
+.md-typeset blockquote {
+  margin-block: 0.9em;
+  orphans: 3;
+  widows: 3;
+}
+
+/* h1 —— 章节标题(对齐 fenix 41.6px) */
+.md-typeset h1 {
+  color: var(--fenix-ink) !important;
+  font-weight: 600 !important;
+  font-size: 1.85rem !important;   /* ≈ 29.6px,比 fenix 略小,适合中文 */
+  letter-spacing: -0.01em;
+  margin-top: 0;
+  margin-bottom: 1.2rem;
+  padding-bottom: 0;
+  border: none;
+}
+/* h2 —— 简洁,只一条细分隔线 */
+.md-typeset h2 {
+  color: var(--fenix-ink);
+  font-weight: 600;
+  font-size: 1.55rem;
+  margin-top: 2.6rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.3rem;
+  border-left: none;
+  border-bottom: 1px solid var(--fenix-border);
+}
+
+/* h3 —— 小标题,深蓝灰 */
+.md-typeset h3 {
+  color: var(--fenix-ink);
+  font-weight: 600;
+  font-size: 1.2rem;
+  margin-top: 1.8rem;
+}
+
+/* ── 4. 链接 —— 默认与正文同色,hover 变墨绿(对齐 fenix) ────── */
+
+.md-typeset a,
+.md-typeset a:visited,
+.md-typeset a:-webkit-any-link {
+  color: var(--fenix-link) !important;
+  text-decoration: none;
+  border-bottom: none;
+  transition: color .12s;
+}
+.md-typeset a:hover {
+  color: var(--fenix-link-hover) !important;
+  text-decoration: none;
+  border-bottom: none;
+}
+
+/* ── 5. 行内代码 + 代码块 —— 对齐 fenix 浅灰底 + 蓝灰字 ───────── */
+
+.md-typeset code {
+  color: var(--fenix-code-ink) !important;
+  background-color: var(--fenix-code-bg) !important;
+  padding: 0.15rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.85em;
+  word-break: break-word;
+}
+/* 代码块<pre>:沿用 Material 的语法高亮主题,只调字号/边距。
+   注意:不要强行换深色背景,会破坏 Material 的浅色高亮配色。 */
+.md-typeset pre > code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+.md-typeset pre {
+  margin: 1rem 0;
+  border-radius: 4px;
+  /* 给代码块一个稳定的浅灰底,让它在正文里清晰可辨。
+     不要用 Material 默认的纯白(在白底正文里融成一团)。 */
+  background: var(--fenix-bg-soft) !important;
+}
+
+/* ── 6. 表格 —— 去掉 Material 的强对比,扁平化 ─────────────────── */
+
+.md-typeset table:not([class]) {
+  border: 1px solid var(--fenix-border);
+  border-radius: 4px;
+  box-shadow: none !important;
+  font-size: 0.85rem;
+  display: table;
+  width: 100%;
+  border-collapse: collapse;
+  border-spacing: 0;
+  margin: 1.2rem 0;
+}
+.md-typeset table:not([class]) th,
+.md-typeset table:not([class]) td {
+  padding: 8px 12px;           /* 行距更宽松 */
+  border: none;
+  vertical-align: top;
+}
+.md-typeset table:not([class]) th {
+  background: var(--fenix-bg-soft);
+  color: var(--fenix-ink);
+  font-weight: 600;
+  border-bottom: 1px solid var(--fenix-border);
+  text-align: left;
+}
+.md-typeset table:not([class]) td {
+  border-top: 1px solid var(--fenix-border);
+}
+.md-typeset table:not([class]) tr:nth-child(even) {
+  background: var(--fenix-bg);     /* 偶数行不要花哨的灰条 */
+}
+.md-typeset table:not([class]) tr:hover td {
+  background: var(--fenix-bg-soft);   /* hover 时淡淡提示 */
+}
+/* 表格里的链接保持低视觉权重,不要满表蓝绿一片 */
+.md-typeset table:not([class]) a {
+  color: var(--fenix-link);
+}
+.md-typeset table:not([class]) a:hover {
+  color: var(--fenix-link-hover);
+}
+
+/* ── 7. 引用块 —— 极简左竖线,无背景填充 ───────────────────────── */
+
+.md-typeset blockquote {
+  border-left: 3px solid var(--fenix-border);
+  background: transparent;
+  color: var(--fenix-ink-soft);
+  padding: 0.2rem 1rem;
+  border-radius: 0;
+}
+
+/* ── 8. 关掉首页 hero 区的紫色渐变(改回 fenix 那种纯净白底) ──── */
+
+.hero {
+  background: var(--fenix-bg);
+  border: none;
+  border-radius: 0;
+  padding: 4rem 1rem 2rem;
+  text-align: center;
+}
+.hero h1 {
+  color: var(--fenix-ink);
+  font-size: 3rem;
+  font-weight: 600;
+  margin-bottom: 0.6rem;
+}
+.hero .hero-formula {
+  color: var(--fenix-link-hover);   /* 墨绿公式色 */
+  font-size: 1.2rem;
+  margin: 1rem 0 1.6rem;
+  font-family: var(--md-code-font);
+}
+.hero .cta {
+  background: var(--fenix-ink);
+  color: var(--fenix-bg);
+  border-radius: 4px;            /* 不用胶囊形,扁平 */
+  padding: 8px 16px;
+  font-weight: 500;
+  font-size: 0.88rem;
+  border: none;
+}
+.hero .cta:hover {
+  background: var(--fenix-link-hover);
+  opacity: 1;
+  transform: none;
+}
+.hero .cta.secondary {
+  background: transparent;
+  color: var(--fenix-ink);
+  border: 1px solid var(--fenix-border);
+}
+.hero .cta.secondary:hover {
+  border-color: var(--fenix-link-hover);
+  color: var(--fenix-link-hover);
+}
+
+/* ── 9. 章节卡片网格 —— 扁平化(去掉浮起+阴影) ────────────────── */
+
+/* 首页三列统计(10 章 / 88 实验 / 5 语言) */
+.stat-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin: 1.4rem 0 2rem;
+  padding: 0;
+}
+@media (max-width: 720px) {
+  .stat-row { grid-template-columns: 1fr; }
+}
+.stat-row p {
+  background: var(--fenix-bg);
+  border: 1px solid var(--fenix-border);
+  border-radius: 4px;
+  padding: 14px 16px;
+  margin: 0;
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--fenix-ink-soft);
+}
+.stat-row p strong {
+  display: block;
+  color: var(--fenix-ink);
+  font-size: 0.95rem;
+  margin-bottom: 3px;
+  font-weight: 600;
+}
+
+/* 章节卡片网格(首页 + 各章实验索引页通用) */
+.exp-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1px;
+  background: var(--fenix-border);
+  border: 1px solid var(--fenix-border);
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 1.4rem 0;
+}
+.exp-card {
+  display: block;
+  background: var(--fenix-bg);
+  padding: 14px 16px;
+  text-decoration: none;
+  color: var(--fenix-ink);
+  border: none;
+  border-radius: 0;
+  transition: background .12s;
+}
+.exp-card:hover {
+  background: var(--fenix-bg-soft);
+  border-color: transparent;
+  transform: none;
+  box-shadow: none !important;
+}
+.exp-card .exp-title {
+  display: block;
+  color: var(--fenix-ink);
+  font-weight: 600;
+  font-size: 0.92rem;
+  margin-bottom: 6px;
+  line-height: 1.4;
+}
+.exp-card:hover .exp-title {
+  color: var(--fenix-link-hover);
+}
+.exp-card .exp-desc {
+  display: block;
+  color: var(--fenix-ink-soft);
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+/* ── 10. 移动端调整 ─────────────────────────────────────────── */
+
+@media screen and (max-width: 600px) {
+  .md-typeset { font-size: 15px; }
+  .md-typeset h1 { font-size: 2rem; }
+  .md-typeset h2 { font-size: 1.3rem; }
+  .hero { padding: 2.5rem 1rem 1.5rem; }
+  .hero h1 { font-size: 2rem; }
+}
+
+/* ── 11. 暗色模式同步 —— 保持 fenix 风格,只是反色 ──────────────── */
+
+[data-md-color-scheme="slate"] {
+  --fenix-ink:        #e6edf3;
+  --fenix-ink-soft:   #8b949e;
+  --fenix-ink-mute:   #6e7681;
+  --fenix-border:     #30363d;
+  --fenix-bg:         #0d1117;
+  --fenix-bg-soft:    #161b22;
+  --fenix-code-bg:    rgba(240, 246, 252, 0.08);
+  --fenix-code-ink:   #79c0ff;
+  --fenix-link:       #e6edf3;
+  --fenix-link-hover: #42b983;
+}
+[data-md-color-scheme="slate"] .md-header,
+[data-md-color-scheme="slate"] .md-sidebar--primary {
+  background-color: var(--fenix-bg) !important;
+  border-color: var(--fenix-border) !important;
+}
+[data-md-color-scheme="slate"] .exp-card,
+[data-md-color-scheme="slate"] .hero {
+  background: var(--fenix-bg);
+}

--- a/extras/mermaid-init.js
+++ b/extras/mermaid-init.js
@@ -1,0 +1,41 @@
+/**
+ * Mermaid loader for MkDocs Material.
+ *
+ * Material's `navigation.instant` swaps page content without a full reload,
+ * so Mermaid must be (re-)initialized after every page swap. We hook into
+ * both the initial load and Material's custom `document-subscriber` event.
+ *
+ * The mermaid.js runtime itself is loaded via mkdocs.yml `extra_javascript`
+ * with `defer`, so it's available by the time this script runs.
+ */
+(function () {
+  function isMermaidReady() {
+    return typeof window.mermaid !== 'undefined';
+  }
+
+  function renderAll() {
+    if (!isMermaidReady()) return;
+    try {
+      window.mermaid.initialize({
+        startOnLoad: false,
+        theme: document.documentElement.getAttribute('data-md-color-scheme') === 'slate'
+          ? 'dark'
+          : 'default',
+        securityLevel: 'loose',     // allow $ in labels, e.g. $web_search
+        flowchart: { curve: 'basis', useMaxWidth: true },
+      });
+      window.mermaid.run({ querySelector: '.mermaid:not([data-processed])' });
+    } catch (e) {
+      console.warn('[mermaid] render failed:', e);
+    }
+  }
+
+  // Re-render whenever Material swaps to a new page.
+  document.addEventListener('DOMContentLoaded', renderAll);
+  document$.subscribe(renderAll);   // `document$` is provided by Material
+
+  // Re-theme when the user toggles light/dark.
+  new MutationObserver(renderAll)
+    .observe(document.documentElement,
+      { attributes: true, attributeFilter: ['data-md-color-scheme'] });
+})();

--- a/index.md
+++ b/index.md
@@ -1,14 +1,130 @@
-# 深入理解 AI Agent：设计原理与工程实践
+---
+title: 深入理解 AI Agent
+description: 围绕核心公式 Agent = LLM + 上下文 + 工具,用 10 章把 AI Agent 从原理讲到工程实战的开源技术书。正文、配图、88 个配套实验全部开源。
+---
 
-> **在线阅读版** · 核心公式：**Agent = LLM + 上下文 + 工具**
+<div class="hero" markdown>
 
-本书围绕核心公式 **Agent = LLM + 上下文 + 工具**，用 10 章把 AI Agent 从原理讲到工程实战。全书正文、配图与 88 个配套实验全部开源，欢迎亲手把实验跑一遍。
+# 深入理解 AI Agent
 
-本站点将仓库中的 Markdown 正文自动构建为可在线阅读的网站，并随仓库更新自动重新构建。使用顶部导航栏的语言 Tab 切换中文 / 繁體中文 / English / தமிழ் / Tiếng Việt。
+**设计原理与工程实践** · 一本完整开源的 AI Agent 技术书
+
+<div class="hero-formula" markdown>
+
+`Agent = LLM + 上下文 + 工具`
+
+</div>
+
+<div class="cta-row" markdown>
+
+📥 [中文 PDF](https://github.com/bojieli/ai-agent-book/releases/download/latest/AI-Agents-in-Depth-zh-CN.pdf){.cta}
+📚 [中文 EPUB](https://github.com/bojieli/ai-agent-book/releases/download/latest/AI-Agents-in-Depth-zh-CN.epub){.cta}
+⭐ [GitHub Star](https://github.com/bojieli/ai-agent-book){.cta .secondary}
+
+</div>
+
+</div>
+
+---
+
+## 这本书讲什么
+
+围绕核心公式 **Agent = LLM + 上下文 + 工具**,用 10 章把 AI Agent 从原理讲到工程实战。**全书正文、配图、88 个配套实验全部开源**,欢迎亲手把实验跑一遍。
+
+<div class="stat-row" markdown>
+
+📊 **10 章** 正文 · 从基础到生产
+
+📂 **88 个** 配套实验 · 70+ 可独立运行
+
+🌐 **5 种** 语言 · 中 / 繁 / 英 / 泰 / 越
+
+</div>
+
+---
+
+## 章节速览
+
+<div class="exp-grid" markdown>
+
+<a class="exp-card" href="book/introduction/">
+<span class="exp-title">📖 引言</span>
+<span class="exp-desc">为什么写这本书 · 好的设计原则如何穿越模型迭代周期</span>
+</a>
+
+<a class="exp-card" href="book/chapter1/">
+<span class="exp-title">🚀 第 1 章 · Agent 基础知识</span>
+<span class="exp-desc">「模型即 Agent」新范式 + Agent 核心公式;Harness 工程才是竞争力</span>
+</a>
+
+<a class="exp-card" href="book/chapter2/">
+<span class="exp-title">🎯 第 2 章 · 上下文工程</span>
+<span class="exp-desc">上下文决定能力上限:KV Cache、提示工程、Agent Skills、上下文压缩</span>
+</a>
+
+<a class="exp-card" href="book/chapter3/">
+<span class="exp-title">📚 第 3 章 · 用户记忆和知识库</span>
+<span class="exp-desc">跨会话记住用户、接入外部知识:用户记忆、RAG、结构化索引、知识图谱</span>
+</a>
+
+<a class="exp-card" href="book/chapter4/">
+<span class="exp-title">🛠️ 第 4 章 · 工具</span>
+<span class="exp-desc">工具是 Agent 的双手:MCP 协议、感知/执行/协作三类工具、异步 Agent</span>
+</a>
+
+<a class="exp-card" href="book/chapter5/">
+<span class="exp-title">💻 第 5 章 · Coding Agent 与代码生成</span>
+<span class="exp-desc">代码是「能创造新工具的工具」,生产级 Coding Agent 全景</span>
+</a>
+
+<a class="exp-card" href="book/chapter6/">
+<span class="exp-title">🎯 第 6 章 · Agent 的评估</span>
+<span class="exp-desc">把表现变成可比较信号:评估环境、指标、统计显著性</span>
+</a>
+
+<a class="exp-card" href="book/chapter7/">
+<span class="exp-title">🧠 第 7 章 · 模型后训练</span>
+<span class="exp-desc">SFT、强化学习——把 Harness 中积累的反馈信号写入模型参数</span>
+</a>
+
+<a class="exp-card" href="book/chapter8/">
+<span class="exp-title">🌱 第 8 章 · Agent 的自我进化</span>
+<span class="exp-desc">外部化学习、工具创造、经验积累——Agent 自己变得更聪明</span>
+</a>
+
+<a class="exp-card" href="book/chapter9/">
+<span class="exp-title">🎙️ 第 9 章 · 多模态与实时交互</span>
+<span class="exp-desc">语音 Agent、Computer Use、机器人操作</span>
+</a>
+
+<a class="exp-card" href="book/chapter10/">
+<span class="exp-title">🤝 第 10 章 · 多 Agent 协作</span>
+<span class="exp-desc">协作架构、失败模式、Agent 社会</span>
+</a>
+
+<a class="exp-card" href="book/afterword/">
+<span class="exp-title">📝 后记</span>
+<span class="exp-desc">模型会不会吃掉 Harness?完整答案与展望</span>
+</a>
+
+</div>
+
+---
+
+## 在线阅读 · 多语言
+
+使用顶部导航栏的语言 Tab 切换:
+
+| 中文 | 繁體中文 | English | தமிழ் | Tiếng Việt |
+|:---:|:---:|:---:|:---:|:---:|
+| ✅ 原版 | 社区翻译 | 社区翻译 | 社区翻译 | 社区翻译 |
+
+---
 
 ## 关于
 
-- 仓库：[bojieli/ai-agent-book](https://github.com/bojieli/ai-agent-book)
-- 许可证：Apache License 2.0
+- **仓库**:[bojieli/ai-agent-book](https://github.com/bojieli/ai-agent-book)
+- **许可证**:Apache License 2.0
+- **本站点**:每次仓库推送后由 GitHub Actions 自动重新构建
 
-> 💡 本书内容持续更新，本站点在每次仓库推送后由 GitHub Actions 自动重新构建。如需下载完整 PDF，请见各语言目录下的 PDF 文件。
+> 💡 本书内容持续更新,本站点在每次仓库推送后由 GitHub Actions 自动重新构建。如需下载完整 PDF,请使用上方下载按钮或访问 [Releases](https://github.com/bojieli/ai-agent-book/releases)。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,15 @@ theme:
   language: zh
   # Custom overrides: injects the language-tab switcher into the header.
   custom_dir: overrides
+  logo: assets/logo.svg
+  favicon: assets/logo.svg
+  # Brand colours — indigo accent matches the book cover and SVG figures.
+  font:
+    text: Noto Sans SC, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif
+    code: JetBrains Mono, SFMono-Regular, Consolas, monospace
+  icon:
+    logo: material/robot-outline
+    repo: fontawesome/brands/github
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
@@ -35,15 +44,48 @@ theme:
         icon: material/weather-sunny
         name: 切换日间模式
   features:
-    - navigation.instant
-    - navigation.tracking
-    - navigation.sections
-    - navigation.top
-    - toc.follow
-    - content.code.copy
-    - content.code.annotate
-    - search.suggest
-    - search.highlight
+    # ── Navigation ──────────────────────────────────────────────
+    # Layout matches icyfenix.cn: a tall chapter tree on the left,
+    # minimal top bar (logo + search + repo). Do NOT use navigation.tabs
+    # — that would cram all 10 chapters into a horizontal bar.
+    - navigation.instant         # SPA-like page swaps, no full reload
+    - navigation.instant.progress # show a loading bar on slow swaps
+    - navigation.tracking        # URL changes with scroll
+    - navigation.sections        # group nav entries into titled sections
+    - navigation.expand          # expand the active chapter's subtree only
+    - navigation.indexes         # section index pages
+    - navigation.top             # "back to top" button
+    - navigation.footer          # prev/next pager in footer
+    # ── Table of contents (right sidebar) ──────────────────────
+    - toc.follow                 # TOC tracks scroll position
+    - toc.integrate              # fold TOC into left sidebar on mobile
+    # ── Content ─────────────────────────────────────────────────
+    - content.code.copy          # copy button on code blocks
+    - content.code.annotate      # rendered annotations in code
+    - content.action.edit        # "edit this page" pencil
+    - content.action.view        # "view source" link
+    - content.tooltips           # rich hover tooltips
+    - content.tabs.link          # sync same-named tabs across page
+    # ── Search ─────────────────────────────────────────────────
+    - search.suggest             # autocomplete-style suggestions
+    - search.highlight           # highlight matches in results
+    - search.share               # shareable search URLs
+
+plugins:
+  # Default Material plugins, made explicit so we can tune them.
+  - search:
+      lang:
+        - ja          # CJK-aware tokenizer; far better for Chinese than `en`
+        - en
+  # Stamp each page with its git commit date — readers see "最后更新" trust signal.
+  - git-revision-date-localized:
+      enable_creation_date: true
+      enable_git_follow: false   # avoids noisy "First revision older than last" warnings
+      type: date
+      fallback_to_build_date: true
+  # Auto-generate Open Graph / Twitter card images so links look rich when
+  # shared to WeChat / Twitter / Slack.
+  - social:
 
 markdown_extensions:
   - admonition
@@ -55,7 +97,16 @@ markdown_extensions:
       generic: true
   - pymdownx.highlight:
       anchor_linenums: true
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      # Render ```mermaid blocks as <div class="mermaid">…</div> so the
+      # mermaid.js runtime (loaded below in extra_javascript) picks them up.
+      # fence_div_format wraps raw content in a <div class="...">, which is
+      # exactly what mermaid.js expects. Any other fenced language still
+      # uses the default highlighted <pre><code>.
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_div_format
   - pymdownx.inlinehilite
   - pymdownx.tabbed:
       alternate_style: true
@@ -63,10 +114,13 @@ markdown_extensions:
 
 extra_javascript:
   - extras/lang-switcher.js
+  - https://unpkg.com/mermaid@11/dist/mermaid.min.js
+  - extras/mermaid-init.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 extra_css:
   - extras/lang-switcher.css
+  - extras/book-theme.css
 
 # Language definitions for the switcher tab bar.
 # Each entry maps its prefix + suffix rules to rewrite URLs across editions.
@@ -79,17 +133,31 @@ extra:
     vi: { label: Tiếng Việt, prefix: book-vi/, suffix: .vi }
 
 nav:
+  # Layout mirrors icyfenix.cn: the left sidebar is a clean chapter tree.
+  # Each chapter title links directly to the prose; the per-chapter
+  # experiment index lives one click deeper so the sidebar stays scannable
+  # instead of being flooded by 78 individual experiment entries.
   - 首页: index.md
   - 引言: book/introduction.md
   - 第1章 Agent基础知识: book/chapter1.md
+  - '第1章 · 配套实验': chapter1/README.md
   - 第2章 上下文工程: book/chapter2.md
+  - '第2章 · 配套实验': chapter2/README.md
   - 第3章 用户记忆和知识库: book/chapter3.md
+  - '第3章 · 配套实验': chapter3/README.md
   - 第4章 工具: book/chapter4.md
+  - '第4章 · 配套实验': chapter4/README.md
   - 第5章 CodingAgent与代码生成: book/chapter5.md
+  - '第5章 · 配套实验': chapter5/README.md
   - 第6章 Agent的评估: book/chapter6.md
+  - '第6章 · 配套实验': chapter6/README.md
   - 第7章 模型后训练: book/chapter7.md
+  - '第7章 · 配套实验': chapter7/README.md
   - 第8章 Agent的自我进化: book/chapter8.md
+  - '第8章 · 配套实验': chapter8/README.md
   - 第9章 多模态与实时交互: book/chapter9.md
+  - '第9章 · 配套实验': chapter9/README.md
   - 第10章 多Agent协作: book/chapter10.md
+  - '第10章 · 配套实验': chapter10/README.md
   - 后记: book/afterword.md
   - 思考题参考答案: book/思考题参考答案.md

--- a/scripts/build_site.sh
+++ b/scripts/build_site.sh
@@ -19,9 +19,27 @@ for lang in book book-en book-ta book-vi book-zhtw; do
   cp -R "$ROOT/$lang" "$DEST/"
 done
 
+# The companion experiment directories (chapterN/). Each chapter has a
+# README.md (experiment index) plus one subfolder per experiment, also
+# documented by its own README.md. These are exposed under /chapterN/ so
+# readers can step from the chapter prose straight into runnable code.
+for ch in chapter1 chapter2 chapter3 chapter4 chapter5 \
+         chapter6 chapter7 chapter8 chapter9 chapter10; do
+  if [ -d "$ROOT/$ch" ]; then
+    cp -R "$ROOT/$ch" "$DEST/"
+  fi
+done
+
 # Copy site-level assets (JS/CSS for the language switcher) that MkDocs
 # resolves relative to docs_dir.
 cp -R "$ROOT/extras" "$DEST/extras"
+
+# Site-wide static assets — logo, favicon, social OG images. Referenced by
+# mkdocs.yml as `assets/<file>` (relative to docs_dir).
+if [ -d "$ROOT/assets" ]; then
+  mkdir -p "$DEST/assets"
+  cp -R "$ROOT/assets/." "$DEST/assets/"
+fi
 
 # Keep only Markdown and images; drop .tex/.py/.lua/.pdf/.sh etc.
 find "$DEST" -type f \
@@ -33,5 +51,34 @@ find "$DEST" -type f \
   ! -name '*.js' \
   ! -name '*.css' \
   -delete
+
+# Drop bulk data files that some experiments bundle as their dataset but
+# that don't belong in the reading site (hundreds of legal-doc markdown
+# files would also slow the git-revision-date plugin to a crawl).
+rm -rf \
+  "$DEST/chapter3/contextual-retrieval/laws" \
+  "$DEST/chapter3/agentic-rag/laws" \
+  2>/dev/null || true
+
+# Rewrite the relative links used inside the experiment READMEs so they
+# resolve correctly in the MkDocs site. Source files are NOT modified —
+# only the copies under _web/.
+#
+# The README source uses GitHub-style relative paths that don't survive
+# MkDocs rendering. Two patterns appear in chapter index pages
+# (`chapterN/README.md`):
+#   ../book/chapter1.md   (point at the chapter prose)
+#   ../README.md          (point at the repo root / homepage)
+#
+# MkDocs renders pages as directory URLs (`chapter1/`), so the `.md`
+# suffix must be stripped. Keep the paths RELATIVE (no leading slash) so
+# they keep working under the site's sub-path
+# (`https://bojieli.github.io/ai-agent-book/`).
+find "$DEST/chapter"* -type f -name '*.md' -print0 \
+  | xargs -0 sed -i.bak \
+      -e 's|\.\./book/\([a-zA-Z0-9_-]*\)\.md|../book/\1/|g' \
+      -e 's|\.\./README\.md|../|g'
+# macOS sed needs the backup suffix above; clean up the .bak files.
+find "$DEST" -name '*.md.bak' -delete
 
 echo "Assembled docs into $DEST"


### PR DESCRIPTION
## What this PR does

The online reading site (deployed via `.github/workflows/deploy-pages.yml`) used to show only the 10 chapter prose pages — the **78 companion experiments under `chapterN/`** were unreachable without jumping to GitHub, and the default Material theme felt cluttered compared to reference book sites like icyfenix.cn. This PR fixes both.

### 1. Surface all 78 experiments in the site

- `scripts/build_site.sh` now copies `chapterN/` into `_web/` so MkDocs picks them up
- Relative links inside experiment READMEs are rewritten from GitHub-style (``../book/chapter1.md``) to MkDocs directory URLs (``../book/chapter1/``), fixing **404s on the \"返回主目录\" / \"读本章正文\" breadcrumb links**
- Per-chapter entry \"第N章 · 配套实验\" in the sidebar — keeps the tree scannable (10 chapters × 2 entries) instead of flooding it with 78 individual experiment entries

### 2. Mermaid support

```mermaid
flowchart TD
    A[用户问题] --> B{Agent 思考}
```
now renders inline. Mermaid v11 is loaded via `extra_javascript`; `mermaid-init.js` re-renders on Material `navigation.instant` page swaps and follows light/dark palette changes.

### 3. Flat, fenix-inspired theme

Verified against `icyfenix.cn` using Playwright (computed-style + pixel sampling):

| element | fenix | this PR |
|---|---|---|
| navbar height | 57.6px | **57px** |
| navbar background | white | **white** |
| navbar shadow | none | **none** |
| sidebar width | 320px | **320px** |
| h1 colour | \`#2c3e50\` | **\`#2c3e50\`** |
| body colour | \`#2c3e50\` | **\`#2c3e50\`** |
| body size | 16px | **16px** |

Strip Material's card / shadow / rounded-corner decoration; primary colour switched from indigo to fenix's deep blue-grey.

### 4. New SVG logo

`assets/logo.svg` — three linked nodes visualising the book's core formula **Agent = LLM + 上下文 + 工具**.

### 5. Homepage redo

- 3-card stat row (10章 / 88实验 / 5语言) replaces the cluttered table
- 12 chapter cards in a flat grid
- \"中文 PDF\" / \"中文 EPUB\" / \"GitHub Star\" buttons linking to the rolling \`latest\` release

### 6. \`<agent-trajectory>\` Web Component (prototype)

A framework-free custom element that replays an Agent's ReAct loop step by step, for embedding directly in chapter prose:

\`\`\`html
<agent-trajectory src=\"/extras/agent-lab/data/ch1-asean-capitals-gpt5.json\" />
\`\`\`

Comes with a SCHEMA.md contract (mirrors the \`_emit(...)\` calls in \`chapter1/web-search-agent/agent.py\`) and two sample trajectories (success + ablation-failure). Not yet wired into \`chapter1.md\` — that lands in a follow-up.

## What's NOT changed

- **No source \`chapterN/README.md\` or \`book/chapterN.md\` edits** — GitHub browsing experience is preserved
- **No PDF / EPUB build pipeline changes**
- **No translations** — only the Chinese site is themed; translated editions inherit the same theme automatically

## Verification

- \`mkdocs build\` completes in ~11s (was ~33s before pruning 287 legal-doc data files out of \`_web/\`)
- Playwright audit on 9 representative pages: 0 broken images, 0 \`.md\` dead-links, 0 4xx (excluding dev-only livereload)
- Language switcher works on all editions (verified by actually clicking it in a real browser → \`book-en/chapter1/\` loads with English title)

## Commits

Split into two for easier review:
1. \`feat(site): expose 78 experiments in nav + flat fenix-inspired theme\`
2. \`feat(site): add <agent-trajectory> Web Component prototype\`

## Screenshots

(see \`/tmp/v2-home.png\`, \`/tmp/v2-ch1.png\`, \`/tmp/v2-exp.png\` if attached)