### PR TITLE
fix(chapter9): don't treat a sentence-final period as a decimal point ("42." was spoken as "forty two point")

### DIFF
--- a/chapter9/live-audio/backend/utils/textProcessor.js
+++ b/chapter9/live-audio/backend/utils/textProcessor.js
@@ -143,7 +143,10 @@ function pronounceSpecialCharacters(text, isCodeBlock = false) {
 function pronounceNumbers(text, language) {
   if (language.startsWith('zh')) return text;
 
-  return text.replace(/(\d+\.?\d*)/g, match => {
+  // Only consume the '.' when it is a real decimal point (digits follow).
+  // The old /(\d+\.?\d*)/ also matched "42." at the end of a sentence, which
+  // ate the period and emitted a dangling "point".
+  return text.replace(/\d+(?:\.\d+)?/g, match => {
     const num = parseFloat(match);
     if (isNaN(num)) return match;
     


### PR DESCRIPTION
Fixes #161

### Problem

```js
146:  return text.replace(/(\d+\.?\d*)/g, match => {
150:    if (match.includes('.')) {
151:      const [integer, decimal] = match.split('.');
152:      return `${numberToWords(parseInt(integer))} point ${decimal.split('')...join(' ')}`;
```

Both the dot and the fractional digits were optional, so `"42."` at the end of a sentence matched in full. `match.includes('.')` was then true, `decimal` was `''`, and the branch emitted `"forty two point "` — the period was consumed by the match and never re-emitted, so the sentence boundary went with it.

`parseFloat("42.")` is `42`, not `NaN`, so the guard at `:148` didn't catch it, and `pronounceSpecialCharacters` only restores `.` when `isCodeBlock === true` (`:133`), which `preprocessSentence` never passes (`:180`).

### Change

Require digits after the dot: `/\d+(?:\.\d+)?/g`.

### Verification

Real `preprocessSentence` from before and after:

```
"The answer is 42."                        before "The answer is forty two point"          after "The answer is forty two."            <-- FIXED
"The answer is 42. It is the meaning…"     before "…forty two point  It is the meaning…"   after "…forty two. It is the meaning…"      <-- FIXED
"I will be there at 5."                    before "I will be there at five point"          after "I will be there at five."            <-- FIXED
"Step 1. Open the door."                   before "Step one point  Open the door."         after "Step one. Open the door."            <-- FIXED

"It costs 19.99 dollars."                  before/after "It costs nineteen point nine nine dollars."      (unchanged)
"Version 2.5 is out."                      before/after "Version two point five is out."                  (unchanged)
"Pi is about 3.14159 exactly."             before/after "Pi is about three point one four one five nine exactly."  (unchanged)
"1000000 people."                          before/after "one million people."                             (unchanged)
```

Every genuine decimal is byte-identical — only the sentence-final case changes.

### Ordering note

This was invisible in practice until #164, because `preprocessSentence`'s output was discarded before reaching the TTS API. With that fixed, this becomes audible — so these two want landing together, or this one first.
