### PR TITLE
fix(chapter2): cancel the attention-render rAF chain on re-run (zooming mid-render superimposed two heatmaps)

### DIFF
--- a/chapter2/attention_visualization/frontend/components/AttentionModal.tsx
+++ b/chapter2/attention_visualization/frontend/components/AttentionModal.tsx
@@ -94,8 +94,16 @@ export default function AttentionModal({ isOpen, onClose, tokens, attentionWeigh
     setIsRendering(true);
     setRenderError(null);
 
+    // A zoom / transform change re-runs this effect. Without cancelling, the
+    // previous rAF chain keeps painting the same canvas at its stale cellSize
+    // while the new one resizes (and so clears) the bitmap, superimposing two
+    // differently-scaled heatmaps.
+    let cancelled = false;
+    let rafId = 0;
+
     // Use requestAnimationFrame for smooth rendering
-    requestAnimationFrame(() => {
+    rafId = requestAnimationFrame(() => {
+      if (cancelled) return;
       try {
         const canvas = canvasRef.current;
         if (!canvas) return;
@@ -149,6 +157,7 @@ export default function AttentionModal({ isOpen, onClose, tokens, attentionWeigh
         let currentRow = 0;
 
         const drawChunk = () => {
+          if (cancelled) return;
           const endRow = Math.min(currentRow + chunkSize, numRows);
           
           for (let i = currentRow; i < endRow; i++) {
@@ -183,7 +192,7 @@ export default function AttentionModal({ isOpen, onClose, tokens, attentionWeigh
           
           // Continue with next chunk if not done
           if (currentRow < numRows) {
-            requestAnimationFrame(drawChunk);
+            rafId = requestAnimationFrame(drawChunk);
           } else {
             // Drawing complete, add labels and legend
             drawLabelsAndLegend();
@@ -268,6 +277,11 @@ export default function AttentionModal({ isOpen, onClose, tokens, attentionWeigh
         setIsRendering(false);
       }
     });
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(rafId);
+    };
 
   }, [isOpen, tokens, attentionWeights, zoomLevel, transformMethod, transformAttention]);
 


### PR DESCRIPTION
Fixes #162

### Problem

The chunked `requestAnimationFrame` chain had no cleanup:

```js
 98:    requestAnimationFrame(() => {          // return value discarded
121:      canvas.width = width;                // resizing clears the bitmap
186:            requestAnimationFrame(drawChunk);
272:  }, [isOpen, tokens, attentionWeights, zoomLevel, transformMethod, transformAttention]);
```

The effect body contains no `return`, and `cancelAnimationFrame` appears nowhere in the file — while `zoomLevel` and `transformMethod` are dependencies. So a zoom click re-ran the effect and started a **second** chain while the first was still painting.

The new chain's `canvas.width = width` wipes what the old one drew; the old chain then keeps painting at its stale `cellSize` into the new canvas. It also finishes by calling `drawLabelsAndLegend()` — painting misaligned axis titles into the margin regions the cell loop never repaints — and `setIsRendering(false)`, clearing the "(Rendering…)" indicator while the live render is still going.

Triggers on any matrix bigger than one chunk (`chunkSize = Math.max(50, Math.floor(100 / zoomLevel))`, so >100 rows at 100% zoom — which is why the chunking exists) when the user clicks Zoom In/Out/100% or changes Transform mid-render.

### Change

Track the rAF id, bail out of `drawChunk` when cancelled, and return a cleanup that sets the flag and cancels the pending frame. This also covers unmount (closing the modal), not just re-runs.

### Verification

Simulating the chain against a fake rAF queue — 500-row matrix, zoom clicked 2 frames in:

```
BEFORE chain#1 paints AFTER chain#2 cleared the canvas: 2
BEFORE setIsRendering(false) fired by: [chain#1, chain#2]

AFTER  chain#1 paints AFTER chain#2 cleared the canvas: 0
AFTER  setIsRendering(false) fired by: [chain#2]
```

So the superimposed painting stops, and the rendering indicator is cleared once, by the chain that actually finished.

**Scope note:** this is a simulation of the effect's control flow, not a browser run — I don't have the trajectory data plus a DOM to drive the real component. The hook lifecycle itself (effect re-runs on `zoomLevel` change, no existing cleanup) was established by reading the file.
