### PR TITLE
fix(chapter9): send the preprocessed text to TTS (textProcessor.js output was computed then discarded)

### DIFF
--- a/chapter9/live-audio/backend/server.js
+++ b/chapter9/live-audio/backend/server.js
@@ -750,7 +750,7 @@ class ConnectionHandler {
           url: config.TTS_API_URL,
           data: {
             "model": (config.TTS_PROVIDERS?.[config.TTS_PROVIDER]?.model) || "FunAudioLLM/CosyVoice2-0.5B",
-            "input": text,
+            "input": processedText,
             "voice": (config.TTS_PROVIDERS?.[config.TTS_PROVIDER]?.voice) || "FunAudioLLM/CosyVoice2-0.5B:diana",
             "response_format": "mp3",
             "sample_rate": 32000,


### PR DESCRIPTION
Fixes #159

### Problem

```js
729:        const processedText = preprocessSentence(text, detectedLang);
730:        // Skip TTS if processed text is empty
731:        if (!processedText.trim()) {
...
753:            "input": text,          // <-- raw, not processedText
```

`processedText` was used only as an emptiness gate and then discarded, so the synthesizer received the untouched sentence — markdown, emoji, `%`, bracketed link text plus the full URL.

That also makes the whole 187-line `textProcessor.js` dead at runtime: it runs on every TTS request and its output is thrown away. `grep -rn preprocessSentence` returns exactly two hits — the import at `server.js:6` and this call site.

### Change

One line: send `processedText`.

### Verification

What the API now receives, running the real `preprocessSentence`:

```
sent BEFORE: "Sure! Here is the **fix**: use `arr.slice(0, n)` instead."
sent AFTER : "Sure! Here is the fix: use arr dot slice left parenthesis zero comma  n right parenthesis  instead."

sent BEFORE: "Great question 😀 — the cost is 25% of the total."
sent AFTER : "Great question   — the cost is twenty five percent  of the total."

sent BEFORE: "See [the docs](https://example.com/a_b_c) for more."
sent AFTER : "See the docs for more."
```

The emptiness gate at `:731` is unchanged, so sentences that preprocess to nothing are still skipped.

### Why this wasn't intentional

One could read `preprocessSentence` as *only* an emptiness gate. The module's contents rule that out: `pronounceNumbers` and `pronounceSpecialCharacters` **lengthen** text (`"25%"` → `"twenty five percent"`, `"@"` → `" at "`), which can only work *against* an emptiness check. A `numberToWords()` implementation and a 21-entry pronunciation map are not written to compute a boolean.

### Related

This unmasks #161 (`pronounceNumbers` turns a sentence-final `"42."` into `"forty two point "`), which is currently invisible precisely because the preprocessed text is discarded. That fix is up separately — worth landing alongside or just before this one.
