### PR TITLE
fix(chapter8): await the demos in interactive mode (nested asyncio.run made --interactive dead)

### DIFF
--- a/chapter8/gaia-experience/demo.py
+++ b/chapter8/gaia-experience/demo.py
@@ -297,7 +297,7 @@ class ExperienceLearningDemo:
             print(f"   - Learned experiences: {len(self.agent.experiences)}")
             print(f"   - Experience DB: {self.agent.experience_db_path}")
     
-    def run_interactive_mode(self):
+    async def run_interactive_mode(self):
         """Run interactive mode for testing."""
         print("\n" + "="*60)
         print("INTERACTIVE MODE")
@@ -314,13 +314,13 @@ class ExperienceLearningDemo:
                 choice = input("\nEnter command (1-5): ").strip()
                 
                 if choice == "1":
-                    asyncio.run(self.demo_knowledge_base_indexing())
+                    await self.demo_knowledge_base_indexing()
                 elif choice == "2":
-                    asyncio.run(self.demo_trajectory_summarization())
+                    await self.demo_trajectory_summarization()
                 elif choice == "3":
-                    asyncio.run(self.demo_experience_agent())
+                    await self.demo_experience_agent()
                 elif choice == "4":
-                    asyncio.run(self.demo_workflow())
+                    await self.demo_workflow()
                 elif choice == "5":
                     print("\nGoodbye!")
                     break
@@ -343,7 +343,7 @@ async def main():
     import sys
     if len(sys.argv) > 1:
         if sys.argv[1] == "--interactive":
-            demo.run_interactive_mode()
+            await demo.run_interactive_mode()
         elif sys.argv[1] == "--kb":
             await demo.demo_knowledge_base_indexing()
         elif sys.argv[1] == "--summarize":


### PR DESCRIPTION
Fixes #143

### Problem

`main()` is a coroutine launched with `asyncio.run(main())` (`:365`), but it called the **synchronous** `run_interactive_mode()`, whose menu handlers each started a second event loop:

```python
317:                    asyncio.run(self.demo_knowledge_base_indexing())
319:                    asyncio.run(self.demo_trajectory_summarization())
321:                    asyncio.run(self.demo_experience_agent())
323:                    asyncio.run(self.demo_workflow())
```

`asyncio.run()` inside a running loop raises `RuntimeError`, and the `except Exception` at `:333` converted that into a printed error — so the menu looped forever doing nothing, leaking a never-awaited coroutine each time.

`--interactive` is the documented primary entry point (`README.md:159-165`, `QUICKSTART.md:37`, `./run.sh demo` → `run.sh:188`). Options 1–4 all failed; only 5 (Exit) worked.

### Change

Make `run_interactive_mode` a coroutine, `await` the four demos directly, and `await` it from `main()`. The only remaining `asyncio.run` is the top-level one at `:365`.

### Verification

Driving the real `run_interactive_mode` from an `async main()` (mirroring `demo.py`'s own structure) with input `1`:

**Before**

```
LOG ERROR: Error in interactive mode: asyncio.run() cannot be called from a running event loop
❌ Error: asyncio.run() cannot be called from a running event loop
RuntimeWarning: coroutine 'demo_knowledge_base_indexing' was never awaited
run_interactive_mode is coroutine fn: False
```

**After**

```
run_interactive_mode is coroutine fn: True
>>> DEMO 1 RAN
```

The non-interactive flags (`--kb`, `--summarize`, …) already awaited correctly and are untouched.
