### PR TITLE
fix(puzzles): allow one-person random statements via count

### DIFF
--- a/chapter5/code-for-logic/build_puzzles.py
+++ b/chapter5/code-for-logic/build_puzzles.py
@@ -119,6 +119,11 @@ def build_puzzle(pid, names, structs, nl_overrides=None):
 def _random_stmt(speaker, names, rng):
     """为 speaker 随机生成一句合法的结构化陈述。"""
     others = [n for n in names if n != speaker]
+    # Solo resident: only count statements are valid (no "others" to name).
+    if not others:
+        role = rng.choice(["knight", "knave"])
+        op = rng.choice([">=", "<=", "=="])
+        return ["count", role, op, rng.randint(1, len(names))]
     kind = rng.choice(["is", "is", "same", "diff", "count"])
     if kind == "is":
         return ["is", rng.choice(others), rng.choice(["knight", "knave"])]

--- a/chapter5/code-for-logic/test_random_stmt_one_person.py
+++ b/chapter5/code-for-logic/test_random_stmt_one_person.py
@@ -1,0 +1,22 @@
+"""Regression: one-person puzzles must not IndexError in _random_stmt."""
+import random
+import sys
+import types
+
+sys.modules.setdefault("constraint", types.ModuleType("constraint"))
+sys.modules["constraint"].Problem = object
+cs = types.ModuleType("csp_solver")
+cs.render_nl = lambda *a, **k: ""
+cs.solve = lambda *a, **k: [{}]
+cs.solve_labeled = lambda *a, **k: {}
+sys.modules["csp_solver"] = cs
+
+from build_puzzles import _random_stmt  # noqa: E402
+
+
+def test_random_stmt_one_person_returns_count():
+    rng = random.Random(0)
+    for _ in range(20):
+        stmt = _random_stmt("A", ["A"], rng)
+        assert stmt[0] == "count"
+        assert stmt[1] in ("knight", "knave")


### PR DESCRIPTION
_random_stmt called choice(others) when min-people=1 left others empty and IndexError. Solo residents only emit count statements.

Repro: python build_puzzles.py --generate 3 --min-people 1 --max-people 1 --seed 0