### PR TITLE
fix(chapter2): stop rewriting every '^' to '**' (XOR silently returned 125 instead of 6)

### DIFF
--- a/chapter2/local_llm_serving/tools.py
+++ b/chapter2/local_llm_serving/tools.py
@@ -93,7 +93,7 @@ class ToolRegistry:
                 "properties": {
                     "code": {
                         "type": "string",
-                        "description": "Python code to execute"
+                        "description": "Python code to execute. Use Python operators: ** for exponentiation (2 ** 10), not ^ — in Python ^ is bitwise XOR."
                     }
                 },
                 "required": ["code"]
@@ -426,10 +426,15 @@ class ToolRegistry:
             # Also strip any leading/trailing whitespace
             code = code.strip()
             
-            # Convert common mathematical notation to Python syntax
-            # Replace ^ with ** for exponentiation
-            code = re.sub(r'\^', '**', code)
-            
+            # NOTE: we deliberately do NOT rewrite '^' to '**' here. '^' is a
+            # valid Python operator (bitwise XOR), so a blanket substitution
+            # silently changes the meaning of correct code -- 5 ^ 3 is 6, but
+            # rewritten as 5 ** 3 it returns 125 with no error. It also broke
+            # anchored regexes (r'^a.*' -> r'**a.*' raises "nothing to repeat")
+            # and corrupted carets inside string literals. The two meanings of
+            # '^' cannot be told apart from the source, so the convention is
+            # stated in the tool description instead.
+
             # Create a full Python namespace with all builtins available
             # This gives the agent access to the complete Python environment
             import sys


### PR DESCRIPTION
Fixes #123

### Problem

```python
430:            # Replace ^ with ** for exponentiation
431:            code = re.sub(r'\^', '**', code)
```

The intent is reasonable, but the substitution is unscoped — and `^` is already a valid Python operator, so it silently changed the meaning of *correct* code.

### Change

Remove the rewrite; state the convention in the tool description instead:

> Use Python operators: `**` for exponentiation (`2 ** 10`), not `^` — in Python `^` is bitwise XOR.

### Why removal rather than scoping it

I considered a `tokenize`-based version that only rewrites `^` outside string literals and comments. That fixes two of the three failure modes but **not** the worst one: `5 ^ 3` is a bare operator between numeric literals, so a scoped rewrite still turns XOR (6) into exponentiation (125), silently.

The two meanings of `^` are not distinguishable from the source — `2^10` (model means power) and `5^3` (model means XOR) are the same shape. Since the ambiguity can't be resolved by analysis, resolving it in the tool description is the honest option: the model is told the convention up front, and correct Python is never rewritten behind its back.

Happy to switch to the tokenizer-scoped variant if you'd rather keep the convenience for the string/regex cases — just say so and I'll push it.

### Verification

Running the real `code_interpreter` before and after:

```
                                    before                     after
XOR (valid Python)               -> '125'                   -> '6'
anchored regex in a string       -> 'nothing to repeat…'    -> "['abc']"
caret inside a string literal    -> 'a caret ** inside…'    -> 'a caret ^ inside…'
exponent written correctly       -> '1024'                  -> '1024'      (unchanged)
markdown fence still stripped    -> '42'                    -> '42'        (unchanged)
```

The markdown-fence stripping above the removed lines is untouched.
