### PR TITLE
fix(chapter8): skip already-indexed GAIA records (each run appended a full duplicate copy; search returned the same doc top_k times)

### DIFF
--- a/chapter8/gaia-experience/knowledge_base.py
+++ b/chapter8/gaia-experience/knowledge_base.py
@@ -121,6 +121,16 @@ class KnowledgeBase:
         
         logger.info(f"Indexing GAIA validation data from {validation_file}")
         
+        # The index is persisted and reloaded by __init__ (_load_index), so
+        # without this every run appends another full copy of the dataset and
+        # search() starts returning the same document top_k times.
+        existing_ids = {
+            doc.get('task_id')
+            for doc in self.documents
+            if doc.get('source') == 'gaia_validation'
+        }
+        skipped = 0
+        
         try:
             with open(validation_file, 'r', encoding='utf-8') as f:
                 for line_num, line in enumerate(f, 1):
@@ -133,9 +143,14 @@ class KnowledgeBase:
                         level = data.get('Level', 0)
                         metadata = data.get('Annotator Metadata', {})
                         
+                        task_id = data.get('task_id', f'gaia_{line_num}')
+                        if task_id in existing_ids:
+                            skipped += 1
+                            continue
+                        
                         # Create experience document
                         experience = {
-                            'task_id': data.get('task_id', f'gaia_{line_num}'),
+                            'task_id': task_id,
                             'question': question,
                             'answer': answer,
                             'level': level,
@@ -148,6 +163,7 @@ class KnowledgeBase:
                         
                         # Add to index
                         self.add_experience(question, experience)
+                        existing_ids.add(task_id)
                         
                     except json.JSONDecodeError as e:
                         logger.error(f"Failed to parse line {line_num}: {e}")
@@ -156,6 +172,8 @@ class KnowledgeBase:
             
             # Save the index after bulk indexing
             self._save_index()
+            if skipped:
+                logger.info(f"Skipped {skipped} GAIA records already present in the index")
             logger.info(f"Successfully indexed {len(self.documents)} experiences from GAIA validation")
             
         except Exception as e:


### PR DESCRIPTION
Fixes #144

### Problem

`__init__` reloads the persisted index (`_load_index`, `:57`), and `index_gaia_validation()` then re-added every record unconditionally and re-saved (`:150`, `:158`) — no dedupe on `task_id` or anything else. So each run appended another full copy of the dataset.

`search()` (`:270-272`) does not dedupe either, so retrieval degrades to returning the same document repeatedly.

### Change

Collect the already-indexed `task_id`s before the loop, skip those records, and log how many were skipped.

### Verification

Three consecutive runs against one persisted `--kb-path`, using the repo's own `gaia-validation.jsonl` (real `KnowledgeBase` and real FAISS; only the sentence-transformer is replaced with a deterministic stub encoder so no model download is needed):

**Before**

```
run #1: total_documents= 165   top-3 task_ids=['c61d22de', '50ad0280', 'ec09fa32']
run #2: total_documents= 330   top-3 task_ids=['c61d22de', 'c61d22de', '50ad0280']
run #3: total_documents= 495   top-3 task_ids=['c61d22de', 'c61d22de', 'c61d22de']
```

By run 3 a `top_k=3` query returns three copies of one experience, so `ExperienceAgent._get_relevant_experiences()` injects the same experience three times instead of three distinct ones.

**After**

```
run #1: total_documents= 165   top-3 task_ids=['c61d22de', '50ad0280', 'ec09fa32']
run #2: total_documents= 165   top-3 task_ids=['c61d22de', '50ad0280', 'ec09fa32']
run #3: total_documents= 165   top-3 task_ids=['c61d22de', '50ad0280', 'ec09fa32']
```

First-run behaviour is identical, so a fresh index is unaffected.

### Why it matters by default

`run.sh` passes `--preload-kb` for both `./run.sh apply` (`:211-218`) and `./run.sh full` (`:231-240`) unless `--no-preload` is given, and nothing ever clears `kb_index/` — so this triggers on the second normal invocation, not in an edge case. Each rerun also recomputed 164 embeddings and grew the on-disk index.
