### PR TITLE
fix(chapter3): don't mutate self.communities while iterating it (RuntimeError on the documented build path)

### DIFF
--- a/chapter3/structured-index/graphrag_indexer.py
+++ b/chapter3/structured-index/graphrag_indexer.py
@@ -315,8 +315,13 @@ class GraphRAGIndexer:
         
         logger.info("Creating hierarchical community summaries...")
         
-        # Group communities by similarity
-        community_embeddings = np.array([c.embedding for c in self.communities.values()])
+        # Group communities by similarity. Snapshot the ids up front: the loop
+        # below inserts the merged communities into self.communities, and
+        # iterating the live dict raised "RuntimeError: dictionary changed size
+        # during iteration". The snapshot also keeps i/j aligned with
+        # similarity_matrix, which is built once from these same communities.
+        community_ids = list(self.communities.keys())
+        community_embeddings = np.array([self.communities[cid].embedding for cid in community_ids])
         similarity_matrix = cosine_similarity(community_embeddings)
         
         # Simple hierarchical clustering
@@ -324,13 +329,13 @@ class GraphRAGIndexer:
         merged_communities = []
         processed = set()
         
-        for i, comm_id in enumerate(self.communities.keys()):
+        for i, comm_id in enumerate(community_ids):
             if comm_id in processed:
                 continue
             
             # Find similar communities
             similar = []
-            for j, other_id in enumerate(self.communities.keys()):
+            for j, other_id in enumerate(community_ids):
                 if i != j and similarity_matrix[i][j] > threshold:
                     similar.append(other_id)
                     processed.add(other_id)


### PR DESCRIPTION
Fixes #121

### Problem

`hierarchical_summarization` iterated the live dict and inserted into it inside the loop:

```python
327:        for i, comm_id in enumerate(self.communities.keys()):
...
384:                self.communities[merged_community.id] = merged_community
```

so Python raised `RuntimeError: dictionary changed size during iteration` on the next step of the outer loop.

The trigger is simply any two community summary embeddings with cosine similarity above `threshold = 0.7` — common in practice, since every community summary comes from the same document and is encoded by the same sentence-transformer.

It is on the documented build path (`main.py:54`, and `api_service.py:170` during `POST /index`), and it fires *after* entity extraction and community detection, so an expensive index build is thrown away.

### Change

Snapshot the community ids before the loop and iterate that list.

This also fixes a second, quieter problem: `similarity_matrix` is built once at `:320` from the pre-merge communities, so `similarity_matrix[i][j]` is indexed by position in *that* set. Inserting into the dict mid-loop desynchronised those indices. Building `community_embeddings` from the same snapshot keeps them aligned by construction.

### Verification

Driving the real method with 4 communities (two near-identical pairs, so two merges fire), with the embedding model and LLM call stubbed:

```
BEFORE:
  CRASH: RuntimeError: dictionary changed size during iteration

AFTER :
  completed OK: 4 communities -> 6 (merged 2 added)
  levels: [0, 1]
```

The merged communities are added with `level=1` as intended, and the original level-0 communities are retained.
