### PR TITLE
fix(evaluate): tolerate empty test sets in parse rate

### DIFF
--- a/chapter8/prompt-distillation/eval_metrics.py
+++ b/chapter8/prompt-distillation/eval_metrics.py
@@ -1,6 +1,0 @@
-"""Small evaluation metrics helpers (no model deps)."""
-
-
-def parse_rate(predicted: int, total: int) -> float:
-    """Fraction of samples with a parseable prediction; empty total -> 0.0."""
-    return predicted / total if total > 0 else 0.0

--- a/chapter8/prompt-distillation/eval_metrics.py
+++ b/chapter8/prompt-distillation/eval_metrics.py
@@ -1,0 +1,6 @@
+"""Small evaluation metrics helpers (no model deps)."""
+
+
+def parse_rate(predicted: int, total: int) -> float:
+    """Fraction of samples with a parseable prediction; empty total -> 0.0."""
+    return predicted / total if total > 0 else 0.0

--- a/chapter8/prompt-distillation/evaluate.py
+++ b/chapter8/prompt-distillation/evaluate.py
@@ -16,11 +16,14 @@ from pathlib import Path
 from typing import List, Dict, Optional
 from collections import defaultdict
 
+from eval_metrics import parse_rate
+
 import torch
 import numpy as np
 from transformers import AutoTokenizer, AutoModelForCausalLM
 from peft import PeftModel
 from tqdm import tqdm
+
 
 
 def load_model(model_path: str, base_model: str = "Qwen/Qwen3-30B-A3B-Instruct-2507"):
@@ -442,7 +445,8 @@ def main():
     print(f"  Total samples: {results['total']}")
     print(f"  Successfully predicted: {results['predicted']}")
     print(f"  Unparseable responses: {results['unparseable']}")
-    print(f"  Parse rate: {results['predicted']/results['total']*100:.2f}%")
+    rate = parse_rate(results["predicted"], results["total"])
+    print(f"  Parse rate: {rate * 100:.2f}%")
     
     if "accuracy" in results:
         print(f"\n  Overall Accuracy: {results['accuracy']*100:.2f}%")
@@ -460,7 +464,7 @@ def main():
             "total_samples": results["total"],
             "predicted": results["predicted"],
             "unparseable": results["unparseable"],
-            "parse_rate": results["predicted"]/results["total"] if results["total"] > 0 else 0,
+            "parse_rate": parse_rate(results["predicted"], results["total"]),
         },
         "predictions": results["predictions"],
     }

--- a/chapter8/prompt-distillation/evaluate.py
+++ b/chapter8/prompt-distillation/evaluate.py
@@ -16,14 +16,11 @@ from pathlib import Path
 from typing import List, Dict, Optional
 from collections import defaultdict
 
-from eval_metrics import parse_rate
-
 import torch
 import numpy as np
 from transformers import AutoTokenizer, AutoModelForCausalLM
 from peft import PeftModel
 from tqdm import tqdm
-
 
 
 def load_model(model_path: str, base_model: str = "Qwen/Qwen3-30B-A3B-Instruct-2507"):
