### PR TITLE
fix(chapter8): match the "Final Answer:"/"Language:" prefixes case-insensitively (they were unreachable)

### DIFF
--- a/chapter8/prompt-distillation/evaluate.py
+++ b/chapter8/prompt-distillation/evaluate.py
@@ -59,7 +59,10 @@ def parse_language_label(response: str) -> Optional[str]:
     
     response = response.strip().lower()
     for pattern in patterns:
-        match = re.search(pattern, response)
+        # response is lower-cased above, so the mixed-case "Final Answer:" /
+        # "Language:" patterns only match case-insensitively — without this
+        # they are unreachable and such answers score as unparseable.
+        match = re.search(pattern, response, re.IGNORECASE)
         if match:
             return match.group(1)
     


### PR DESCRIPTION
Fixes #126

Follow-up to the `format_pred_label` fix — that resolved the `TypeError`; this is the remaining half.

### Problem

`parse_language_label` lower-cases the response and then matches two **mixed-case** patterns against it:

```python
    response = response.strip().lower()
    for pattern in patterns:
        match = re.search(pattern, response)
```

with `r"Final Answer:\s*([a-z]{2})"` and `r"Language:\s*([a-z]{2})"` in the list. Against an already-lower-cased string those can never match, so both patterns are unreachable.

### Change

Pass `re.IGNORECASE`.

### Verification

Same harness against the file before and after:

```
                                before      after
'Final Answer: en'          ->  None        'en'
'final answer: en'          ->  None        'en'
'Language: fr'              ->  None        'fr'
'LANGUAGE: DE'              ->  None        'de'

'en'                        ->  'en'        'en'      (unchanged)
'EN'                        ->  'en'        'en'      (unchanged)
'  fr  '                    ->  'fr'        'fr'      (unchanged)
'The language is English.'  ->  None        None      (correctly unparseable)
''                          ->  None        None      (unchanged)
```

The two anchored `^([a-z]{2})$` patterns are unaffected, and genuinely unparseable input still returns `None`.

### Why it matters

A student model answering `Final Answer: en` — the exact format those two patterns exist to accept — was scored as unparseable, which understates accuracy and inflates the `unparseable` count in the distillation comparison. Now that the crash is fixed the run completes and reports those numbers, so the wrong result is no longer obvious from a traceback.
