### PR TITLE
fix(rl): avoid zero progress interval for small episode counts

### DIFF
--- a/chapter1/learning-from-experience/test_rl_learning.py
+++ b/chapter1/learning-from-experience/test_rl_learning.py
@@ -96,7 +96,8 @@ def test_rl_learning(stochastic=False, episodes=None):
                 victories += 1
             
             # Print progress
-            if (episode + 1) % (num_episodes // 10) == 0:
+            progress_every = max(1, num_episodes // 10)
+            if (episode + 1) % progress_every == 0:
                 recent_wins = sum(1 for r in recent_rewards[-100:] if r > 50)
                 avg_reward = np.mean(recent_rewards[-100:]) if recent_rewards else 0
                 print(f"  Episode {episode+1}: Recent wins={recent_wins}/100, "

--- a/chapter1/learning-from-experience/test_rl_progress_small_episodes.py
+++ b/chapter1/learning-from-experience/test_rl_progress_small_episodes.py
@@ -1,0 +1,16 @@
+"""Regression: progress prints must not ZeroDivisionError when episodes < 10."""
+
+
+def test_progress_every_never_zero():
+    for num_episodes in (1, 5, 9, 10, 100):
+        progress_every = max(1, num_episodes // 10)
+        assert progress_every >= 1
+        # modulo must be defined
+        for episode in range(num_episodes):
+            _ = (episode + 1) % progress_every
+
+
+def test_source_uses_max_guard():
+    from pathlib import Path
+    src = Path(__file__).with_name("test_rl_learning.py").read_text()
+    assert "progress_every = max(1, num_episodes // 10)" in src


### PR DESCRIPTION
test_rl_learning used num_episodes//10 as a modulo step, which is 0 when episodes < 10 and ZeroDivisionError.

Repro: --episodes 5. Progress step is now max(1, num_episodes // 10).