### PR TITLE
fix(evaluate): tolerate None pred_label in progress prints

### DIFF
--- a/chapter8/prompt-distillation/evaluate.py
+++ b/chapter8/prompt-distillation/evaluate.py
@@ -42,6 +42,11 @@ def load_model(model_path: str, base_model: str = "Qwen/Qwen3-30B-A3B-Instruct-2
     return model, tokenizer
 
 
+def format_pred_label(pred_label: Optional[str]) -> str:
+    """Display token for progress lines when the model reply is unparseable."""
+    return pred_label or "??"
+
+
 def parse_language_label(response: str) -> Optional[str]:
     """Extract the language label from model response."""
     # Try to match common patterns
@@ -134,14 +139,14 @@ def evaluate_model(
             display_sentence = sentence if len(sentence) <= 60 else sentence[:57] + "..."
             
             print(f"{status_color} [{idx+1:4d}/{len(test_sentences)}] "
-                  f"Pred: {pred_label:>2s} | GT: {gt_label:>2s} | "
+                  f"Pred: {format_pred_label(pred_label):>2s} | GT: {gt_label:>2s} | "
                   f"Acc: {correct}/{total} ({correct/total*100:5.1f}%) | "
                   f"{display_sentence}")
         else:
             # No ground truth - just show prediction
             display_sentence = sentence if len(sentence) <= 60 else sentence[:57] + "..."
             print(f"  [{idx+1:4d}/{len(test_sentences)}] "
-                  f"Pred: {pred_label:>2s} | "
+                  f"Pred: {format_pred_label(pred_label):>2s} | "
                   f"{display_sentence}")
     
     print("="*80)

--- a/chapter8/prompt-distillation/test_evaluate_none_pred_label.py
+++ b/chapter8/prompt-distillation/test_evaluate_none_pred_label.py
@@ -1,0 +1,38 @@
+"""Regression: unparseable model output (pred_label None) must not crash progress prints."""
+import sys
+import types
+
+import pytest
+
+
+def _stub_evaluate_deps() -> None:
+    for name in ["torch", "numpy", "transformers", "peft", "tqdm"]:
+        sys.modules.setdefault(name, types.ModuleType(name))
+    sys.modules["transformers"].AutoTokenizer = object
+    sys.modules["transformers"].AutoModelForCausalLM = object
+    sys.modules["peft"].PeftModel = object
+    sys.modules["tqdm"].tqdm = lambda x, **k: x
+
+
+_stub_evaluate_deps()
+
+from evaluate import format_pred_label, parse_language_label  # noqa: E402
+
+
+def test_parse_language_label_returns_none_for_prose():
+    assert parse_language_label("I believe this is English.") is None
+
+
+def test_format_pred_label_none_is_displayable():
+    pred_label = parse_language_label("I believe this is English.")
+    assert pred_label is None
+    token = format_pred_label(pred_label)
+    assert token == "??"
+    assert f"Pred: {token:>2s}" == "Pred: ??"
+    with pytest.raises(TypeError):
+        f"{pred_label:>2s}"
+
+
+def test_format_pred_label_keeps_real_codes():
+    assert format_pred_label("en") == "en"
+    assert f"{format_pred_label('fr'):>2s}" == "fr"


### PR DESCRIPTION
Unparseable student replies make parse_language_label return None, and the progress line formatted pred_label with :>2s, which TypeError mid-eval.

Repro: parse_language_label("I believe this is English.") is None; formatting that value with :>2s raises.

Missing labels now display as "??" so evaluation continues.