### PR TITLE
fix(chapter4): sniff document type by magic bytes (arXiv PDF URLs failed as "Unsupported file type: .07041v1")

### DIFF
--- a/chapter4/perception-tools/src/multimodal_tools.py
+++ b/chapter4/perception-tools/src/multimodal_tools.py
@@ -6,7 +6,7 @@ import logging
 import os
 import traceback
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 import base64
 
 import requests
@@ -105,6 +105,31 @@ async def read_webpage(
         )
 
 
+def _sniff_document_type(path: Path) -> Optional[str]:
+    """Detect .pdf/.docx/.pptx from magic bytes when the extension is unusable.
+
+    A URL's path often carries no real extension (e.g.
+    https://arxiv.org/pdf/2301.07041 -> ".07041"), so the downloaded temp
+    file's suffix cannot be trusted to identify the format.
+    """
+    try:
+        with open(path, 'rb') as f:
+            header = f.read(4)
+        if header.startswith(b'%PDF'):
+            return '.pdf'
+        if header.startswith(b'PK\x03\x04'):
+            import zipfile
+            with zipfile.ZipFile(path) as zf:
+                names = zf.namelist()
+            if any(n.startswith('word/') for n in names):
+                return '.docx'
+            if any(n.startswith('ppt/') for n in names):
+                return '.pptx'
+    except Exception as e:
+        logging.debug(f"Document type sniffing failed: {e}")
+    return None
+
+
 async def read_document(
     file_path: str,
     extract_images: bool = False
@@ -131,6 +156,10 @@ async def read_document(
         logging.info(f"📄 Reading document: {path}")
         
         file_ext = path.suffix.lower()
+        if file_ext not in ('.pdf', '.docx', '.pptx'):
+            # The suffix came from the URL path and may be meaningless
+            # (".07041", ".tmp"), so fall back to the file's magic bytes.
+            file_ext = _sniff_document_type(path) or file_ext
         
         # PDF extraction
         if file_ext == '.pdf':


### PR DESCRIPTION
Fixes #148

### Problem

`read_document` accepts a URL, downloads it, and then typed it purely from the temp file's suffix:

```python
133:        file_ext = path.suffix.lower()
...
188:            raise ValueError(f"Unsupported file type: {file_ext}")
```

That suffix comes from the *URL path* (`base.py:121-122`), which for extension-less document URLs is meaningless:

```
https://arxiv.org/pdf/2301.07041   -> '.07041'
http://arxiv.org/pdf/2301.07041v1  -> '.07041v1'
https://host/download?id=42        -> '.tmp'
https://host/paper.pdf             -> '.pdf'
```

The HTTP `Content-Type` and the file's magic bytes were both ignored, and the downloaded bytes were discarded as `_`.

This project hands the agent exactly those arXiv URLs as `pdf_url` (`public_data_tools.py:412`, `arxiv_enhanced.py:52`), so "search arXiv → read the paper" was a broken two-step.

### Change

Add `_sniff_document_type()` — `%PDF` → `.pdf`, `PK\x03\x04` plus a `word/` or `ppt/` member → `.docx` / `.pptx` — and use it only when the suffix is not already one of the three supported extensions.

### Verification

Against a local server returning a real 5-page PDF with `Content-Type: application/pdf`:

**Before**

```
/pdf/2301.07041     -> FAIL  Document reading failed: Unsupported file type: .07041
/pdf/2301.07041v1   -> FAIL  Document reading failed: Unsupported file type: .07041v1
/download?id=42     -> FAIL  Document reading failed: Unsupported file type: .tmp
/paper.pdf          -> OK    {"file_type": "pdf", "page_count": 5, ...}
```

**After**

```
/pdf/2301.07041     -> OK    {"file_name": "tmpavzdi46j.07041",   "file_type": "pdf", "page_count": 5}
/pdf/2301.07041v1   -> OK    {"file_name": "tmpa0ljya3p.07041v1", "file_type": "pdf", "page_count": 5}
/download?id=42     -> OK    {"file_name": "tmp3pdeemux.tmp",     "file_type": "pdf", "page_count": 5}
/paper.pdf          -> OK    {"file_name": "tmpy0bvm46j.pdf",     "file_type": "pdf", "page_count": 5}
```

The `.pdf` path is unchanged — the sniff only runs when the extension is already unusable, so correctly-named files never pay for it.

### Note

Using the response's `Content-Type` would also work; I went with magic bytes because it additionally handles servers that mislabel the type. Happy to switch if you'd prefer the header.

There is a related temp-file leak in these functions (`read_document` / `parse_image` / `parse_video` never unlink the download, unlike `search_tools.py:200`) — I left it out to keep this change focused, and can send it separately.
