### PR TITLE
fix(chapter7): honour compare_models.py's --base_model/--pretrained_path/--finetuned_path/--max_seq_length

### DIFF
--- a/chapter7/continued-pretraining/compare_models.py
+++ b/chapter7/continued-pretraining/compare_models.py
@@ -150,21 +150,21 @@ def main():
     print(f"  1. {Colors.RED}Baseline{Colors.ENDC} - Original Mistral (no Korean training)")
     print(f"  2. {Colors.GREEN}Pretrained{Colors.ENDC} - After Korean Wikipedia training")
     print(f"  3. {Colors.CYAN}Finetuned{Colors.ENDC} - After instruction tuning")
-    print(f"\n{Colors.CYAN}Generation settings: temperature=0.3, do_sample=True (no repetition_penalty){Colors.ENDC}\n")
+    print(f"\n{Colors.CYAN}Generation settings: temperature={args.temperature}, do_sample=True (no repetition_penalty){Colors.ENDC}\n")
     
     # Load all three models
     print_section("📥 LOADING MODELS", Colors.BLUE)
     
     print(f"{Colors.YELLOW}Loading baseline model (original Mistral v0.3)...{Colors.ENDC}")
-    baseline_model, baseline_tokenizer = load_baseline_model()
+    baseline_model, baseline_tokenizer = load_baseline_model(args.base_model, args.max_seq_length)
     print(f"{Colors.GREEN}✓ Baseline model loaded{Colors.ENDC}")
     
     print(f"\n{Colors.YELLOW}Loading pretrained model (after Korean pretraining)...{Colors.ENDC}")
-    pretrained_model, pretrained_tokenizer = load_model("lora_model_pretrained")
+    pretrained_model, pretrained_tokenizer = load_model(args.pretrained_path, args.max_seq_length)
     print(f"{Colors.GREEN}✓ Pretrained model loaded{Colors.ENDC}")
     
     print(f"\n{Colors.YELLOW}Loading finetuned model (after instruction tuning)...{Colors.ENDC}")
-    finetuned_model, finetuned_tokenizer = load_model("lora_model")
+    finetuned_model, finetuned_tokenizer = load_model(args.finetuned_path, args.max_seq_length)
     print(f"{Colors.GREEN}✓ Finetuned model loaded{Colors.ENDC}")
     
     # Define prompts


### PR DESCRIPTION
Fixes #149

### Problem

`parse_args()` defines four options and both loaders accept them —

```python
30:def load_baseline_model(base_model="unsloth/mistral-7b-v0.3", max_seq_length=2048):
42:def load_model(model_path, max_seq_length=2048):
```

— but `main()` ignored all four:

```python
159:    baseline_model, baseline_tokenizer = load_baseline_model()
163:    pretrained_model, pretrained_tokenizer = load_model("lora_model_pretrained")
167:    finetuned_model, finetuned_tokenizer = load_model("lora_model")
```

`grep -n "args\." compare_models.py` returned only `args.max_new_tokens` / `args.temperature`.

### Change

Pass `args.base_model`, `args.pretrained_path`, `args.finetuned_path` and `args.max_seq_length` through, and show the real `args.temperature` in the settings banner instead of a hardcoded `0.3`.

### Verification

Running `main()` with `--base_model MY/base-model-v9 --pretrained_path my_pretrained_dir --finetuned_path my_finetuned_dir --max_seq_length 4096`, recording what actually reaches the loaders:

**Before**

```
  [0] model='unsloth/mistral-7b-v0.3' max_seq_length=2048
  [1] model='lora_model_pretrained'   max_seq_length=2048
  [2] model='lora_model'              max_seq_length=2048
```

**After**

```
  [0] model='MY/base-model-v9'  max_seq_length=4096
  [1] model='my_pretrained_dir' max_seq_length=4096
  [2] model='my_finetuned_dir'  max_seq_length=4096
```

Defaults are unchanged, so an argument-less invocation behaves exactly as before. The sibling `evaluate_model.py` (`:248-252`) already threads these values through, which is the contract this restores.
