### PR TITLE
fix(chapter2): stop compress_for_history shadowing its content parameter (error fallback discarded the tool result)

### DIFF
--- a/chapter2/context-compression/compression_strategies.py
+++ b/chapter2/context-compression/compression_strategies.py
@@ -188,9 +188,13 @@ Provide a focused summary:"""
                 summary_parts = []
                 for chunk in stream:
                     if chunk.choices and chunk.choices[0].delta.content:
-                        content = chunk.choices[0].delta.content
-                        print(content, end="", flush=True)
-                        summary_parts.append(content)
+                        # NB: do not name this `content` — that shadows the
+                        # `content` parameter (the original tool output) and
+                        # breaks the truncation fallback below when the stream
+                        # fails part-way through.
+                        delta_text = chunk.choices[0].delta.content
+                        print(delta_text, end="", flush=True)
+                        summary_parts.append(delta_text)
                 print("\n")  # New lines after streaming
                 compressed = "".join(summary_parts)
             else:


### PR DESCRIPTION
Fixes #90

### Problem

In `ContextCompressor.compress_for_history`, the streaming loop rebound the method's own `content` **parameter** to each delta:

```python
for chunk in stream:
    if chunk.choices and chunk.choices[0].delta.content:
        content = chunk.choices[0].delta.content   # shadows the parameter
```

so by the time the `except` ran, `content` was the last chunk the model emitted — not the tool output the fallback is meant to preserve:

```python
truncated = content[:2000] + "\n\n[Content truncated for history...]"
```

On a mid-stream failure (dropped connection, read timeout, rate limit, malformed chunk) the tool message in the agent's history was silently replaced by a fragment of a half-written summary.

Because `original_length` is captured before the `try`, it stayed correct — so the banner in `agent.py:310-314` still read `[Original: 6,500 chars → Compressed: 52 chars]` and the loss looked like *successful* compression.

Reachable in the default configuration: `run_all_strategies.py:124` runs `WINDOWED_CONTEXT` with `enable_streaming=True`, and `agent.py:301` is the only caller.

### Change

Rename the loop variable to `delta_text`. Single hunk, no behaviour change on the happy path.

### Verification

Drove the **real** `ContextCompressor` with a stubbed client whose stream yields two content chunks and then raises, on a 6 500-character tool output.

**Before**

```
original_length   : 6500
compressed_length : 52
content starts    : 'Summary part 2. \n\n[Content truncated for history...]'
fallback preserved the tool output: False
```

**After**

```
original_length   : 6500
compressed_length : 2036
content starts    : 'OpenAI co-founders: Sam Altman (CEO), Greg Brockman (President). OpenAI co-found'
fallback preserved the tool output: True
fallback is the documented 2000-char truncation: True
```

Happy path, both before and after:

```
happy path content: 'Altman and Brockman founded OpenAI.' | assembled from all chunks: True
```

### Scope

`compress_for_history` is the only method in this file where `content` is a parameter — the other four (`_no_compression`, `_non_context_aware_individual_summary`, `_non_context_aware_combined_summary`, `_context_aware_summary`, `_context_aware_with_citations`) take `search_results` and fall back to that, so their local `content` binding is harmless and is left alone.
