### PR TITLE
fix(raptor): keep chunk step at least 1 when overlap equals size

### DIFF
--- a/chapter3/structured-index/raptor_indexer.py
+++ b/chapter3/structured-index/raptor_indexer.py
@@ -60,8 +60,9 @@ class RaptorIndexer:
         """Split text into chunks with overlap."""
         words = text.split()
         chunks = []
+        step = max(1, self.config.chunk_size - self.config.chunk_overlap)
         
-        for i in range(0, len(words), self.config.chunk_size - self.config.chunk_overlap):
+        for i in range(0, len(words), step):
             chunk = " ".join(words[i:i + self.config.chunk_size])
             if chunk:
                 chunks.append(chunk)

--- a/chapter3/structured-index/test_raptor_chunk_step.py
+++ b/chapter3/structured-index/test_raptor_chunk_step.py
@@ -1,0 +1,64 @@
+"""Regression: equal chunk_size/overlap must not crash range() with step 0."""
+import sys
+import types
+from dataclasses import dataclass
+
+
+def _stub_raptor_deps() -> None:
+    mods = [
+        "tiktoken",
+        "tqdm",
+        "umap",
+        "openai",
+        "sentence_transformers",
+        "loguru",
+        "sklearn",
+        "sklearn.mixture",
+        "sklearn.metrics",
+        "sklearn.metrics.pairwise",
+        "config",
+    ]
+    for name in mods:
+        sys.modules.setdefault(name, types.ModuleType(name))
+    sys.modules["sklearn.mixture"].GaussianMixture = object
+    sys.modules["sklearn.metrics.pairwise"].cosine_similarity = lambda *a, **k: None
+    sys.modules["openai"].OpenAI = object
+    sys.modules["sentence_transformers"].SentenceTransformer = object
+    sys.modules["loguru"].logger = types.SimpleNamespace(
+        info=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+    )
+    sys.modules["tqdm"].tqdm = lambda x, **k: x
+
+    @dataclass
+    class RaptorConfig:
+        pass
+
+    sys.modules["config"].RaptorConfig = RaptorConfig
+
+
+_stub_raptor_deps()
+
+from raptor_indexer import RaptorIndexer  # noqa: E402
+
+
+@dataclass
+class _Cfg:
+    chunk_size: int = 1000
+    chunk_overlap: int = 1000
+
+
+def test_chunk_text_equal_size_and_overlap():
+    indexer = RaptorIndexer.__new__(RaptorIndexer)
+    indexer.config = _Cfg()
+    words = ("alpha beta gamma " * 200).strip()
+    chunks = indexer.chunk_text(words)
+    assert len(chunks) >= 1
+    assert all(isinstance(c, str) and c for c in chunks)
+
+
+def test_chunk_text_normal_overlap_still_advances():
+    indexer = RaptorIndexer.__new__(RaptorIndexer)
+    indexer.config = _Cfg(chunk_size=10, chunk_overlap=2)
+    chunks = indexer.chunk_text(" ".join(f"w{i}" for i in range(30)))
+    assert len(chunks) > 1


### PR DESCRIPTION
Equal RAPTOR_CHUNK_SIZE and RAPTOR_CHUNK_OVERLAP made range() use step 0 and ValueError while chunking ordinary documents. Sibling chunkers already use max(1, size - overlap).

Repro: chunk_size=1000, chunk_overlap=1000, then chunk_text on a multi-word document.

Step is now max(1, size - overlap).