### PR TITLE
fix(chapter6): use np.nan instead of np.NAN, which NumPy 2.0 removed (main.py crashed at step 4)

### DIFF
--- a/chapter6/elo-leaderboard/bradley_terry.py
+++ b/chapter6/elo-leaderboard/bradley_terry.py
@@ -140,7 +140,9 @@ def predict_win_rate(elo_ratings: Dict[str, float],
             wins[b][a] = 1 - ea
     
     data = {
-        a: [wins[a][b] if a != b else np.NAN for b in names]
+        # np.nan, not np.NAN: the upper-case aliases were removed in NumPy 2.0
+        # and requirements.txt allows numpy>=1.24 (i.e. 2.x).
+        a: [wins[a][b] if a != b else np.nan for b in names]
         for a in names
     }
     


### PR DESCRIPTION
Fixes #87

### Problem

`bradley_terry.py:143` used `np.NAN`. The upper-case aliases (`np.NAN`, `np.NaN`, `np.Inf`) were **removed in NumPy 2.0**, and `chapter6/elo-leaderboard/requirements.txt:2` is `numpy>=1.24.0` with no upper bound — so a fresh `pip install -r requirements.txt` today installs NumPy 2.x and the line raises.

`predict_win_rate` is called unconditionally from `main.py:165` ("Step 4: Calculating predicted win rates"), i.e. **after** loading the Arena dataset and running 100 bootstrap Bradley-Terry fits. All of that work was discarded and none of `leaderboard.png` / `rating_distribution.png` / `win_rate_matrix.png` was produced.

### Change

`np.NAN` → `np.nan`. On NumPy 1.x `np.NAN is np.nan`, so this is behaviour-identical there and simply restores NumPy 2 compatibility.

### Verification

Before, on the same interpreter:

```
$ python -c "import numpy as np; np.NAN"
AttributeError: module 'numpy' has no attribute 'NAN'
```

After, running the real function on numpy 2.0.2:

```
numpy 2.0.2
model_a         a         b         c
model_b
a             NaN  0.759747  0.640065
b        0.240253       NaN  0.359935
c        0.359935  0.640065       NaN
diagonal all NaN: True
```

Off-diagonals are correct complements and the diagonal is NaN, as intended.

`python cli.py pipeline` never calls this function and is unaffected either way.
