### PR TITLE
fix(chapter4): drain subprocess pipes concurrently with wait() (>256 KB of output deadlocked and was reported as a bogus TIMEOUT)

### DIFF
--- a/chapter4/execution-tools/multilang_executor.py
+++ b/chapter4/execution-tools/multilang_executor.py
@@ -171,16 +171,23 @@ class LanguageExecutor:
                     logger.warning(f"Failed to write stdin: {e}")
             
             start_time = time.time()
-            
+
+            # Drain both pipes concurrently with the wait. Reading only *after*
+            # process.wait() deadlocks as soon as the child fills the OS pipe
+            # buffer (~256 KB here): the child blocks in write(), so it never
+            # exits and wait() never returns, turning a fast program with large
+            # stdout into a bogus TIMEOUT.
+            stdout_task = asyncio.ensure_future(get_all_output(process.stdout))
+            stderr_task = asyncio.ensure_future(get_all_output(process.stderr))
+
             try:
                 # Wait for process with timeout
                 await asyncio.wait_for(process.wait(), timeout=timeout)
                 execution_time = time.time() - start_time
-                
-                # Read output non-blocking
-                stdout = await get_all_output(process.stdout)
-                stderr = await get_all_output(process.stderr)
-                
+
+                stdout = await stdout_task
+                stderr = await stderr_task
+
                 logger.debug(f'Command completed in {execution_time:.2f}s')
                 
                 return {
@@ -199,8 +206,8 @@ class LanguageExecutor:
                     kill_process_tree(process.pid)
                     logger.info(f'Process {process.pid} killed due to timeout')
 
-                stdout = await get_all_output(process.stdout)
-                stderr = await get_all_output(process.stderr)
+                stdout = await stdout_task
+                stderr = await stderr_task
                 
                 return {
                     "status": ExecutionStatus.TIMEOUT,


### PR DESCRIPTION
Fixes #100

### Problem

`_run_command` awaited the process exit **before** reading either pipe:

```python
177:                await asyncio.wait_for(process.wait(), timeout=timeout)
...
181:                stdout = await get_all_output(process.stdout)
182:                stderr = await get_all_output(process.stderr)
```

and `get_all_output` is documented (line 27) as *"Call after the process has exited or been killed."*

Nothing drains the `StreamReader` while the child runs, so once roughly 256 KB accumulates the reader pauses its transport, the OS pipe buffer fills, the child blocks in `write()`, and `process.wait()` never returns — the classic `Process.wait()` + `PIPE` deadlock.

```
before:  10000 -> SUCCESS 0.02s
        300000 -> TIMEOUT 5.02s, stdout truncated at 262144 bytes
```

262144 is exactly 256 KB (2 x 64 KB reader limit + 64 KB pipe buffer).

### Change

Start both reads as tasks *before* the wait, and await them on the success path and the timeout path alike.

### Verification

Against the real `LanguageExecutor`, `timeout=5.0`:

```
  10 KB stdout     status=SUCCESS  rc=0 stdout=   10001 stderr=      0 t=0.02s
  300 KB stdout    status=SUCCESS  rc=0 stdout=  300001 stderr=      0 t=0.02s
  5 MB stdout      status=SUCCESS  rc=0 stdout= 5000001 stderr=      0 t=0.02s
  large stderr     status=SUCCESS  rc=0 stdout=       0 stderr= 400000 t=0.02s
  nonzero exit     status=FAILED   rc=3 stdout=       4 stderr=      0 t=0.02s
  real timeout     status=TIMEOUT  stdout=  350001 t=2.03s err=Execution timed out after 2.0 seconds
```

The last row is the important control: a program that genuinely hangs is **still** reported as `TIMEOUT` — and the partial output it produced before hanging is now preserved rather than lost.

### Side effect worth noting

`execution_tools.py:18` sets `MAX_OUTPUT_CHARS = 10000` and `:153-159` implements a truncate-persist-and-LLM-summarize path for larger outputs. That path could previously never receive more than 256 KB, and in practice never ran at all because such calls were reported as timeouts. It now works as designed.
