### PR TITLE
fix(csv): honor max_rows in extract_csv_content data

### DIFF
--- a/chapter4/perception-tools/src/document_processing_tools.py
+++ b/chapter4/perception-tools/src/document_processing_tools.py
@@ -274,7 +274,7 @@ async def extract_csv_content(
             "rows": len(df),
             "columns": len(df.columns),
             "column_names": df.columns.tolist(),
-            "data": df.head(100).to_dict(orient="records"),  # First 100 rows
+            "data": df.to_dict(orient="records"),
             "preview": df.head(10).to_string(),
             "truncated": len(df) == max_rows
         }

--- a/chapter4/perception-tools/src/test_csv_max_rows.py
+++ b/chapter4/perception-tools/src/test_csv_max_rows.py
@@ -1,0 +1,46 @@
+"""Regression: extract_csv_content must honor max_rows in data, not hard-cap at 100."""
+import asyncio
+import json
+import sys
+import types
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+def _stub_deps() -> None:
+    for name in ["docx", "pptx", "PyPDF2", "dotenv"]:
+        sys.modules.setdefault(name, types.ModuleType(name))
+    sys.modules["docx"].Document = object
+    sys.modules["pptx"].Presentation = object
+    sys.modules["dotenv"].load_dotenv = lambda *a, **k: None
+
+    mcp = types.ModuleType("mcp")
+    mcp_types = types.ModuleType("mcp.types")
+
+    class TextContent:
+        def __init__(self, type=None, text=None):
+            self.type = type
+            self.text = text
+
+    mcp_types.TextContent = TextContent
+    sys.modules["mcp"] = mcp
+    sys.modules["mcp.types"] = mcp_types
+
+
+_stub_deps()
+
+from document_processing_tools import extract_csv_content  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_csv_data_honors_max_rows(tmp_path: Path):
+    path = tmp_path / "t.csv"
+    pd.DataFrame({"id": range(250)}).to_csv(path, index=False)
+    r = await extract_csv_content(str(path), max_rows=1000)
+    payload = json.loads(r.text)
+    msg = payload["message"]
+    assert msg["rows"] == 250
+    assert len(msg["data"]) == 250
+    assert msg["truncated"] is False


### PR DESCRIPTION
extract_csv_content applied df.head(100) after nrows=max_rows, so data silently truncated while truncated stayed False.

Repro: CSV with 250 rows and max_rows=1000 returned data length 100 with truncated=False.