### PR TITLE
fix(elo-leaderboard): map 'tie (bothbad)' instead of producing NaN ratings

### DIFF
--- a/chapter6/elo-leaderboard/optimized_elo.py
+++ b/chapter6/elo-leaderboard/optimized_elo.py
@@ -151,8 +151,12 @@ class NumpyEloRatingSystem:
         
         # Convert outcomes to numeric (1.0 for A wins, 0.0 for B wins, 0.5 for tie)
         print("Converting outcomes to numeric...")
-        outcome_map = {'model_a': 1.0, 'model_b': 0.0, 'tie': 0.5}
-        outcomes = df['winner'].map(outcome_map).values.astype(np.float64)
+        # 'tie (bothbad)' is a real Arena outcome; unmapped values become NaN and
+        # would silently poison every rating they touch, so fall back to a tie
+        # (same as EloRatingSystem.update_ratings).
+        outcome_map = {'model_a': 1.0, 'model_b': 0.0,
+                       'tie': 0.5, 'tie (bothbad)': 0.5}
+        outcomes = df['winner'].map(outcome_map).fillna(0.5).values.astype(np.float64)
         
         return model_a_indices, model_b_indices, outcomes
     

--- a/chapter6/elo-leaderboard/test_tie_bothbad.py
+++ b/chapter6/elo-leaderboard/test_tie_bothbad.py
@@ -1,0 +1,49 @@
+"""
+Regression test for 'tie (bothbad)' handling in optimized_elo (实验 6-6 排行榜).
+
+Chatbot Arena battle data has four outcomes; 'tie (bothbad)' was missing from
+the outcome map, so Series.map produced NaN. NaN then propagated through the
+rating updates and spread to every model that later faced an affected one,
+leaving the whole leaderboard NaN.
+"""
+import numpy as np
+import pandas as pd
+
+from optimized_elo import NumpyEloRatingSystem
+
+
+def test_tie_bothbad_does_not_produce_nan_outcomes():
+    """'tie (bothbad)' maps to a tie instead of NaN."""
+    df = pd.DataFrame({
+        "model_a": ["a", "a"],
+        "model_b": ["b", "b"],
+        "winner": ["model_a", "tie (bothbad)"],
+    })
+    _, _, outcomes = NumpyEloRatingSystem()._prepare_data(df)
+    assert not np.isnan(outcomes).any()
+    assert outcomes[1] == 0.5
+
+
+def test_tie_bothbad_does_not_poison_the_leaderboard():
+    """One 'tie (bothbad)' battle used to NaN every rating, including model c."""
+    df = pd.DataFrame({
+        "model_a": ["a", "a", "b"],
+        "model_b": ["b", "b", "c"],
+        "winner": ["model_a", "tie (bothbad)", "model_a"],
+    })
+    system = NumpyEloRatingSystem()
+    system.process_matches_vectorized(df, show_progress=False)
+    ratings = [rating for _, rating, _, _ in system.get_leaderboard()]
+    assert len(ratings) == 3
+    assert not any(np.isnan(r) for r in ratings)
+
+
+def test_unknown_outcome_falls_back_to_tie():
+    """An unrecognized label degrades to a tie rather than NaN."""
+    df = pd.DataFrame({
+        "model_a": ["a"],
+        "model_b": ["b"],
+        "winner": ["something_new"],
+    })
+    _, _, outcomes = NumpyEloRatingSystem()._prepare_data(df)
+    assert outcomes[0] == 0.5


### PR DESCRIPTION
Fixes #77.

Arena battle data has four outcomes, but the outcome map in `_prepare_data` only covered three. `Series.map` returned NaN for `tie (bothbad)`, which propagated through the rating updates and spread to every model that later faced an affected one — on real data that leaves essentially the whole leaderboard NaN, silently.

Maps it to a tie and falls back to 0.5 for any unrecognized label, matching `EloRatingSystem.update_ratings`. Adds a regression test; all 3 cases fail on `main`, and the existing suite still passes (15 total).