### PR TITLE
fix(elo): return a final time slice when date_range is empty

### DIFF
--- a/chapter6/elo-leaderboard/data_loader.py
+++ b/chapter6/elo-leaderboard/data_loader.py
@@ -193,6 +193,10 @@ def get_time_slices(df: pd.DataFrame, interval: str = 'W') -> list:
     """
     if 'tstamp' not in df.columns:
         raise ValueError("DataFrame must have 'tstamp' column")
+
+    if len(df) == 0:
+        print(f"Created 0 time slices with interval '{interval}'")
+        return []
     
     df['datetime'] = pd.to_datetime(df['tstamp'], unit='s')
     min_date = df['datetime'].min()
@@ -207,8 +211,8 @@ def get_time_slices(df: pd.DataFrame, interval: str = 'W') -> list:
         if len(slice_df) > 0:
             slices.append((end_date, slice_df))
     
-    # Add final slice with all data
-    if date_ranges[-1] < max_date:
+    # Empty date_ranges when span < interval; also cover trailing gap to max_date.
+    if len(date_ranges) == 0 or date_ranges[-1] < max_date:
         slices.append((max_date, df.copy()))
     
     print(f"Created {len(slices)} time slices with interval '{interval}'")

--- a/chapter6/elo-leaderboard/test_time_slices_short_span.py
+++ b/chapter6/elo-leaderboard/test_time_slices_short_span.py
@@ -1,0 +1,51 @@
+"""
+Regression: get_time_slices must not IndexError when the tstamp span is
+shorter than the requested interval (default weekly).
+
+Chatbot Arena samples, same-second dumps, and single-row demos all produce an
+empty pd.date_range for freq='W'; the old code then crashed on date_ranges[-1].
+"""
+import pandas as pd
+
+from data_loader import get_time_slices
+
+
+def test_identical_timestamps_return_one_slice():
+    """Two battles at the same unix second (weekly interval) -> one slice."""
+    ts = 1_700_000_000
+    df = pd.DataFrame({
+        "tstamp": [ts, ts],
+        "model_a": ["a", "c"],
+        "model_b": ["b", "d"],
+        "winner": ["model_a", "model_b"],
+    })
+    slices = get_time_slices(df, interval="W")
+    assert len(slices) == 1
+    end_date, slice_df = slices[0]
+    assert len(slice_df) == 2
+    assert end_date == pd.to_datetime(ts, unit="s")
+
+
+def test_empty_dataframe_returns_empty_list():
+    """Empty input returns [] instead of NaT ValueError."""
+    df = pd.DataFrame({"tstamp": pd.Series(dtype="float64")})
+    assert get_time_slices(df, interval="W") == []
+
+
+def test_multi_week_span_still_produces_buckets():
+    """A span covering multiple weeks still yields intermediate buckets."""
+    # ~3 weeks apart
+    df = pd.DataFrame({
+        "tstamp": [1_700_000_000, 1_700_000_000 + 21 * 86400],
+        "model_a": ["a", "c"],
+        "model_b": ["b", "d"],
+        "winner": ["model_a", "model_b"],
+    })
+    slices = get_time_slices(df, interval="W")
+    assert len(slices) >= 2
+    assert all(len(s[1]) > 0 for s in slices)
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
get_time_slices crashed with IndexError when all rows shared one timestamp (or the span was shorter than the weekly interval): pd.date_range returned no buckets and the code still indexed date_ranges[-1].

Repro: two rows with the same tstamp, then get_time_slices(df, interval="W").

Empty frames now return []; short spans return one full-data slice. Test covers identical timestamps, empty input, and a multi-week span.