### PR TITLE
fix(excel): honor max_rows for all-sheets reads

### DIFF
--- a/chapter4/collaboration-tools/src/excel_tools.py
+++ b/chapter4/collaboration-tools/src/excel_tools.py
@@ -60,7 +60,7 @@ async def read_excel_data(
             sheets = excel_file.sheet_names
             for sheet in sheets:
                 df = pd.read_excel(path, sheet_name=sheet, nrows=max_rows)
-                data[sheet] = df.head(100).to_dict(orient="records")
+                data[sheet] = df.to_dict(orient="records")
         
         return {
             "success": True,

--- a/chapter4/collaboration-tools/src/test_excel_max_rows_all_sheets.py
+++ b/chapter4/collaboration-tools/src/test_excel_max_rows_all_sheets.py
@@ -1,0 +1,47 @@
+"""Regression: all-sheets read must honor max_rows (not a hard 100-row cap)."""
+import asyncio
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from openpyxl import Workbook
+
+from excel_tools import read_excel_data
+
+
+def _workbook(path: Path, n_rows: int) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Data"
+    ws.append(["id", "val"])
+    for i in range(n_rows):
+        ws.append([i, f"r{i}"])
+    wb.save(path)
+
+
+@pytest.mark.asyncio
+async def test_all_sheets_honors_max_rows(tmp_path: Path):
+    path = tmp_path / "wide.xlsx"
+    _workbook(path, 150)
+
+    all_sheets = await read_excel_data(str(path), sheet_name=None, max_rows=1000)
+    named = await read_excel_data(str(path), sheet_name="Data", max_rows=1000)
+
+    assert all_sheets["success"] is True
+    assert named["success"] is True
+    assert len(named["data"]["Data"]) == 150
+    assert len(all_sheets["data"]["Data"]) == 150
+
+
+@pytest.mark.asyncio
+async def test_all_sheets_still_respects_smaller_max_rows(tmp_path: Path):
+    path = tmp_path / "wide.xlsx"
+    _workbook(path, 150)
+
+    result = await read_excel_data(str(path), sheet_name=None, max_rows=40)
+    assert result["success"] is True
+    assert len(result["data"]["Data"]) == 40
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
read_excel_data with sheet_name=None applied df.head(100) after nrows=max_rows, so rows beyond 100 were dropped even when max_rows allowed them. Named-sheet reads already returned the full window.

Repro: workbook with 150 rows, read_excel_data(path, sheet_name=None, max_rows=1000) returned 100 rows while sheet_name="Data" returned 150.

All-sheets now returns the same nrows window as a named sheet.