### PR TITLE
fix(sanitize): redact URL passwords that contain : or /

### DIFF
--- a/chapter2/log-sanitization/regex_sanitizer.py
+++ b/chapter2/log-sanitization/regex_sanitizer.py
@@ -74,7 +74,7 @@ _RULES = [
     (
         # 连接串中的口令，如 postgres://user:PASSWORD@host:5432/db
         "url_credential", "[REDACTED_URL_CRED]",
-        re.compile(r"://[^\s:/@]+:([^\s:/@]+)@"),
+        re.compile(r"://[^\s:/@]+:([^\s@]+)@"),
         1, None,
     ),
     (

--- a/chapter2/log-sanitization/test_url_credential_colon_slash.py
+++ b/chapter2/log-sanitization/test_url_credential_colon_slash.py
@@ -1,0 +1,23 @@
+"""Regression: URL passwords containing ':' or '/' must be fully redacted."""
+from regex_sanitizer import sanitize
+
+
+def test_password_with_slash_redacted():
+    text, hits = sanitize("DATABASE_URL=postgres://alice:a/b@db.example:5432/app")
+    assert "a/b" not in text
+    assert "[REDACTED_URL_CRED]" in text
+    assert any(h["category"] == "url_credential" for h in hits)
+
+
+def test_password_with_colon_redacted():
+    text, hits = sanitize("redis://default:foo:bar@10.0.0.1:6379/0")
+    assert "foo:bar" not in text
+    assert "[REDACTED_URL_CRED]" in text
+    assert any(h["category"] == "url_credential" for h in hits)
+
+
+def test_simple_password_still_redacted():
+    text, hits = sanitize("postgres://alice:secret@db.example:5432/app")
+    assert "secret" not in text
+    assert "[REDACTED_URL_CRED]" in text
+    assert any(h["category"] == "url_credential" for h in hits)


### PR DESCRIPTION
The url_credential regex stopped the password capture at : and /, so connection strings like postgres://user:a/b@host or redis://default:foo:bar@host left password fragments in the clear.

Repro: sanitize("postgres://alice:a/b@db.example:5432/app") left "a/" visible.

Passwords may now include : and / up to the @ host separator.