### PR TITLE
fix(sanitize): redact full quoted secret values

### DIFF
--- a/chapter2/log-sanitization/regex_sanitizer.py
+++ b/chapter2/log-sanitization/regex_sanitizer.py
@@ -111,9 +111,10 @@ _RULES = [
         "secret_assignment", "[REDACTED_SECRET]",
         re.compile(
             r"(?i)(?:password|passwd|pwd|secret|token|api[_-]?key|"
-            r"access[_-]?key|auth|credential)[\"']?\s*[=:]\s*[\"']?([^\s\"',}]{4,})"
+            r"access[_-]?key|auth|credential)[\"']?\s*[=:]\s*"
+            r"(?:\"([^\"]{4,})\"|'([^']{4,})'|([^\s\"',}]{4,}))"
         ),
-        1, None,
+        (1, 2, 3), None,
     ),
     (
         "email", "[REDACTED_EMAIL]",
@@ -184,8 +185,13 @@ def sanitize(text: str) -> Tuple[str, List[Dict]]:
     """
     candidates: List[Dict] = []
     for priority, (category, placeholder, pattern, group, validator) in enumerate(_RULES):
+        groups = group if isinstance(group, tuple) else (group,)
         for m in pattern.finditer(text):
-            start, end = m.span(group)
+            start = end = -1
+            for g in groups:
+                start, end = m.span(g)
+                if start >= 0:
+                    break
             if start < 0:  # 该捕获组未参与本次匹配
                 continue
             value = text[start:end]

--- a/chapter2/log-sanitization/test_quoted_secret_spaces.py
+++ b/chapter2/log-sanitization/test_quoted_secret_spaces.py
@@ -1,0 +1,23 @@
+"""Regression: quoted secret assignments must redact the full value, including spaces."""
+from regex_sanitizer import sanitize
+
+
+def test_double_quoted_password_with_spaces():
+    text, hits = sanitize('password="hunter 2 with spaces"')
+    assert "hunter" not in text
+    assert "spaces" not in text
+    assert "[REDACTED_SECRET]" in text
+    assert any(h["category"] == "secret_assignment" for h in hits)
+
+
+def test_single_quoted_password_with_spaces():
+    text, hits = sanitize("api_key='sk-abc def ghi'")
+    assert "sk-abc" not in text
+    assert "ghi" not in text
+    assert "[REDACTED_SECRET]" in text
+
+
+def test_unquoted_secret_still_redacted():
+    text, hits = sanitize("password=hunter2xyz")
+    assert "hunter2xyz" not in text
+    assert "[REDACTED_SECRET]" in text


### PR DESCRIPTION
Quoted assignments like `password="hunter 2 with spaces"` only redacted the first token, leaving the rest of the secret in the clear.

When quotes open the value, capture through the closing quote.