### PR TITLE
fix(intuitor): extract nested braces from boxed answers

### DIFF
--- a/chapter7/Intuitor/evaluate_from_cache.py
+++ b/chapter7/Intuitor/evaluate_from_cache.py
@@ -23,12 +23,23 @@ def extract_answer_from_boxed(text: str) -> Optional[str]:
     # 确保是字符串
     text = str(text)
     
-    # 匹配 \\boxed{number}，这个模式同时匹配 \boxed{} 和 \(\boxed{}\)
-    match = re.search(r'\\boxed\{([^}]+)\}', text)
-    if match:
-        return match.group(1).strip()
-    
-    return None
+    # Balanced braces so nested LaTeX like \boxed{\frac{1}{2}} is not truncated.
+    marker = "\\boxed{"
+    start = text.find(marker)
+    if start < 0:
+        return None
+    i = start + len(marker)
+    depth = 1
+    while i < len(text) and depth:
+        ch = text[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        i += 1
+    if depth != 0:
+        return None
+    return text[start + len(marker) : i - 1].strip()
 
 
 def extract_answer_from_gsm8k_format(text: str) -> Optional[str]:

--- a/chapter7/Intuitor/test_boxed_nested_braces.py
+++ b/chapter7/Intuitor/test_boxed_nested_braces.py
@@ -1,0 +1,18 @@
+"""Regression: nested braces inside \\boxed{} must not truncate."""
+
+from evaluate_from_cache import extract_answer_from_boxed
+
+
+def test_boxed_nested_frac():
+    text = r"The answer is \boxed{\frac{1}{2}}"
+    assert extract_answer_from_boxed(text) == r"\frac{1}{2}"
+
+
+def test_boxed_simple_integer():
+    text = r"Final answer: \boxed{42}"
+    assert extract_answer_from_boxed(text) == "42"
+
+
+def test_boxed_deeper_nesting():
+    text = r"\boxed{\frac{a}{b+c}}"
+    assert extract_answer_from_boxed(text) == r"\frac{a}{b+c}"


### PR DESCRIPTION
`\boxed{\frac{1}{2}}` was parsed with `[^}]+`, so the answer truncated to `\frac{1` and accuracy scoring went wrong.\n\nScan balanced braces so nested LaTeX inside `\boxed{...}` is kept intact.