### PR TITLE
fix(chapter5): keep newlines when NotebookEdit writes cell source (split('\n') corrupted every multi-line cell)

### DIFF
--- a/chapter5/coding-agent/tools/notebook_edit_tool.py
+++ b/chapter5/coding-agent/tools/notebook_edit_tool.py
@@ -48,7 +48,9 @@ class NotebookEditTool(BaseTool):
                 new_cell = {
                     "cell_type": cell_type,
                     "metadata": {},
-                    "source": new_source.split('\n')
+                    # nbformat stores source as a list of lines that KEEP their
+                    # trailing '\n'; readers rebuild the cell with ''.join(source).
+                    "source": new_source.splitlines(keepends=True)
                 }
                 
                 if cell_type == "code":
@@ -91,7 +93,7 @@ class NotebookEditTool(BaseTool):
                 if cell_id:
                     for cell in cells:
                         if cell.get('id') == cell_id:
-                            cell["source"] = new_source.split('\n')
+                            cell["source"] = new_source.splitlines(keepends=True)
                             if cell_type:
                                 cell["cell_type"] = cell_type
                             break


### PR DESCRIPTION
Fixes #86

### Problem

`notebook_edit_tool.py` wrote cell source with `new_source.split('\n')` on both the insert path (`:51`) and the replace path (`:94`). `split` **discards** the separators, but nbformat's multi-line-string convention is a list of lines that **keep** their trailing `\n`, because readers rebuild the cell with `''.join(source)` — including this repo's own `tools/read_tool.py:152`.

```python
>>> ''.join("def hello():\n    print('world')\n    return True".split('\n'))
"def hello():    print('world')    return True"
```

So a `NotebookEdit` of any multi-line cell reported success and left the cell as one mangled line that no longer parses. Re-reading with the repo's `Read` tool showed the corrupted single line, so the agent could not even see what it broke.

### Change

`splitlines(keepends=True)` at both sites.

### Verification

Round-trip through the real `NotebookEditTool` (this is the property that actually matters — write then read must equal the original, not merely "the mangling is gone"):

```
stored list           : ['def hello():\n', "    print('world')\n", '    return True']
round-trip == original: True | len==3: True
insert round-trip     : True
empty source          : []
```

`""` still yields `[]`, a valid empty cell.

Existing tests:

```
$ python -m pytest tests/test_notebook_edit_tool.py -q
12 passed in 0.24s
```

Note `test_multiline_source` only asserts `len(cell["source"]) == 3`, so it passed both before and after — it never checked the joined content. The round-trip assertion above is what distinguishes the two.
