### PR TITLE
fix(chapter5): make BashOutput return only new output since the last check, as documented

### DIFF
--- a/chapter5/coding-agent/system_state.py
+++ b/chapter5/coding-agent/system_state.py
@@ -17,6 +17,9 @@ class SystemState:
     todos: List[Dict[str, Any]] = field(default_factory=list)
     shell_sessions: Dict[str, Any] = field(default_factory=dict)
     default_shell_id: str = "default"
+    # Byte offset already returned by BashOutput, per bash_id, so each call can
+    # return "only new output since the last check" as the tool documents.
+    bash_output_offsets: Dict[str, int] = field(default_factory=dict)
     os_type: str = field(default_factory=lambda: os.uname().sysname)
     python_version: str = field(default_factory=lambda: subprocess.getoutput("python3 --version"))
     

--- a/chapter5/coding-agent/tools/bash_output_tool.py
+++ b/chapter5/coding-agent/tools/bash_output_tool.py
@@ -33,9 +33,20 @@ class BashOutputTool(BaseTool):
             return {"error": f"Bash job not found (no output log) for bash_id: {bash_id}"}
         
         try:
+            # Return only what has been appended since the last check, as the
+            # tool description promises. The offset is per bash_id and lives in
+            # SystemState so it survives across calls.
+            previous_offset = self.state.bash_output_offsets.get(bash_id, 0)
+            if os.path.getsize(log_file) < previous_offset:
+                # Log was truncated or rotated — start over rather than
+                # seeking past the end and returning nothing forever.
+                previous_offset = 0
+
             with open(log_file, 'r') as f:
+                f.seek(previous_offset)
                 output = f.read()
-            
+                self.state.bash_output_offsets[bash_id] = f.tell()
+
             if filter_pattern:
                 # Filter lines matching pattern
                 lines = output.split('\n')


### PR DESCRIPTION
Fixes #125

### Problem

`tools.json` and the tool docstring both state:

> - Always returns only new output since the last check

but the implementation read the whole file:

```python
36:            with open(log_file, 'r') as f:
37:                output = f.read()
```

with no offset stored anywhere — `grep` for `last_check` / `last_read` / `seek(` / `offset` across `bash_output_tool.py`, `bash_tool.py` and `system_state.py` returns nothing.

```
before:  call 1 -> 'line1\n'
         call 2 -> 'line1\nline2\n'      # spec requires 'line2\n'
```

Monitoring a long-running background job is the documented use case, and it is precisely the case that degrades: every poll re-sends everything emitted so far, so a build or test run producing a few hundred KB grows the context quadratically across polls — and the model cannot tell what is *new*, which is the only question it is polling to answer.

### Change

Track a per-`bash_id` byte offset in `SystemState` (which the tool already receives), seek to it, and record `f.tell()` afterwards.

Two edge cases handled deliberately:

- **Truncation / rotation** — if the file is now smaller than the stored offset, reset to 0 instead of seeking past EOF and returning nothing forever.
- **Filtering** — the `filter` regex now applies to the newly read slice, so filtering and incremental reads compose as the description implies.

### Verification

```
  call 1 (new)       : 'line1\n'
  call 2 (only new)  : 'line2\n'
  call 3 (no change) : ''
  call 4 (two new)   : 'line3\nline4\n'
  after truncation   : 'fresh\n'
  other bash_id      : 'a\nb\n'          <- offsets are per bash_id
  first id unaffected: 'line5\n'
  filtered new slice : 'keepme'
  missing log        : same error dict as before
```

```
$ python -m pytest tests/test_bash_output_tool.py -q
4 passed in 1.70s
```
