### PR TITLE
fix(agent-skills-ppt): contain run_skill_script to the skill's scripts dir

### DIFF
--- a/chapter2/agent-skills-ppt/demo.py
+++ b/chapter2/agent-skills-ppt/demo.py
@@ -135,7 +135,11 @@ def tool_run_skill_script(catalog: dict, name: str, script: str, payload: str,
     info = catalog.get(name)
     if not info:
         return f"[error] 未找到 Skill: {name}"
-    script_path = (info["dir"] / "scripts" / script).resolve()
+    scripts_dir = (info["dir"] / "scripts").resolve()
+    script_path = (scripts_dir / script).resolve()
+    # 防目录穿越：脚本会被直接执行，必须落在该 skill 的 scripts 目录内
+    if not script_path.is_relative_to(scripts_dir):
+        return f"[error] 非法脚本路径: {script}"
     if not script_path.exists():
         return f"[error] 脚本不存在: {script}"
 

--- a/chapter2/agent-skills-ppt/test_dispatch.py
+++ b/chapter2/agent-skills-ppt/test_dispatch.py
@@ -8,6 +8,7 @@ incomplete LLM tool call crashed the whole run with KeyError. Fixed to
 return "[error] ..." strings that the agent can recover from.
 """
 
+import os
 from pathlib import Path
 
 from demo import dispatch, scan_skill_catalog
@@ -42,3 +43,24 @@ def test_valid_read_skill_still_works():
     result = dispatch(catalog, "read_skill", {"name": "pptx"}, OUT)
     assert not result.startswith("[error]")
     assert len(result) > 0
+
+
+def test_run_skill_script_rejects_absolute_path(tmp_path):
+    """run_skill_script executes the file, so it must stay inside scripts/."""
+    outside = tmp_path / "evil.py"
+    outside.write_text("raise AssertionError('executed out-of-tree script')")
+    catalog = scan_skill_catalog()
+    result = dispatch(catalog, "run_skill_script",
+                      {"name": "pptx", "script": str(outside), "payload": "{}"}, OUT)
+    assert result.startswith("[error]")
+
+
+def test_run_skill_script_rejects_parent_traversal(tmp_path):
+    outside = tmp_path / "evil.py"
+    outside.write_text("raise AssertionError('executed out-of-tree script')")
+    catalog = scan_skill_catalog()
+    scripts_dir = (catalog["pptx"]["dir"] / "scripts").resolve()
+    rel = os.path.relpath(outside, scripts_dir)
+    result = dispatch(catalog, "run_skill_script",
+                      {"name": "pptx", "script": rel, "payload": "{}"}, OUT)
+    assert result.startswith("[error]")


### PR DESCRIPTION
Fixes #75.

`script` is a model-supplied tool argument and the file is executed via `exec_module`, but no containment check was applied — an absolute path or `../` traversal escapes the skill directory and runs arbitrary code in the host process. `read_skill_file` right above already guards this way.

Adds the same check before the `exists()` test, plus two regression tests. Both new tests fail on `main` with `AssertionError: executed out-of-tree script`; all 6 pass with the fix.