### PR TITLE
fix(elo): tolerate empty history in prepare_animation_data

### DIFF
--- a/chapter6/elo-leaderboard/animation.py
+++ b/chapter6/elo-leaderboard/animation.py
@@ -21,6 +21,14 @@ def prepare_animation_data(history_df: pd.DataFrame, top_n: int = 15) -> dict:
     """
     # Get all unique dates
     dates = sorted(history_df['date'].unique())
+    if len(dates) == 0:
+        return {
+            'frames': [],
+            'total_frames': 0,
+            'top_n': top_n,
+            'start_date': None,
+            'end_date': None,
+        }
     
     # For each date, get top N models
     frames = []

--- a/chapter6/elo-leaderboard/test_animation_empty_history.py
+++ b/chapter6/elo-leaderboard/test_animation_empty_history.py
@@ -1,0 +1,11 @@
+"""Regression: prepare_animation_data must tolerate empty history."""
+import pandas as pd
+from animation import prepare_animation_data
+
+
+def test_empty_history_returns_empty_frames():
+    df = pd.DataFrame(columns=["date", "model", "rating", "rank", "matches", "wins"])
+    data = prepare_animation_data(df)
+    assert data["frames"] == []
+    assert data["total_frames"] == 0
+    assert data["start_date"] is None


### PR DESCRIPTION
Empty history made dates=[] then dates[0] IndexError. Return empty frames with null start/end dates.

Repro: prepare_animation_data on a history DataFrame with no rows.