@@ -44,11 +41,14 @@ def load_model(model_path: str, base_model: str = "Qwen/Qwen3-30B-A3B-Instruct-2
     
     return model, tokenizer
 
+def compute_parse_rate(predicted: int, total: int) -> float:
+    """Parseable prediction rate; empty total is 0.0 (not ZeroDivisionError)."""
+    return predicted / total if total > 0 else 0.0
+
 
 def format_pred_label(pred_label: Optional[str]) -> str:
     """Display token for progress lines when the model reply is unparseable."""
     return pred_label or "??"
-
 
 def parse_language_label(response: str) -> Optional[str]:
     """Extract the language label from model response."""
@@ -74,7 +74,6 @@ def parse_language_label(response: str) -> Optional[str]:
         return response
     
     return None
-
 
 def evaluate_model(
     model,
@@ -178,7 +177,6 @@ def evaluate_model(
     
     return results
 
-
 def build_confusion_matrix(predictions: List[str], ground_truth: List[str], 
                            sentences: List[str]) -> Dict:
     """
@@ -251,7 +249,6 @@ def build_confusion_matrix(predictions: List[str], ground_truth: List[str],
         "all_languages_sorted": sorted_languages,  # All languages sorted by accuracy
     }
 
-
 def print_confusion_matrix(confusion_data: Dict):
     """Pretty print confusion matrix and analysis."""
     print("\n" + "="*80)
@@ -320,7 +317,6 @@ def print_confusion_matrix(confusion_data: Dict):
                 print(f"     - Predicted {pred_lang} (should be {lang}): {sentence_preview}")
     
     print("\n" + "="*80)
-
 
 def main():
     parser = argparse.ArgumentParser(
@@ -445,7 +441,7 @@ def main():
     print(f"  Total samples: {results['total']}")
     print(f"  Successfully predicted: {results['predicted']}")
     print(f"  Unparseable responses: {results['unparseable']}")
-    rate = parse_rate(results["predicted"], results["total"])
+    rate = compute_parse_rate(results["predicted"], results["total"])
     print(f"  Parse rate: {rate * 100:.2f}%")
     
     if "accuracy" in results:
@@ -464,7 +460,7 @@ def main():
             "total_samples": results["total"],
             "predicted": results["predicted"],
             "unparseable": results["unparseable"],
-            "parse_rate": parse_rate(results["predicted"], results["total"]),
+            "parse_rate": compute_parse_rate(results["predicted"], results["total"]),
         },
         "predictions": results["predictions"],
     }
@@ -523,7 +519,6 @@ def main():
         json.dump(output, f, indent=2, ensure_ascii=False)
     print(f"\n📁 Complete results saved to: {args.output_file}")
     print(f"   Includes: predictions, confusion matrix, per-language stats, error examples")
-
 
 if __name__ == "__main__":
     main()

--- a/chapter8/prompt-distillation/test_evaluate_empty_parse_rate.py
+++ b/chapter8/prompt-distillation/test_evaluate_empty_parse_rate.py
@@ -1,10 +1,25 @@
 """Regression: empty test set must not ZeroDivisionError on parse-rate summary."""
-from eval_metrics import parse_rate
+import sys
+import types
 
 
-def test_parse_rate_empty_total_is_zero():
-    assert parse_rate(0, 0) == 0.0
+def _stub_evaluate_deps() -> None:
+    for name in ["torch", "numpy", "transformers", "peft", "tqdm"]:
+        sys.modules.setdefault(name, types.ModuleType(name))
+    sys.modules["transformers"].AutoTokenizer = object
+    sys.modules["transformers"].AutoModelForCausalLM = object
+    sys.modules["peft"].PeftModel = object
+    sys.modules["tqdm"].tqdm = lambda x, **k: x
 
 
-def test_parse_rate_nonzero_total():
-    assert parse_rate(8, 10) == 0.8
+_stub_evaluate_deps()
+
+from evaluate import compute_parse_rate  # noqa: E402
+
+
+def test_compute_parse_rate_empty_total_is_zero():
+    assert compute_parse_rate(0, 0) == 0.0
+
+
+def test_compute_parse_rate_nonzero_total():
+    assert compute_parse_rate(8, 10) == 0.8

--- a/chapter8/prompt-distillation/test_evaluate_empty_parse_rate.py
+++ b/chapter8/prompt-distillation/test_evaluate_empty_parse_rate.py
@@ -1,0 +1,10 @@
+"""Regression: empty test set must not ZeroDivisionError on parse-rate summary."""
+from eval_metrics import parse_rate
+
+
+def test_parse_rate_empty_total_is_zero():
+    assert parse_rate(0, 0) == 0.0
+
+
+def test_parse_rate_nonzero_total():
+    assert parse_rate(8, 10) == 0.8


### PR DESCRIPTION
An empty or blank-only `--test_file` made `results['total']=0` and the summary print crashed with ZeroDivisionError, while the JSON summary path already guarded.

Use the same empty-total guard for the printed parse rate.