### PR TITLE
fix(chapter9): stop appending the trailing sentence twice (duplicated text on screen and in the replayed history)

### DIFF
--- a/chapter9/live-audio/backend/server.js
+++ b/chapter9/live-audio/backend/server.js
@@ -502,7 +502,10 @@ class ConnectionHandler {
           // Handle any remaining content
           if (currentSentence.trim()) {
             await this.synthesizeAndStreamAudio(currentSentence);
-            accumulatedContent += currentSentence;
+            // NOTE: do NOT add currentSentence to accumulatedContent here.
+            // Every token already did `accumulatedContent += content` as it
+            // arrived, so adding the trailing fragment again duplicates it in
+            // the message the user sees and in the history replayed to the LLM.
             
             // Update message history with final content
             const lastMessage = this.messageHistory[this.messageHistory.length - 1];


### PR DESCRIPTION
Fixes #160

### Problem

Every streamed token already accumulated into both variables:

```js
442:              currentSentence += content;
443:              accumulatedContent += content;
```

(and the same pair again at `:490-491` in the stream-`end` buffer handler). `currentSentence` is reset to `''` whenever a sentence completes (`:452`), so at stream end it holds exactly the trailing fragment — which `accumulatedContent` already contains. The end handler then added it a second time:

```js
497:          if (currentSentence.trim()) {
498:            await this.synthesizeAndStreamAudio(currentSentence);
499:            accumulatedContent += currentSentence;
```

### Impact

`accumulatedContent` is written to `messageHistory` (`:503`), which is both rendered to the user via `chat_history_delta` **and** replayed into the next LLM request (`:360-363`). So the duplication showed on screen and poisoned the conversation context for every subsequent turn.

It fires whenever a reply doesn't end on a boundary `isCompleteSentence()` recognises — most replies ending in a list item, a bare clause, or a number+period (`:550` explicitly rejects that last case).

### Change

Drop the second append. `synthesizeAndStreamAudio(currentSentence)` still runs, so the trailing audio is unaffected.

### Verification

```
produced: "Sure! Here you go: apple"
  before : "Sure! Here you go: appleHere you go: apple"   *** DUPLICATED ***
  after  : "Sure! Here you go: apple"                     OK

produced: "Done. Anything else"
  before : "Done. Anything elseAnything else"             *** DUPLICATED ***
  after  : "Done. Anything else"                          OK

produced: "Step 1. Open the door"
  before : "Step 1. Open the doorOpen the door"           *** DUPLICATED ***
  after  : "Step 1. Open the door"                        OK

produced: "Yes."
  before : "Yes."                                         OK  (already correct)
  after  : "Yes."                                         OK
```

The reply that already ended on a sentence boundary is unchanged, confirming this only removes the double-count.

### Note

This touches `server.js` like #164, but a different hunk (~line 499 vs ~753); they are independent changes and both report mergeable.
