### PR TITLE
fix(elo): keep parallel filter chunk_size at least 1

### DIFF
--- a/chapter6/elo-leaderboard/parallel_processing.py
+++ b/chapter6/elo-leaderboard/parallel_processing.py
@@ -223,9 +223,14 @@ def filter_data_parallel(df: pd.DataFrame,
     """
     if n_jobs == -1:
         n_jobs = min(cpu_count(), 4)  # Cap at 4 for filtering
+
+    if len(df) == 0:
+        return df.copy()
+
+    n_jobs = max(1, min(n_jobs, len(df)))
     
     # Split DataFrame into chunks
-    chunk_size = len(df) // n_jobs
+    chunk_size = max(1, len(df) // n_jobs)
     chunks = [df.iloc[i:i+chunk_size] for i in range(0, len(df), chunk_size)]
     
     def apply_filters(chunk):

--- a/chapter6/elo-leaderboard/test_filter_data_parallel_small.py
+++ b/chapter6/elo-leaderboard/test_filter_data_parallel_small.py
@@ -1,0 +1,21 @@
+"""Regression: filter_data_parallel must tolerate n_jobs > len(df)."""
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from parallel_processing import filter_data_parallel
+
+
+def test_n_jobs_larger_than_rows():
+    df = pd.DataFrame({"anony": [True, False, True], "turn": [1, 2, 1]})
+
+    def map_inline(fn, chunks):
+        return [fn(c) for c in chunks]
+
+    pool = MagicMock()
+    pool.__enter__.return_value.map.side_effect = map_inline
+    pool.__exit__.return_value = False
+
+    with patch("parallel_processing.Pool", return_value=pool):
+        out = filter_data_parallel(df, {"anony_only": True}, n_jobs=8)
+    assert len(out) == 2


### PR DESCRIPTION
filter_data_parallel used len(df)//n_jobs which is 0 when n_jobs exceeds the row count, then range(..., 0) ValueError.

Repro: filter_data_parallel on 3 rows with n_jobs=8.