### PR TITLE
fix(chapter1): stop reseeding the global RNG every episode (400 resets gave only 55 distinct exploration streams)

### DIFF
--- a/chapter1/learning-from-experience/game_environment.py
+++ b/chapter1/learning-from-experience/game_environment.py
@@ -53,9 +53,12 @@ class TreasureHuntGame:
             seed: Random seed for reproducibility
             stochastic: If True, adds random elements to the game
         """
-        if seed is not None:
-            random.seed(seed)
-        
+        # NOTE: do not call random.seed() here. reset() re-runs __init__ once per
+        # episode with a fresh 14-bit seed, and the learning agents draw their
+        # exploration from the *global* random module -- reseeding it would pin
+        # that stream to one of only 10001 states per episode and make whole
+        # episodes repeat verbatim. The env's own randomness is self-contained
+        # in self.random_state below, which is still seeded from `seed`.
         self.stochastic = stochastic
         self.random_state = random.Random(seed) if stochastic else None
         


### PR DESCRIPTION
Fixes #103

### Problem

`__init__` called the **global** `random.seed(seed)`, and `reset()` re-runs `__init__` once per episode with a freshly drawn 14-bit seed:

```python
471:    def reset(self, seed: int = None) -> str:
473:        if seed is None:
474:            seed = random.randint(0, 10000)
475:        self.__init__(seed=seed, stochastic=self.stochastic)
```

The learning agents draw their exploration from that same global module (`rl_agent.py:79-81,94`), so every episode pinned the process-wide RNG to one of only 10 001 states — and both the episode's exploration and the *next* episode's seed became a deterministic function of that 14-bit value.

### Change

Remove the two `random.seed()` lines. The environment's own randomness already lives in its private generator on the next line, `self.random_state = random.Random(seed)`, which still receives `seed`.

### Verification

400 `reset()` calls, sampling 30 exploration draws per episode:

```
before: resets: 400 | distinct exploration streams: 55
        first exact repeat: episode 25 == 55 -> cycle period 30
after : resets: 400 | distinct exploration streams: 400
```

Nothing else changes:

```
env random_state still seeded & reproducible: True
constructing the game no longer disturbs the global RNG: True
```

```
$ python test_basic.py
ALL TESTS PASSED! ✅
```

### Note on reproducibility

This is about **entropy**, not determinism — `experiment.py --seed` reproduces a run either way, because `reset()` still draws its per-episode seed from the global stream. What changes is that the stream is no longer collapsed to a 14-bit state at every episode boundary.
