### PR TITLE
fix(chapter4): restore timers on the serving loop (restored timers were cancelled and erased from disk)

### DIFF
--- a/chapter4/collaboration-tools/src/main.py
+++ b/chapter4/collaboration-tools/src/main.py
@@ -535,6 +535,22 @@ async def mcp_get_subagent_status(
 # SERVER LIFECYCLE
 # ============================================================================
 
+async def _serve() -> None:
+    """Restore saved timers and serve requests on the SAME event loop.
+
+    `asyncio.run(_load_timers())` used to run in a throwaway loop: closing it
+    cancelled every `_run_timer` task that had just been restored, and the
+    CancelledError handler then marked those timers "cancelled" and re-saved,
+    which drops them from storage. Restored timers therefore never fired and
+    were lost from memory *and* disk.
+
+    `FastMCP.run(transport="stdio")` is itself just `anyio.run(run_stdio_async)`,
+    so awaiting `run_stdio_async()` here is the same server entry point.
+    """
+    await _load_timers()
+    await mcp.run_stdio_async()
+
+
 # Run the server
 if __name__ == "__main__":
     logger.info("Starting Collaboration Tools MCP Server...")
@@ -543,12 +559,9 @@ if __name__ == "__main__":
     config = load_config()
     logger.info(f"Configuration loaded: log_level={config.log_level}")
     
-    # Load saved timers
-    asyncio.run(_load_timers())
-    
     try:
-        # Run the MCP server
-        mcp.run(transport="stdio")
+        # Restore saved timers, then run the MCP server (one shared loop)
+        asyncio.run(_serve())
     finally:
         # Cleanup on exit
         logger.info("Shutting down Collaboration Tools MCP Server...")


### PR DESCRIPTION
Fixes #101

### Problem

`_load_timers` (`timer_tools.py:416`) re-arms each saved timer with `asyncio.create_task(_run_timer(...))`. It was called as:

```python
547:    asyncio.run(_load_timers())
...
551:        mcp.run(transport="stdio")
```

`asyncio.run` cancels every pending task and closes its loop as soon as `_load_timers` returns. `_run_timer`'s cancellation handler (`timer_tools.py:103-108`) then marks the timer `"cancelled"` and calls `_save_timers()`, which persists only `active`/`expired` entries (`:382-385`) — so the timer is dropped from memory **and erased from disk**. `mcp.run()` then starts a brand-new loop with nothing scheduled.

The logs said so in consecutive lines:

```
Restored timer abc-123 with 59.999555s remaining
Timer abc-123 was cancelled
```

### Change

Restore the timers and serve on the same loop:

```python
async def _serve() -> None:
    await _load_timers()
    await mcp.run_stdio_async()

...
    asyncio.run(_serve())
```

`FastMCP.run(transport="stdio")` is itself just `anyio.run(self.run_stdio_async)`, so this is the same server entry point — confirmed against the installed `mcp` SDK, where `run_stdio_async` is a coroutine function.

### Verification

One active timer seeded on disk.

**Before**

```
BEFORE on disk: ['abc-123']
    Restored timer abc-123 with 59.999555s remaining
    Timer abc-123 was cancelled
AFTER  in-memory status: cancelled
AFTER  on disk: {}
```

**After** (3-second timer, serving loop held open 5 seconds in place of `run_stdio_async`)

```
BEFORE on disk: ['abc-123']
    Restored timer abc-123 with 2.999268s remaining
    Timer abc-123 expired: nightly
    Timer callback: wake up
AFTER  in-memory status: expired
AFTER  on disk: {'abc-123': {..., 'status': 'expired', 'completed_at': '...'}}
```

The timer now actually fires, runs its callback, and remains recorded.
