### PR TITLE
fix(ci): install git-revision-date plugin + silence MkDocs 2.0 banner (hotfix)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -17,6 +17,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # Silence the MkDocs 2.0 banner. We pin to mkdocs-material 9.x in
+      # requirements-docs.txt, so the upcoming breaking change doesn't
+      # affect us until we explicitly upgrade. The variable name is read
+      # by material/templates/__init__.py and stable across 9.x releases.
+      NO_MKDOCS_2_WARNING: "1"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,7 +31,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install MkDocs Material
-        run: pip install mkdocs-material
+        run: pip install -r requirements-docs.txt
       - name: Assemble docs
         run: bash scripts/build_site.sh
       - name: Build site

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,10 @@
+# Python dependencies for building the online reading site.
+# Used by .github/workflows/deploy-pages.yml. Pin to minor ranges so CI is
+# reproducible but still gets patch-level security fixes.
+#
+# Why pin: an upstream release of mkdocs-material or a plugin can silently
+# break the site build (it has happened — see PR #73). A pinned range lets
+# us upgrade deliberately rather than discovering the breakage in CI.
+
+mkdocs-material >= 9.5, < 10
+mkdocs-git-revision-date-localized-plugin >= 1.2, < 2


### PR DESCRIPTION
## 🚨 Hotfix — GitHub Pages deployment is broken on main

PR #73 added the \`git-revision-date-localized\` plugin to \`mkdocs.yml\` but didn't update CI to install it, so every \`deploy-pages\` run since the merge fails with:

\`\`\`
ERROR -  Config value 'plugins': The \"git-revision-date-localized\" plugin is not installed
Aborted with a configuration error.
\`\`\`

The live site at https://bojieli.github.io/ai-agent-book/ is therefore stale (last successful deploy was before #73 landed).

## Fix

Same as the follow-up commit I pushed to the #73 branch after it was merged (which didn't make it into the merge commit). Cherry-picked here as a standalone hotfix.

- **Add \`requirements-docs.txt\`** pinning \`mkdocs-material >= 9.5, < 10\` and \`mkdocs-git-revision-date-localized-plugin >= 1.2, < 2\`. Pinning prevents future upstream releases from silently breaking CI — which is exactly what happened here.
- **Change \`pip install mkdocs-material\` → \`pip install -r requirements-docs.txt\`** in \`deploy-pages.yml\` so all plugins get installed.
- **Silence the MkDocs 2.0 banner** via \`NO_MKDOCS_2_WARNING=1\`. The banner is pure noise — we pin to 9.x, so the upcoming breaking change doesn't affect us. Variable name confirmed by reading \`material/templates/__init__.py\`:

\`\`\`python
if is_mkdocs() and not os.getenv(\"NO_MKDOCS_2_WARNING\"):
    print(... banner ...)
\`\`\`

## Verified locally

\`\`\`
$ NO_MKDOCS_2_WARNING=1 mkdocs build -d /tmp/site-ci
INFO - Documentation built in 11.72 seconds
\`\`\`

No banner, no plugin errors, build succeeds.

## Recommendation

Merge ASAP — the live site is broken until this lands.