### PR TITLE
fix(chapter10): pass one namespace to exec in execute_python (comprehensions/functions raised NameError)

### DIFF
--- a/chapter10/multi-role-transfer/tools.py
+++ b/chapter10/multi-role-transfer/tools.py
@@ -110,7 +110,10 @@ def execute_python(code: str) -> str:
     buf = io.StringIO()
     try:
         with contextlib.redirect_stdout(buf):
-            exec(code, safe_globals, {})  # noqa: S102 —— 受限命名空间下的教学示例
+            # 只传一个命名空间：globals 与 locals 若是两个不同的 dict，顶层代码会变成
+            # 「类体」语义——函数体/推导式看不到顶层赋值的变量，正常代码会报 NameError。
+            # 沙箱限制来自 safe_globals["__builtins__"]，不受影响。
+            exec(code, safe_globals)  # noqa: S102 —— 受限命名空间下的教学示例
     except Exception as exc:  # noqa: BLE001
         return f"代码执行出错：{type(exc).__name__}: {exc}\n已捕获输出：\n{buf.getvalue()}"
     out = buf.getvalue().strip()


### PR DESCRIPTION
Fixes #85

### Problem

`chapter10/multi-role-transfer/tools.py:113` called `exec` with two *different* namespaces:

```python
exec(code, safe_globals, {})
```

That gives top-level code class-body semantics — assignments land in the throw-away locals dict, but nested scopes (function bodies, comprehensions, generator expressions) resolve free names against `safe_globals` only. So any snippet that assigns a name at top level and then reads it inside a `def` or a comprehension raised `NameError`.

Since `execute_python` is the `coding` role's only tool (`roles.py:79`), the model was told its own valid Python was broken and retried variants against `max_steps`.

### Change

Pass a single namespace: `exec(code, safe_globals)`.

`chapter1/context/agent.py:276` in this repo already does it this way.

### The sandbox is unchanged

The restriction comes entirely from `safe_globals["__builtins__"]`, which the third argument never affected.

### Verification

Ran the real `execute_python` from `chapter10/multi-role-transfer/` after the change:

```
comprehension  : [1.0, 1.956, 2.697]
function       : 0.3708
straight-line  : 0.6422
still sandboxed: 代码执行出错：ImportError: __import__ not found
```

The first two cases failed with `NameError` before this patch; the third was already fine; the fourth confirms `import os` is still blocked.
