### PR TITLE
fix(chapter3): handle the 0-d score array when reranking a single candidate (HTTP 500 on the shipped E-2001 demo query)

### DIFF
--- a/chapter3/retrieval-pipeline/reranker.py
+++ b/chapter3/retrieval-pipeline/reranker.py
@@ -178,10 +178,11 @@ class Reranker:
             if not isinstance(scores, np.ndarray):
                 scores = np.array(scores)
             
-            # Ensure scores is 1D
-            if len(scores.shape) > 1:
-                scores = scores.squeeze()
-                
+            # Ensure scores is 1D. FlagReranker.compute_score returns a bare
+            # float when exactly one pair is scored, which becomes a 0-d array
+            # here — atleast_1d keeps the single-candidate case iterable.
+            scores = np.atleast_1d(np.asarray(scores).squeeze())
+
         except Exception as e:
             logger.error(f"Reranking failed: {e}")
             return []


### PR DESCRIPTION
Fixes #106

### Problem

The shape normalisation only handled the "too many dimensions" case:

```python
181:            # Ensure scores is 1D
182:            if len(scores.shape) > 1:
183:                scores = scores.squeeze()
```

`FlagEmbedding==1.2.10` — the version pinned in `requirements.txt:12` — returns a **bare float** when exactly one pair is scored (`flag_reranker.py:221-222`: `if len(all_scores) == 1: return all_scores[0]`).

`np.array(4.375)` is a 0-d array, so `len(scores.shape)` is `0`, not `> 1`; no squeeze happened, and

```python
191:        for i, score in enumerate(scores):
```

raised `TypeError: iteration over a 0-d array`. That loop sits **after** the `except` block (which ends at `:187`), so the existing handler never caught it and `POST /search` returned HTTP 500.

Reachable from the project's own demo: `test_client.py:447` sends `"E-2001"` against a 5-document corpus where only `api_error` contains that token — exactly one candidate — and `skip_reranking` defaults to `False` (`main.py:78`).

### Change

```python
scores = np.atleast_1d(np.asarray(scores).squeeze())
```

### Verification

Every shape `compute_score` can return, through the patched lines:

```
  bare float (1 pair, FlagEmbedding 1.2.10)  shape=(1,)  iterates=1  values=[4.375]
  list of 1                                  shape=(1,)  iterates=1  values=[4.375]
  list of 3                                  shape=(3,)  iterates=3  values=[1.0, 2.0, 3.0]
  column (3,1)                               shape=(3,)  iterates=3  values=[1.0, 2.0, 3.0]
  (1,1)                                      shape=(1,)  iterates=1  values=[4.375]
```

The multi-candidate behaviour is unchanged — `(3,)` and `(3,1)` produce exactly what they did before.
