### PR TITLE
fix(chapter3): rebuild ANNOY into a fresh index (second POST /index returned 500: You can't build a built index)

### DIFF
--- a/chapter3/dense-embedding/indexing.py
+++ b/chapter3/dense-embedding/indexing.py
@@ -85,10 +85,11 @@ class AnnoyIndex(VectorIndex):
             del self.index_to_id[old_index]
             del self.vectors_cache[old_index]
         
-        # Add to index
+        # Cache the vector only. ANNOY refuses new items once build() has run,
+        # so the underlying index is (re)created from vectors_cache in
+        # rebuild_index() instead of being mutated in place here.
         current_index = self.next_index
-        self.index.add_item(current_index, vector.tolist())
-        
+
         # Update mappings
         self.id_to_index[doc_id] = current_index
         self.index_to_id[current_index] = doc_id
@@ -209,16 +210,23 @@ class AnnoyIndex(VectorIndex):
     
     def rebuild_index(self) -> None:
         """Build/rebuild the ANNOY index."""
-        if self.is_built and self.logger:
-            self.logger.logger.debug("Index already built, skipping rebuild")
+        if self.is_built:
+            if self.logger:
+                self.logger.logger.debug("Index already built, skipping rebuild")
             return
-        
+
         start_time = time.time()
-        
+
         if self.logger:
             self.logger.logger.info(f"🏗️  Building ANNOY index with {self.n_trees} trees")
-        
-        self.index.build(self.n_trees)
+
+        # ANNOY can neither accept items after a build nor be built twice, so
+        # always construct a fresh index from the cached vectors.
+        new_index = annoy.AnnoyIndex(self.dimension, self.metric)
+        for internal_index, vector in self.vectors_cache.items():
+            new_index.add_item(internal_index, vector.tolist())
+        new_index.build(self.n_trees)
+        self.index = new_index
         self.is_built = True
         
         if self.logger:


### PR DESCRIPTION
Fixes #105

### Problem

`AnnoyIndex.add_item` pushed vectors into an index that had already been built, and `rebuild_index` then called `build()` on it a second time:

```python
90:        self.index.add_item(current_index, vector.tolist())
...
221:        self.index.build(self.n_trees)
```

ANNOY accepts neither. Replaying the server's `/index` sequence (`main.py:213` add, `main.py:221-222` rebuild):

```
  POST /index #1: OK docs=1
  POST /index #2: FAILED -> Exception: You can't build a built index
  POST /index #3: FAILED -> Exception: You can't build a built index
```

With `--index-type annoy` the second and every later `POST /index` returned HTTP 500 (`main.py:231-233`), so the backend was effectively limited to a single document. `cli.py:302-306` only escaped this because it adds **all** vectors first and rebuilds exactly once.

### Change

- `add_item` now only records the vector in `vectors_cache` and updates the mappings; it no longer mutates `self.index`.
- `rebuild_index` constructs a fresh `annoy.AnnoyIndex` from `vectors_cache` and swaps it in.

This is the same approach `_rebuild_without_deleted` already uses in this class (`:101-123`), so it matches the file's existing idiom.

Separately, the "already built, skipping rebuild" early return was gated on `and self.logger`, so a **logger-less** index that was already built fell through and hit the double-build as well. That check now short-circuits on `is_built` and only the logging is conditional.

### Verification

```
  200 sequential add+rebuild cycles: OK, size 200        (crashed at #2 before)
  delete doc5: True -> size 199
  deleted doc gone from top-20 of its own vector: True
  logger-less instance no longer double-builds: True
```

Behaviour equivalence — the same script run against the **pre-fix** and **post-fix** file, using the one ordering the pre-fix code supported (`cli.py`'s add-all-then-build-once), 50 queries against a 200 x 16 index:

```
original vs fixed, cli.py add-all-then-build-once pattern:
  IDENTICAL search results on 50 queries
```

`delete_item` and in-place update (`add_item` with an existing `doc_id`) keep `id_to_index` / `index_to_id` / `vectors_cache` consistent, and repeated `rebuild_index()` is a no-op.
