### PR TITLE
fix(sanitize): redact empty-user URL credentials

### DIFF
--- a/chapter2/log-sanitization/regex_sanitizer.py
+++ b/chapter2/log-sanitization/regex_sanitizer.py
@@ -74,7 +74,7 @@ _RULES = [
     (
         # 连接串中的口令，如 postgres://user:PASSWORD@host:5432/db
         "url_credential", "[REDACTED_URL_CRED]",
-        re.compile(r"://[^\s:/@]+:([^\s@]+)@"),
+        re.compile(r"://[^\s:/@]*:([^\s@]+)@"),
         1, None,
     ),
     (

--- a/chapter2/log-sanitization/test_url_credential_empty_user.py
+++ b/chapter2/log-sanitization/test_url_credential_empty_user.py
@@ -1,0 +1,22 @@
+"""Regression: URL credentials with an empty username must be redacted."""
+from regex_sanitizer import sanitize
+
+
+def test_redis_empty_user_password_redacted():
+    text, hits = sanitize("redis://:secretpass@10.0.0.1:6379/0")
+    assert "secretpass" not in text
+    assert "[REDACTED_URL_CRED]" in text
+    assert any(h["category"] == "url_credential" for h in hits)
+
+
+def test_postgres_empty_user_password_redacted():
+    text, hits = sanitize("DATABASE_URL=postgres://:hunter2@localhost:5432/db")
+    assert "hunter2" not in text
+    assert "[REDACTED_URL_CRED]" in text
+    assert any(h["category"] == "url_credential" for h in hits)
+
+
+def test_named_user_password_still_redacted():
+    text, hits = sanitize("redis://default:secretpass@10.0.0.1:6379/0")
+    assert "secretpass" not in text
+    assert "[REDACTED_URL_CRED]" in text


### PR DESCRIPTION
Connection strings like `redis://:password@host` left the password in the clear because the credential regex required a non-empty username.

Allow an empty username so password-only Redis/Postgres URLs redact like named-user ones.