### PR TITLE
fix(chapter3): treat GraphRAG chunk_overlap as a word budget (window never advanced: 241 chunks instead of 6)

### DIFF
--- a/chapter3/structured-index/graphrag_indexer.py
+++ b/chapter3/structured-index/graphrag_indexer.py
@@ -89,10 +89,20 @@ class GraphRAGIndexer:
             if current_size + len(words) > self.config.chunk_size:
                 if current_chunk:
                     chunks.append(" ".join(current_chunk))
-                # Start new chunk with overlap
-                overlap_size = min(self.config.chunk_overlap, len(current_chunk))
-                current_chunk = current_chunk[-overlap_size:] if overlap_size > 0 else []
-                current_size = sum(len(s.split()) for s in current_chunk)
+                # Start new chunk with overlap. chunk_overlap is a WORD budget
+                # (the same unit as chunk_size, which current_size is measured
+                # in); len(current_chunk) is a SENTENCE count, so using it here
+                # kept the whole previous chunk and the window never advanced.
+                overlap: List[str] = []
+                overlap_size = 0
+                for prev in reversed(current_chunk):
+                    prev_size = len(prev.split())
+                    if overlap_size + prev_size > self.config.chunk_overlap:
+                        break
+                    overlap.insert(0, prev)
+                    overlap_size += prev_size
+                current_chunk = overlap
+                current_size = overlap_size
             
             current_chunk.append(sentence)
             current_size += len(words)


### PR DESCRIPTION
Fixes #88

### Problem

`GraphRAGIndexer.chunk_text` computed the carry-over overlap as a **sentence** count:

```python
overlap_size = min(self.config.chunk_overlap, len(current_chunk))
current_chunk = current_chunk[-overlap_size:] if overlap_size > 0 else []
current_size = sum(len(s.split()) for s in current_chunk)
```

but `chunk_overlap` is a **word** budget — the same unit as `chunk_size`, which `current_size` (a running word count) is compared against on the line directly above, and the same way `RaptorIndexer.chunk_text` uses the pair.

A 1200-word chunk holds roughly 60 sentences, so `min(100, 60) == 60` retained the **entire** chunk as "overlap". `current_size` was restored to ~1200 and the very next sentence overflowed again, so from then on one nearly-identical chunk was emitted per sentence — the sliding window never advanced.

### Change

Accumulate trailing sentences until the word budget is reached. Forward progress is guaranteed whenever `chunk_overlap < chunk_size` (100 < 1200), and a single oversized sentence still terminates — the loop breaks immediately, leaving an empty overlap.

### Verification

Same harness, run against the file before and after, on a 6 000-word document (300 sentences × 20 words) with the shipped defaults:

**Before**

```
chunks: 241 | chunk sizes: [1200, 1220, 1240, ... 2020, 2020, 2020]
overlap words per boundary: [1200, 1220, 1240, ... 2000, 2000, 2000]
total words emitted: 469,600   (78.3x the document)
```

The overlap is literally the whole preceding chunk, and the chunks grow without bound until they saturate.

**After**

```
chunks: 6 | chunk sizes: [1200, 1200, 1200, 1200, 1200, 500]
overlap words per boundary: [100, 100, 100, 100, 100]
total words emitted: 6,500     (1.08x the document)
```

Additional properties checked after the change:

- all 300 sentences covered, **in order**, none dropped
- overlap non-zero at every boundary and never above the 100-word budget
- mixed sentence lengths (a 150-word sentence interleaved with 1-word ones): 2 chunks, 1.06x duplication, terminates
- oversized single sentence (5 000 words): terminates, 2 chunks
- empty document and single short sentence: unchanged

### Why it matters

`build_knowledge_graph` makes one LLM entity-extraction call **per chunk** (`graphrag_indexer.py:173`), so this was ~40x the intended LLM calls and wall-clock time for a build, over massively duplicated near-identical chunks — every entity re-extracted ~100 times, and `attributes["chunk_id"]` effectively meaningless.
