### PR TITLE
fix(chapter8): clear replay_used when replay fails (failed replays reported fake "Nx faster / 0 LLM calls")

### DIFF
--- a/chapter8/browser-use-rpa/learning_agent/agent.py
+++ b/chapter8/browser-use-rpa/learning_agent/agent.py
@@ -306,6 +306,11 @@ class LearningAgent:
                 # If replay failed, fall back to learning mode
                 if not result['success']:
                     logger.warning("Replay failed, falling back to learning mode")
+                    # The LLM loop is about to run, so this is no longer a
+                    # replay run. Leaving the flag set makes the summary log and
+                    # the demos report "0 LLM calls / Nx faster" for a run that
+                    # actually made real LLM calls.
+                    self.metrics['replay_used'] = False
                     result = await self._run_with_learning(max_steps)
             
             else:


### PR DESCRIPTION
Fixes #145

### Problem

`metrics['replay_used']` was set **before** the replay result was checked, and the fallback never cleared it:

```python
303:                self.metrics['replay_used'] = True
304:                self.metrics['success'] = result['success']
306:                # If replay failed, fall back to learning mode
307:                if not result['success']:
308:                    logger.warning("Replay failed, falling back to learning mode")
309:                    result = await self._run_with_learning(max_steps)
```

Both consumers read the flag as "no LLM was used" — `agent.py:320-325` chooses between the "completed with replay / Model calls saved" and "completed with learning / LLM calls made" logs, and `demo_email.py:181-192` gates the whole "Performance Improvements / LLM calls saved / Nx faster" block on it.

So a **failed** replay reported a saving that never happened, on precisely the runs where the chapter's claim didn't hold. The trigger is routine: `replay.py:133` sets `success = (steps_completed == total_steps)`, so any stale selector, timeout or changed page makes it `False` — which is why the fallback exists at all.

### Change

Clear the flag before falling back.

### Verification

Driving the real `run()` (extracted and exercised with a stub agent) where replay fails and the fallback makes 7 LLM calls:

**Before**

```
WARNING: Replay failed, falling back to learning mode
INFO: Task completed with replay in 0.00s
INFO: Model calls saved: 0
returned metrics: {'llm_calls': 7, 'replay_used': True, 'success': False}
--- what demo_email.py:181 prints ---
   - Workflow reused: Yes
   - LLM calls saved: 12   <-- FABRICATED
```

**After**

```
WARNING: Replay failed, falling back to learning mode
INFO: Task completed with learning in 0.00s
INFO: LLM calls made: 7
returned metrics: {'llm_calls': 7, 'replay_used': False, 'success': False}
--- what demo_email.py:181 prints ---
   - Workflow reused: No
   - LLM calls made: 7
```

A *successful* replay is unaffected — the flag is still set at `:303` and nothing clears it on that path.
