### PR TITLE
fix(chapter9): emit speech_start so barge-in actually fires (the client's interrupt handler was unreachable)

### DIFF
--- a/chapter9/live-audio/backend/server.js
+++ b/chapter9/live-audio/backend/server.js
@@ -228,7 +228,13 @@ class ConnectionHandler {
       const vadResults = await this.vad.processAudioChunk(audioChunk);
       
       for (const result of vadResults) {
-        if (result.type === 'speech_end') {
+        if (result.type === 'speech_start') {
+          // Barge-in: tell the client to stop playing the current answer.
+          this.ws.send(JSON.stringify({
+            type: 'speech_start',
+            timestamp: result.timestamp
+          }));
+        } else if (result.type === 'speech_end') {
           // Speech segment ended, process with STT
           await this.processSpeechSegment(result.audioData, result.duration);
         }

--- a/chapter9/live-audio/backend/utils/vad.js
+++ b/chapter9/live-audio/backend/utils/vad.js
@@ -171,6 +171,10 @@ class VoiceActivityDetector {
             this.speechStartTime = currentTime;
             this.speechBuffer = Buffer.alloc(0);
             console.log('Silero VAD: Speech started (prob:', speechProb.toFixed(3), ')');
+            // Emit the rising edge so the server can tell the client to barge
+            // in. Without this the client's 'speech_start' handler is dead and
+            // the assistant keeps talking over the user.
+            results.push({ type: 'speech_start', timestamp: currentTime });
           }
           
           this.lastSpeechTime = currentTime;


### PR DESCRIPTION
Fixes #150

### Problem

`README.md:275` promises barge-in, and the frontend implements it:

```js
// frontend/pages/index.tsx:195
case 'speech_start':
  handleInterrupt();     // stops playback, clears the echo worklet + audio queue
```

But nothing ever sent that message. The VAD detected the rising edge and only logged it — the only `results.push` calls were `speech_end` (`vad.js:194`, `:231`) — and `server.js:230` forwarded only `speech_end`.

```
$ grep -rn "speech_start" backend/ frontend/
  frontend/pages/index.tsx:195   <- WebSocket handler (never reached)
  frontend/pages/index.tsx:419   <- worklet handler (worklet never posts it either)
```

Both interrupt paths were dead: the browser worklet was deliberately stripped of VAD ("now using server-side Silero VAD only", `audioWorklet.js:6-7`) and now posts only raw PCM and `{type:'queue_empty'}`.

### Change

- `vad.js`: push `{ type: 'speech_start', timestamp }` on the rising edge.
- `server.js`: forward it over the WebSocket.

The client handler already exists and is untouched.

### Verification

Simulating the VAD state machine over a speech → silence → speech frame sequence, with the server dispatch applied:

```
before: ["processSpeechSegment() -> STT"]
after : ["ws.send speech_start -> handleInterrupt()",
         "processSpeechSegment() -> STT",
         "ws.send speech_start -> handleInterrupt()"]
```

The `speech_end` → STT path is unchanged — this only adds the previously-missing event. Both files pass `node --check`.

**Honest scope note:** end-to-end barge-in needs a microphone and live ASR/LLM/TTS keys, which I don't have, so the browser-side interruption itself is traced by reading rather than executed. What is demonstrated here is that the event is now emitted and forwarded, which is the missing link.

### Note on the two files

This touches `vad.js` (emit) and `server.js` (forward); the fix is meaningless with either half alone, so they belong in one change.
