### PR TITLE
fix(kb): ignore FAISS padding indices below zero

### DIFF
--- a/chapter8/gaia-experience/knowledge_base.py
+++ b/chapter8/gaia-experience/knowledge_base.py
@@ -268,7 +268,7 @@ class KnowledgeBase:
                 
                 results = []
                 for idx in indices[0]:
-                    if idx < len(self.documents):
+                    if 0 <= idx < len(self.documents):
                         results.append(self.documents[idx])
                 
                 return results

--- a/chapter8/gaia-experience/test_kb_faiss_negative_idx.py
+++ b/chapter8/gaia-experience/test_kb_faiss_negative_idx.py
@@ -1,0 +1,12 @@
+"""Regression: FAISS padding index -1 must not map to documents[-1]."""
+from pathlib import Path
+
+
+def test_search_guards_negative_indices():
+    src = Path(__file__).with_name("knowledge_base.py").read_text()
+    assert "0 <= idx < len(self.documents)" in src
+
+    documents = [{"id": i} for i in range(3)]
+    indices = [0, -1, -1]
+    results = [documents[idx] for idx in indices if 0 <= idx < len(documents)]
+    assert results == [{"id": 0}]


### PR DESCRIPTION
When the index is shorter than documents, FAISS pads with -1 and idx < len(docs) still matched, returning documents[-1].

Require 0 <= idx before appending search hits.