### PR TITLE
ci: fix Chinese figure fonts in CI-built PDFs (PingFang on-demand download)

### DIFF
--- a/.github/scripts/download_apple_fonts.swift
+++ b/.github/scripts/download_apple_fonts.swift
@@ -1,0 +1,70 @@
+// Download Apple's on-demand fonts so CI-built PDFs match local builds.
+//
+// Since macOS Sequoia, PingFang (and other CJK fonts) are no longer preinstalled
+// in /System/Library/Fonts; they live in on-demand asset bundles that a fresh
+// GitHub runner has never downloaded. Without this step, rsvg-convert falls back
+// to Hiragino Sans (a Japanese font) for Chinese text in SVG figures.
+//
+// Usage: swift download_apple_fonts.swift "PingFang SC" "PingFang TC"
+// Exits non-zero if any requested family is still unavailable afterwards.
+
+import CoreText
+import Foundation
+
+let families = Array(CommandLine.arguments.dropFirst())
+guard !families.isEmpty else {
+    fputs("usage: download_apple_fonts.swift <family name>...\n", stderr)
+    exit(2)
+}
+
+func isAvailable(_ family: String) -> Bool {
+    let attrs = [kCTFontFamilyNameAttribute: family] as CFDictionary
+    let desc = CTFontDescriptorCreateWithAttributes(attrs)
+    // CoreText falls back to a default font when the family is missing, so
+    // confirm the resolved font really has the requested family name.
+    let font = CTFontCreateWithFontDescriptor(desc, 12, nil)
+    return CTFontCopyFamilyName(font) as String == family
+}
+
+var failed = false
+for family in families {
+    if isAvailable(family) {
+        print("\(family): already available")
+        continue
+    }
+    print("\(family): not available, requesting download...")
+    let attrs = [kCTFontFamilyNameAttribute: family] as CFDictionary
+    let desc = CTFontDescriptorCreateWithAttributes(attrs)
+    let sema = DispatchSemaphore(value: 0)
+    var lastError: CFError?
+    CTFontDescriptorMatchFontDescriptorsWithProgressHandler([desc] as CFArray, nil) { state, progress in
+        switch state {
+        case .didFailWithError:
+            let params = progress as NSDictionary
+            lastError = (params[kCTFontDescriptorMatchingError] as! CFError)
+            sema.signal()
+        case .didFinish:
+            sema.signal()
+        default:
+            break
+        }
+        return true
+    }
+    if sema.wait(timeout: .now() + 300) == .timedOut {
+        print("\(family): download timed out")
+        failed = true
+        continue
+    }
+    if let err = lastError {
+        print("\(family): download failed: \(err)")
+        failed = true
+        continue
+    }
+    if isAvailable(family) {
+        print("\(family): downloaded successfully")
+    } else {
+        print("\(family): still unavailable after download attempt")
+        failed = true
+    }
+}
+exit(failed ? 1 : 0)

--- a/.github/scripts/download_apple_fonts.swift
+++ b/.github/scripts/download_apple_fonts.swift
@@ -23,7 +23,15 @@ func isAvailable(_ family: String) -> Bool {
     // CoreText falls back to a default font when the family is missing, so
     // confirm the resolved font really has the requested family name.
     let font = CTFontCreateWithFontDescriptor(desc, 12, nil)
-    return CTFontCopyFamilyName(font) as String == family
+    guard CTFontCopyFamilyName(font) as String == family else { return false }
+    // CoreText registers on-demand fonts (dimmed in Font Book) before they are
+    // downloaded; the family name then matches but there is no font file yet,
+    // and renderers quietly substitute another font. Require a real file.
+    guard let url = CTFontCopyAttribute(font, kCTFontURLAttribute) as? URL else {
+        print("\(family): registered but no font file on disk")
+        return false
+    }
+    return FileManager.default.fileExists(atPath: url.path)
 }
 
 var failed = false

