### PR TITLE
fix(chapter4): make the HEAD size pre-check best-effort (a 405/403 HEAD aborted downloads GET could serve)

### DIFF
--- a/chapter4/perception-tools/src/base.py
+++ b/chapter4/perception-tools/src/base.py
@@ -93,18 +93,24 @@ def download_file_from_url(
     """
     max_size_bytes = max_size_mb * 1024 * 1024
     
+    # Best-effort size pre-check. Many hosts refuse HEAD (presigned S3/GCS URLs
+    # sign the verb and return 403; CDN/WAF-fronted endpoints often return 405),
+    # so a failed HEAD must not abort a download that GET can serve -- the
+    # streaming loop below enforces max_size_bytes either way.
     try:
-        # Check content length first
         head_response = requests.head(url, timeout=timeout, allow_redirects=True)
         head_response.raise_for_status()
-        
         content_length = head_response.headers.get("content-length")
-        if content_length and int(content_length) > max_size_bytes:
-            raise ValueError(
-                f"File size ({int(content_length) / (1024 * 1024):.2f} MB) "
-                f"exceeds maximum allowed size ({max_size_mb} MB)"
-            )
-        
+    except requests.RequestException:
+        content_length = None
+
+    if content_length and int(content_length) > max_size_bytes:
+        raise ValueError(
+            f"File size ({int(content_length) / (1024 * 1024):.2f} MB) "
+            f"exceeds maximum allowed size ({max_size_mb} MB)"
+        )
+
+    try:
         # Download the file
         response = requests.get(url, timeout=timeout, stream=True)
         response.raise_for_status()
@@ -129,5 +135,8 @@ def download_file_from_url(
         
     except requests.RequestException as e:
         raise requests.RequestException(f"Failed to download file from URL: {e}")
+    except ValueError:
+        # Documented in the docstring; must not be rewrapped as IOError.
+        raise
     except Exception as e:
         raise IOError(f"Error downloading file: {e}")


### PR DESCRIPTION
Fixes #147

### Problem

The HEAD size pre-check sat inside the main `try` and called `raise_for_status()`:

```python
 96:    try:
 98:        head_response = requests.head(url, timeout=timeout, allow_redirects=True)
 99:        head_response.raise_for_status()
...
130:    except requests.RequestException as e:
131:        raise requests.RequestException(f"Failed to download file from URL: {e}")
```

so a non-2xx **HEAD** aborted the function and the GET was never attempted — even though the streaming loop already enforces the cap independently:

```python
113:        for chunk in response.iter_content(chunk_size=8192):
114:            if len(content) + len(chunk) > max_size_bytes:
115:                raise ValueError(...)
```

Hosts that refuse HEAD are common: presigned S3/GCS URLs sign the HTTP verb and return 403, and CDN/WAF-fronted or dynamic endpoints often return 405. That broke all four URL-consuming tools — `download` (`search_tools.py:193`), `document_reader`, `image_parser`, `video_parser` (`multimodal_tools.py:126/237/313`).

Second, smaller problem: the documented `ValueError` never escaped — it was swallowed by the bare `except Exception` and rewrapped as `IOError`, contradicting the docstring at `:90-91` and leaving callers unable to distinguish "too big" from "network failed".

### Change

- Treat the HEAD as best-effort: catch `RequestException` around it and fall through with `content_length = None`.
- Perform the size comparison outside that try, so a genuine over-limit still raises `ValueError`.
- Re-raise `ValueError` explicitly before the generic `except Exception`.

### Verification

Against a local server that returns 405 for HEAD and 200 for GET:

**Before**

```
plain GET works? 200 459 bytes
download_file_from_url: RAISED RequestException: Failed to download file from URL: 405 Client Error: Method Not Allowed
size limit: RequestException instead of ValueError
```

**After**

```
plain GET works? 200 459 bytes
download_file_from_url: OK -> 459 bytes
size limit: ValueError (as documented): File size exceeds maximum allowed size (0.1 MB)
```

The second line of each run is the same 300 KB download against a `max_size_mb=0.1` cap, confirming the limit is still enforced — now via the streaming loop, and surfacing as the documented exception type.
