### PR TITLE
fix(chapter7): set save_total_limit = 5 to match the "only the 5 most recent checkpoints" message

### DIFF
--- a/chapter7/continued-pretraining/continued-pretrain.py
+++ b/chapter7/continued-pretraining/continued-pretrain.py
@@ -336,6 +336,10 @@ trainer = UnslothTrainer(
         # Checkpoint saving
         save_strategy = "steps",
         save_steps = 100,
+        # Keep only the 5 most recent checkpoints, as the banner above
+        # promises. Without this HF keeps every one, and a ~2000-step run
+        # writes ~20 LoRA+optimizer checkpoints (fills a free-Colab disk).
+        save_total_limit = 5,
         
         # WandB configuration
         report_to = "wandb",
@@ -464,6 +468,10 @@ trainer = UnslothTrainer(
         # Checkpoint saving
         save_strategy = "steps",
         save_steps = 100,
+        # Keep only the 5 most recent checkpoints, as the banner above
+        # promises. Without this HF keeps every one, and a ~2000-step run
+        # writes ~20 LoRA+optimizer checkpoints (fills a free-Colab disk).
+        save_total_limit = 5,
         
         # WandB configuration
         report_to = "wandb",


### PR DESCRIPTION
Fixes #163

### Problem

Both stages print a retention promise:

```python
300:print(f"Only the 5 most recent checkpoints will be kept{Colors.ENDC}")
432:print(f"Only the 5 most recent checkpoints will be kept{Colors.ENDC}")
```

but `grep -n save_total_limit continued-pretrain.py` returned **zero hits** — neither `UnslothTrainingArguments` block set it. HuggingFace's default is `None`, meaning keep every checkpoint, and both stages save every 100 steps (`:338`, `:466`).

On a ~2000-step run that is roughly 20 checkpoint directories per stage instead of 5, each holding LoRA adapter weights plus optimizer state. The README targets free Colab, where the disk fills mid-run and the job dies after hours of training — with the console having told the user this was handled.

### Change

`save_total_limit = 5` in both blocks, next to the existing `save_steps = 100`.

### Verification

```
$ grep -c "Only the 5 most recent checkpoints will be kept"  -> 2
$ grep -c "save_total_limit = 5,"                            -> 2

300: print("Only the 5 most recent checkpoints will be kept")
338:         save_steps = 100,
342:         save_total_limit = 5,
432: print("Only the 5 most recent checkpoints will be kept")
470:         save_steps = 100,
474:         save_total_limit = 5,
```

Each stage's message now matches its own configuration. File parses clean.
