### PR TITLE
fix(chapter3): keep the trailing fragment in _split_into_sentences (text with no terminal punctuation was dropped entirely)

### DIFF
--- a/chapter3/agentic-rag/chunking.py
+++ b/chapter3/agentic-rag/chunking.py
@@ -125,7 +125,13 @@ class DocumentChunker:
         
         # Reconstruct sentences with their endings
         result = []
-        for i in range(0, len(sentences) - 1, 2):
+        # Step to the end of the list: re.split with a capturing group yields
+        # [text, delim, text, delim, ..., trailing_text], so stopping at
+        # len(sentences) - 1 dropped the trailing fragment whenever the text
+        # did not end in terminal punctuation (and returned [] for text with
+        # none at all). The strip-and-filter below still discards the empty
+        # tail that re.split produces when the text does end in punctuation.
+        for i in range(0, len(sentences), 2):
             if i + 1 < len(sentences):
                 result.append(sentences[i] + sentences[i + 1])
             else:

--- a/chapter3/contextual-retrieval/chunking.py
+++ b/chapter3/contextual-retrieval/chunking.py
@@ -125,7 +125,13 @@ class DocumentChunker:
         
         # Reconstruct sentences with their endings
         result = []
-        for i in range(0, len(sentences) - 1, 2):
+        # Step to the end of the list: re.split with a capturing group yields
+        # [text, delim, text, delim, ..., trailing_text], so stopping at
+        # len(sentences) - 1 dropped the trailing fragment whenever the text
+        # did not end in terminal punctuation (and returned [] for text with
+        # none at all). The strip-and-filter below still discards the empty
+        # tail that re.split produces when the text does end in punctuation.
+        for i in range(0, len(sentences), 2):
             if i + 1 < len(sentences):
                 result.append(sentences[i] + sentences[i + 1])
             else:

--- a/chapter3/contextual-retrieval/contextual_chunking.py
+++ b/chapter3/contextual-retrieval/contextual_chunking.py
@@ -266,7 +266,13 @@ class ContextualChunker:
         
         # Reconstruct sentences with their endings
         result = []
-        for i in range(0, len(sentences) - 1, 2):
+        # Step to the end of the list: re.split with a capturing group yields
+        # [text, delim, text, delim, ..., trailing_text], so stopping at
+        # len(sentences) - 1 dropped the trailing fragment whenever the text
+        # did not end in terminal punctuation (and returned [] for text with
+        # none at all). The strip-and-filter below still discards the empty
+        # tail that re.split produces when the text does end in punctuation.
+        for i in range(0, len(sentences), 2):
             if i + 1 < len(sentences):
                 result.append(sentences[i] + sentences[i + 1])
             else:


### PR DESCRIPTION
Fixes #122

### Problem

`re.split` with a capturing group returns `[text, delim, text, delim, ..., trailing_text]`. The reassembly loop stopped one element early:

```python
for i in range(0, len(sentences) - 1, 2):
```

so when the text did not end in terminal punctuation the list had odd length `2n+1` and index `2n` was never reached — the trailing fragment was silently dropped. With no terminal punctuation anywhere, the result was an empty list and the entire paragraph was discarded.

These are RAG chunkers, so dropped text is never indexed and can never be retrieved. Headings, list items, table cells and log lines routinely lack terminal punctuation.

### Change

`range(0, len(sentences), 2)`, keeping the existing `i + 1 < len(sentences)` guard for the odd tail.

Well-formed input is unaffected: when the text *does* end in punctuation, `re.split` emits an empty trailing element, and the existing `[s.strip() for s in result if s.strip()]` already discards it.

### Verification

Same harness run against the file before and after:

```
                                                  before                        after
'One. Two. Trailing with no period'   ['One.','Two.']               ['One.','Two.','Trailing with no period']
'第一句。第二句。没有句号的结尾片段'          ['第一句。','第二句。']          ['第一句。','第二句。','没有句号的结尾片段']
'No punctuation at all'               []                            ['No punctuation at all']
'Multiple!!! Bangs??? Here'           ['Multiple!!!','Bangs???']    ['Multiple!!!','Bangs???','Here']

'One. Two.'                           ['One.','Two.']               ['One.','Two.']          (unchanged)
'第一句。第二句。'                        ['第一句。','第二句。']          ['第一句。','第二句。']    (unchanged)
''                                    []                            []                       (unchanged)
```

### Scope

Three byte-identical copies, all patched:

- `chapter3/agentic-rag/chunking.py:128`
- `chapter3/contextual-retrieval/chunking.py:128`
- `chapter3/contextual-retrieval/contextual_chunking.py:269`

All three verified to produce identical output after the change.

Happy to split this into three PRs if you'd prefer them reviewed separately — I kept them together since the change and the justification are the same in each.
