### PR TITLE
fix(coding_agent): quote ShellSession cwd with spaces

### DIFF
--- a/chapter5/coding-agent/tests/test_shell_session.py
+++ b/chapter5/coding-agent/tests/test_shell_session.py
@@ -40,3 +40,19 @@ class TestShellSessionMarker:
             assert "hello-after" in out
         finally:
             s.kill()
+
+    def test_execute_when_cwd_contains_spaces(self, temp_dir):
+        """ShellSession must quote cwd so paths with spaces do not break cd."""
+        space_dir = temp_dir / "dir with spaces"
+        space_dir.mkdir()
+        s = ShellSession(
+            session_id="test_cwd_spaces",
+            current_directory=str(space_dir),
+        )
+        try:
+            out, code = s.execute("pwd", timeout=10)
+            assert code == 0
+            assert "dir with spaces" in out
+            assert "too many arguments" not in out.lower()
+        finally:
+            s.kill()

--- a/chapter5/coding-agent/tools/shell_session.py
+++ b/chapter5/coding-agent/tools/shell_session.py
@@ -6,6 +6,7 @@ import subprocess
 import time
 import os
 import re
+import shlex
 import queue
 import threading
 from dataclasses import dataclass, field
@@ -63,7 +64,7 @@ class ShellSession:
         
         try:
             # Send command
-            full_command = f"cd {self.current_directory} && {command}\n"
+            full_command = f"cd {shlex.quote(self.current_directory)} && {command}\n"
             self.process.stdin.write(full_command)
             self.process.stdin.write("echo __CMD_DONE__$?\n")
             self.process.stdin.flush()


### PR DESCRIPTION
ShellSession prefixed every command with an unquoted `cd {cwd}`, so a working directory with spaces failed (`cd: too many arguments`).

Quote the cwd with `shlex.quote`.