### PR TITLE
fix(chapter2): give windowed compression the real query (hasattr(call,'id') was never true)

### DIFF
--- a/chapter2/context-compression/agent.py
+++ b/chapter2/context-compression/agent.py
@@ -39,6 +39,10 @@ class ToolCall:
     result: Optional[Any] = None
     compressed_result: Optional[CompressedContent] = None
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+    # Provider-side tool_call id, so a tool message in the history can be
+    # matched back to the call that produced it (used by windowed compression
+    # to recover the original query).
+    id: Optional[str] = None
 
 
 @dataclass
@@ -293,7 +297,7 @@ TODAY'S DATE: {date_string}"""
                     
                     # Try to find the query from the tool call
                     for call in self.trajectory.tool_calls:
-                        if hasattr(call, 'id') and call.id == tool_call_id:
+                        if call.id is not None and call.id == tool_call_id:
                             query = call.arguments.get('query', query)
                             break
                     
@@ -559,7 +563,8 @@ TODAY'S DATE: {date_string}"""
                             tool_name=function_name,
                             arguments=function_args,
                             result=result,
-                            compressed_result=compressed
+                            compressed_result=compressed,
+                            id=tool_call['id']
                         )
                         self.trajectory.tool_calls.append(tool_call_record)
                         


### PR DESCRIPTION
Fixes #124

### Problem

```python
295:                    for call in self.trajectory.tool_calls:
296:                        if hasattr(call, 'id') and call.id == tool_call_id:
297:                            query = call.arguments.get('query', query)
```

`self.trajectory.tool_calls` holds this module's own `ToolCall` dataclass (`:35`), whose fields are `tool_name, arguments, result, compressed_result, timestamp` — there is no `id`. So `hasattr(call, 'id')` is `False` for every element, the loop can never match, and `query` keeps the literal default `"Information search"`.

That value goes straight into `compress_for_history`, which builds the summarization prompt around it:

```
Focus on information relevant to: {query}
```

So the single input that makes this strategy *context-aware* was never supplied. Every windowed compression summarized against a placeholder — degrading silently to generic summarization, and free to drop exactly the information the user asked about.

### Change

- Add `id: Optional[str] = None` to `ToolCall`.
- Populate it from `tool_call['id']` at the construction site (`:558`), which already has the value in scope.
- Change the guard to `call.id is not None and call.id == tool_call_id`, so an id-less entry can never silently restore the always-false behaviour.

### Verification

Replaying the exact lookup:

```
  fields          : ['tool_name', 'arguments', 'result', 'compressed_result', 'timestamp', 'id']
  lookup call_abc123  -> 'who founded OpenAI'      (was 'Information search')
  lookup call_1       -> 'first q'
  lookup missing      -> 'Information search'      (fallback preserved)
  legacy no-id entry handled: True
```

The default is still used when no matching call is found, and a `ToolCall` constructed without an id does not break the lookup.