--- a/.github/scripts/verify_pdf_fonts.py
+++ b/.github/scripts/verify_pdf_fonts.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Verify that Chinese PDFs embed PingFang in SVG-derived figures.
+
+Guards against the macOS-runner regression where PingFang (an on-demand font
+since macOS Sequoia) is missing and rsvg-convert silently falls back to
+Hiragino Sans, rendering Chinese figure text with Japanese glyph variants.
+
+Usage: verify_pdf_fonts.py <pdf> [<pdf> ...]
+"""
+
+import re
+import sys
+import zlib
+from collections import Counter
+
+# A handful of Hiragino streams appear even in correct local builds (glyphs
+# PingFang lacks); a full fallback produces dozens.
+HIRAGINO_LIMIT = 10
+
+
+def scan(path):
+    data = open(path, "rb").read()
+    hits = Counter()
+    for m in re.finditer(rb"stream\r?\n", data):
+        start = m.end()
+        end = data.find(b"endstream", start)
+        if end < 0:
+            continue
+        try:
+            decoded = zlib.decompress(data[start:end])
+        except zlib.error:
+            continue
+        for name in (b"PingFang", b"Hiragino", b"Songti", b"Heiti", b"Noto"):
+            if name in decoded:
+                hits[name.decode()] += 1
+    return hits
+
+
+def main():
+    failed = False
+    for path in sys.argv[1:]:
+        hits = scan(path)
+        print(f"{path}: {dict(hits)}")
+        if hits["PingFang"] == 0:
+            print(f"  ERROR: no PingFang embedded -- figure font fallback occurred")
+            failed = True
+        if hits["Hiragino"] > HIRAGINO_LIMIT:
+            print(f"  ERROR: {hits['Hiragino']} Hiragino streams (limit {HIRAGINO_LIMIT})"
+                  " -- Japanese fallback font used for Chinese figure text")
+            failed = True
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -39,12 +39,24 @@ jobs:
           brew install --cask mactex-no-gui font-dejavu font-noto-sans-cjk-sc font-noto-sans-cjk-tc font-noto-serif-tamil
           echo "/Library/TeX/texbin" >> "$GITHUB_PATH"
 
+      # PingFang is an on-demand font since macOS Sequoia and is absent on fresh
+      # runners; without it rsvg-convert renders Chinese figure text in Hiragino
+      # Sans (Japanese glyph variants). Fetch it so CI output matches local builds.
+      - name: Download on-demand Apple fonts
+        run: swift .github/scripts/download_apple_fonts.swift "PingFang SC" "PingFang TC"
+
       - name: Build PDFs
         run: |
           set -e
           for dir in book book-zhtw book-en book-vi book-ta; do
             (cd "$dir" && bash build_pdf.sh)
           done
+
+      - name: Verify Chinese figure fonts
+        run: |
+          python3 .github/scripts/verify_pdf_fonts.py \
+            "book/深入理解-AI-Agent-李博杰-v1.2.pdf" \
+            "book-zhtw/深入理解-AI-Agent-李博杰-v1.2-zhtw.pdf"
 
       - name: Build EPUBs
         run: ./build_epub.sh all


### PR DESCRIPTION
CI-built zh-CN/zh-TW PDFs rendered all Chinese text inside SVG figures in Hiragino Sans (Japanese glyph variants) instead of PingFang SC. Since macOS Sequoia, PingFang is an on-demand font that fresh GitHub runners have never downloaded, so rsvg-convert silently substitutes Hiragino. Body text (Songti SC / Heiti SC via XeLaTeX) was unaffected.

- Add `download_apple_fonts.swift`: fetches on-demand Apple fonts via CoreText before the build, treating registered-but-not-downloaded fonts (no file on disk) as unavailable.
- Add `verify_pdf_fonts.py` + workflow step: fails the build if the Chinese PDFs don't embed PingFang or embed an excessive number of Hiragino streams, so this can't silently regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URxVbFzU57ZEzx3GuWP5M6