### PR TITLE
fix(chapter4): clamp the lower bound of a PDF page range ("0-3" returned the document's last page as "Page 0")

### DIFF
--- a/chapter4/perception-tools/src/document_processing_tools.py
+++ b/chapter4/perception-tools/src/document_processing_tools.py
@@ -325,7 +325,10 @@ def parse_page_range(page_range: str, total_pages: int) -> list[int]:
         part = part.strip()
         if "-" in part:
             start, end = map(int, part.split("-"))
-            pages.extend(range(start - 1, min(end, total_pages)))
+            # Clamp both ends: the caller's guard is `page_num < total_pages`,
+            # which a negative index passes, and reader.pages[-1] is the LAST
+            # page -- so an unclamped start silently returns the wrong page.
+            pages.extend(range(max(0, start - 1), min(end, total_pages)))
         else:
             page_num = int(part) - 1
             if 0 <= page_num < total_pages:


### PR DESCRIPTION
Fixes #146

### Problem

```python
328:            pages.extend(range(start - 1, min(end, total_pages)))
```

Only the upper end is clamped, so `page_range="0-3"` yields `[-1, 0, 1, 2]`. The caller's guard checks just the upper end too:

```python
56:                if page_num < total_pages:
57:                    page = reader.pages[page_num]
```

`-1` passes it, and `reader.pages[-1]` is the document's **last** page — returned with `success: true` and mislabelled `--- Page 0 ---`.

### Change

`range(max(0, start - 1), min(end, total_pages))`

This restores symmetry with the sibling branch, which already rejects out-of-range pages with `0 <= page_num < total_pages`.

### Verification

Same specs against the function before and after — only the broken one changes:

```
  '1-3'    before=[0, 1, 2]          after=[0, 1, 2]
  '0-3'    before=[-1, 0, 1, 2]      after=[0, 1, 2]
  '0'      before=[]                 after=[]
  '3-1'    before=[]                 after=[]
  '2-99'   before=[1, 2, 3, 4]       after=[1, 2, 3, 4]
  '1,3,5'  before=[0, 2, 4]          after=[0, 2, 4]
  '0,2'    before=[1]                after=[1]
```
