### PR TITLE
fix(chapter2): don't report valid UTF-8 files as binary when a character straddles the 1024-byte sniff boundary

### DIFF
--- a/chapter2/system-hint/agent.py
+++ b/chapter2/system-hint/agent.py
@@ -4,6 +4,7 @@ An agent that demonstrates advanced trajectory management with system hints,
 including timestamps, tool call tracking, TODO lists, and detailed error messages.
 """
 
+import codecs
 import json
 import os
 import sys
@@ -572,9 +573,12 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                             "file_path": file_path,
                             "is_binary": True
                         }
-                    # Also check if it's valid UTF-8
+                    # Also check if it's valid UTF-8. Decode incrementally with
+                    # final=False so a multi-byte character split by the
+                    # 1024-byte read boundary is not mistaken for binary content
+                    # (every CJK character is 3 bytes, so this is common).
                     try:
-                        chunk.decode('utf-8')
+                        codecs.getincrementaldecoder('utf-8')().decode(chunk, False)
                     except UnicodeDecodeError:
                         return {
                             "success": False,


### PR DESCRIPTION
Fixes #104

### Problem

The binary sniff in `_tool_read_file` strict-decoded a hard-cut 1024-byte prefix:

```python
566:                    chunk = f.read(1024)
...
577:                        chunk.decode('utf-8')
```

If byte 1024 lands inside a multi-byte character, `decode` raises `unexpected end of data` and a perfectly valid UTF-8 file is returned to the model as `is_binary: true`. Every CJK character is 3 bytes, so in this repo that is the ordinary case.

**12 of the 277** valid UTF-8 text files under `chapter2/` were affected — including `chapter2/README.md` and `chapter2/system-hint/README.md`, while the agent's own system prompt (`:167`) instructs it to *"systematically read key files (README, main.py, agent.py)"*.

### Change

Decode the prefix incrementally with `final=False`, which tolerates a character split by the read boundary while still raising on genuinely invalid bytes. Adds `import codecs`.

### Verification

Against the real `_tool_read_file`:

```
  chapter2/README.md                                   success=True is_binary=None
  chapter2/system-hint/README.md                       success=True is_binary=None
  chapter2/log-sanitization/regex_sanitizer.py         success=True is_binary=None
  chapter2/prompt-engineering/run_ablation.py          success=True is_binary=None
  valid UTF-8 text files still misreported as binary: 0     (was 12)
```

The negative cases still behave — this does not weaken the check:

```
  real binary still rejected: True            (bytes 0..255 repeated)
  invalid-UTF8 (no NUL) still rejected: True  (b'hello \xff\xfe world' repeated)
```

The null-byte check above it is untouched.
