### PR TITLE
fix(intuitor): tolerate empty sample text lists

### DIFF
--- a/chapter7/Intuitor/evaluate_from_cache.py
+++ b/chapter7/Intuitor/evaluate_from_cache.py
@@ -189,7 +189,11 @@ def evaluate_from_parquet(parquet_path: str, verbose: bool = False):
                 continue
         
         # 提取模型输出
-        model_output = sample_data.get('text', [''])[0] if isinstance(sample_data.get('text'), list) else sample_data.get('text', '')
+        text_field = sample_data.get('text', [''])
+        if isinstance(text_field, list):
+            model_output = text_field[0] if text_field else ''
+        else:
+            model_output = text_field if text_field is not None else ''
         
         # 确保 model_output 是字符串
         if isinstance(model_output, bytes):

--- a/chapter7/Intuitor/test_empty_text_list.py
+++ b/chapter7/Intuitor/test_empty_text_list.py
@@ -1,0 +1,22 @@
+"""Regression: empty sample text list must not IndexError."""
+
+
+def _extract_model_output(sample_data):
+    text_field = sample_data.get('text', [''])
+    if isinstance(text_field, list):
+        return text_field[0] if text_field else ''
+    return text_field if text_field is not None else ''
+
+
+def test_empty_text_list():
+    assert _extract_model_output({"text": []}) == ""
+
+
+def test_nonempty_text_list():
+    assert _extract_model_output({"text": ["hello"]}) == "hello"
+
+
+def test_source_guards_empty_list():
+    from pathlib import Path
+    src = Path(__file__).with_name("evaluate_from_cache.py").read_text()
+    assert "text_field[0] if text_field else ''" in src


### PR DESCRIPTION
evaluate_from_parquet indexed sample text[0] when text was [], IndexError. Treat an empty list as an empty string.

Repro: cache row with sample text: [].