### PR TITLE
fix(self-evolving): tolerate bad __TOOL_RESULT__ JSON

### DIFF
--- a/chapter8/self-evolving-tools/test_tool_result_bad_json.py
+++ b/chapter8/self-evolving-tools/test_tool_result_bad_json.py
@@ -1,0 +1,30 @@
+"""Regression: malformed __TOOL_RESULT__ JSON must not raise JSONDecodeError."""
+import tempfile
+from pathlib import Path
+
+from tool_manager import ToolLibrary
+
+
+def test_malformed_tool_result_returns_error_dict():
+    lib = ToolLibrary(library_dir=Path(tempfile.mkdtemp()))
+    # Tool prints a broken marker line, then would have returned ok — driver still emits marker from wrapper.
+    # Inject via code that prints a bad marker before the wrapper's print by overriding run to print bad then return.
+    code = (
+        "def run(**kwargs):\n"
+        "    print('__TOOL_RESULT__{not-json')\n"
+        "    return {'ok': True}\n"
+    )
+    rec = {"name": "t", "description": "d", "parameters": {"type": "object", "properties": {}}, "code": code}
+    out = lib._run_record(rec, {})
+    assert isinstance(out, dict)
+    assert out.get("success") is False
+    assert "invalid result marker" in out.get("error", "")
+
+
+def test_valid_tool_result_still_succeeds():
+    lib = ToolLibrary(library_dir=Path(tempfile.mkdtemp()))
+    code = "def run(**kwargs):\n    return {'ok': True}\n"
+    rec = {"name": "t", "description": "d", "parameters": {"type": "object", "properties": {}}, "code": code}
+    out = lib._run_record(rec, {})
+    assert out.get("success") is True
+    assert out.get("result") == {"ok": True}

--- a/chapter8/self-evolving-tools/tool_manager.py
+++ b/chapter8/self-evolving-tools/tool_manager.py
@@ -177,7 +177,15 @@ class ToolLibrary:
                 return {"success": False, "error": "tool crashed", "stderr": r.stderr[-3000:]}
             for line in r.stdout.splitlines():
                 if line.startswith("__TOOL_RESULT__"):
-                    return {"success": True, "result": json.loads(line[len("__TOOL_RESULT__"):])}
+                    raw = line[len("__TOOL_RESULT__"):]
+                    try:
+                        return {"success": True, "result": json.loads(raw)}
+                    except json.JSONDecodeError as e:
+                        return {
+                            "success": False,
+                            "error": f"invalid result marker: {e}",
+                            "stdout": r.stdout[-2000:],
+                        }
             return {"success": False, "error": "no result marker", "stdout": r.stdout[-2000:]}
         except subprocess.TimeoutExpired:
             return {"success": False, "error": f"timeout after {timeout}s"}


### PR DESCRIPTION
A malformed `__TOOL_RESULT__` line raised JSONDecodeError out of `_run_record`, while crash/timeout already returned `success=False` dicts.

Catch JSONDecodeError and return an error dict.