### PR TITLE
ci: relax figure-font verify threshold

### DIFF
--- a/.github/scripts/verify_pdf_fonts.py
+++ b/.github/scripts/verify_pdf_fonts.py
@@ -13,9 +13,10 @@ import sys
 import zlib
 from collections import Counter
 
-# A handful of Hiragino streams appear even in correct local builds (glyphs
-# PingFang lacks); a full fallback produces dozens.
-HIRAGINO_LIMIT = 10
+# A handful of Hiragino streams appear even in correct builds (rare glyphs
+# PingFang lacks; the fontconfig cascade on CI falls back slightly more often
+# than local CoreText: ~12 streams vs ~4). A wholesale fallback produces 50+.
+HIRAGINO_LIMIT = 20
 
 
 def scan(path):


### PR DESCRIPTION
Run 29886372906 confirmed PingFang now embeds correctly (286/260 streams) with 12/11 residual Hiragino streams for rare glyphs PingFang lacks — the fontconfig cascade falls back slightly more often than local CoreText (4 streams). Raise the limit to 20; wholesale fallback (the bug this guards against) produces 50+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URxVbFzU57ZEzx3GuWP5M6