### PR TITLE
fix(chapter4): guard json.loads on tool-call arguments (malformed args left conversation_history permanently invalid)

### DIFF
--- a/chapter4/agent-with-event-trigger/agent.py
+++ b/chapter4/agent-with-event-trigger/agent.py
@@ -1117,8 +1117,27 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                     
                     for tool_call in message.tool_calls:
                         function_name = tool_call.function.name
-                        function_args = json.loads(tool_call.function.arguments)
-                        
+                        raw_args = tool_call.function.arguments or "{}"
+                        try:
+                            function_args = json.loads(raw_args)
+                        except json.JSONDecodeError as exc:
+                            # Malformed/truncated arguments must not abort the
+                            # turn: the assistant message with tool_calls is
+                            # already in the history, so bailing out here would
+                            # leave this tool_call_id unanswered and every later
+                            # request would be rejected by the provider.
+                            err = (f"Invalid tool arguments (not valid JSON): {exc}. "
+                                   f"Raw arguments: {raw_args[:500]}")
+                            logger.warning(f"  ❌ {err}")
+                            self.tool_calls.append(ToolCall(
+                                tool_name=function_name, arguments={}, error=err))
+                            self.conversation_history.append({
+                                "role": "tool",
+                                "tool_call_id": tool_call.id,
+                                "content": json.dumps({"error": err})
+                            })
+                            continue
+
                         if self.config.enable_tool_counter:
                             self.tool_call_counts[function_name] = self.tool_call_counts.get(function_name, 0) + 1
                             call_number = self.tool_call_counts[function_name]


### PR DESCRIPTION
Fixes #102

### Problem

The assistant message carrying `tool_calls` is appended to history at `:1116`, and the arguments were parsed unguarded on the next line:

```python
1116:                    self.conversation_history.append(message.model_dump())
1118:                    for tool_call in message.tool_calls:
1119:                        function_name = tool_call.function.name
1120:                        function_args = json.loads(tool_call.function.arguments)
```

If a provider returns `arguments=""`, or JSON truncated by `max_tokens` (`server.py:155` sets `max_tokens=4096`), `json.loads` raises, the blanket `except Exception` at `:1202` returns an error, and **no** `role="tool"` messages are appended.

That leaves a `tool_call_id` unanswered, violating the protocol invariant that every `tool_call` in an assistant message is answered by a matching `tool` message. `server.py:45` holds one process-global `agent` reused by every `POST /event` (`:299`), so one malformed argument string poisoned the history for the life of the process — every later request rejected with HTTP 400 until someone called `POST /agent/reset`. The handler at `:1202` only logs and returns; it never repairs the history.

### Change

- `arguments or "{}"` — `""` is the legitimate *no-argument* case, so the tool still runs.
- On `json.JSONDecodeError`: record the failure in `self.tool_calls`, append an error `role="tool"` message for that `tool_call_id`, and `continue` with the remaining tool calls.

The history therefore stays valid, and the model sees the error and can correct itself.

`chapter4/async-agent/runtime.py:300-303` in this same chapter already does exactly this.

### Verification

Driving the real `EventTriggeredAgent` with a stub client.

**Before** (`arguments=""`):

```
success=False error=Expecting value: line 1 column 1 (char 0)
roles=['system', 'user', 'assistant']        <- no tool message
```

**After**, for three argument strings:

```
  arguments = "" (empty)
    success=True error=None
    roles=['system', 'user', 'assistant', 'tool', 'assistant']
    every tool_call_id answered: True

  arguments truncated by max_tokens        ('{"query": "ana')
    success=True error=None
    roles=['system', 'user', 'assistant', 'tool', 'assistant']
    every tool_call_id answered: True

  arguments valid (control)                ('{"a": 1}')
    success=True error=None
    roles=['system', 'user', 'assistant', 'tool', 'assistant']
    every tool_call_id answered: True
```

The control case confirms normal tool calls are unaffected, and in each case the agent recovers and reaches a final answer on the next iteration instead of dying.
