### PR TITLE
fix(elo): map monthly interval M to ME for modern pandas

### DIFF
--- a/chapter6/elo-leaderboard/data_loader.py
+++ b/chapter6/elo-leaderboard/data_loader.py
@@ -202,8 +202,11 @@ def get_time_slices(df: pd.DataFrame, interval: str = 'W') -> list:
     min_date = df['datetime'].min()
     max_date = df['datetime'].max()
     
+    # Pandas 2.2+ removed 'M' (month-end); keep the documented monthly alias.
+    freq = "ME" if interval == "M" else interval
+
     # Generate date ranges
-    date_ranges = pd.date_range(start=min_date, end=max_date, freq=interval)
+    date_ranges = pd.date_range(start=min_date, end=max_date, freq=freq)
     
     slices = []
     for end_date in date_ranges:

--- a/chapter6/elo-leaderboard/test_time_slices_monthly_interval.py
+++ b/chapter6/elo-leaderboard/test_time_slices_monthly_interval.py
@@ -1,0 +1,9 @@
+"""Regression: documented interval='M' must work on modern pandas."""
+import pandas as pd
+from data_loader import get_time_slices
+
+
+def test_monthly_interval_alias():
+    df = pd.DataFrame({"tstamp": [1_700_000_000, 1_710_000_000]})
+    slices = get_time_slices(df, interval="M")
+    assert len(slices) >= 1


### PR DESCRIPTION
Documented interval='M' raises ValueError on pandas 2.2+ because 'M' was removed. Map M to ME before date_range.

Repro: get_time_slices(df, interval="M") on a multi-month tstamp frame.