### PR TITLE
fix(cost): keep tool_ctx_tokens 0 distinct from unknown

### DIFF
--- a/chapter6/agent-cost-analysis/test_trace_offline.py
+++ b/chapter6/agent-cost-analysis/test_trace_offline.py
@@ -59,6 +59,14 @@ def test_from_records_keeps_real_values():
     assert s.latency_s == 1.2
 
 
+def test_from_records_keeps_zero_tool_ctx_tokens():
+    """Explicit 0 means known-zero tool context, not unknown (-1)."""
+    tr = Tracer.from_records([_span(tool_ctx_tokens=0)],
+                             pricing=config.default_pricing())
+    assert tr.spans[0].tool_ctx_tokens == 0
+    assert tr.total_tool_ctx_tokens() == 0
+
+
 def _write_trace(tmp_path, scenarios):
     path = tmp_path / "trace.json"
     path.write_text(json.dumps({"model": "gpt-5.6-luna", "scenarios": scenarios}),

--- a/chapter6/agent-cost-analysis/tracer.py
+++ b/chapter6/agent-cost-analysis/tracer.py
@@ -114,11 +114,12 @@ class Tracer:
                 step=r.get("step", ""),
                 tool=r.get("tool", ""),
                 kind=r.get("kind", "llm"),
-                # 防御：trace JSON 里字段缺失或显式为 null 时按 0（tool_ctx 按未知 -1）处理
+                # Missing/null tool_ctx → -1 (unknown); keep explicit 0 (known-zero).
                 prompt_tokens=int(r.get("prompt_tokens") or 0),
                 cached_tokens=int(r.get("cached_tokens") or 0),
                 completion_tokens=int(r.get("completion_tokens") or 0),
-                tool_ctx_tokens=int(r.get("tool_ctx_tokens") or -1),
+                tool_ctx_tokens=(-1 if r.get("tool_ctx_tokens") is None
+                                 else int(r.get("tool_ctx_tokens"))),
                 latency_s=float(r.get("latency_s") or 0.0),
             )
             span.cost_usd = tr.pricing.cost_usd(


### PR DESCRIPTION
Tracer.from_records used `int(r.get("tool_ctx_tokens") or -1)`, so an explicit 0 (known-zero tool context) became -1 (unknown).

Offline replay of a span that recorded tool_ctx_tokens=0 then treated it as missing. Coerce only null/missing to -1; keep 0.