### PR TITLE
fix(edit): reject empty old_string with replace_all

### DIFF
--- a/chapter5/coding-agent/tests/test_edit_tool.py
+++ b/chapter5/coding-agent/tests/test_edit_tool.py
@@ -42,6 +42,24 @@ class TestEditTool:
         assert result.success
         assert result.data["replacements"] == 3
         assert file_path.read_text() == "replaced bar replaced baz replaced"
+
+    def test_empty_old_string_replace_all_rejected(self, system_state, temp_dir):
+        """Empty old_string with replace_all must not insert between every character."""
+        tool = EditTool(system_state)
+        file_path = temp_dir / "empty_old.txt"
+        original = "abcd"
+        file_path.write_text(original)
+
+        result = tool.execute({
+            "file_path": str(file_path),
+            "old_string": "",
+            "new_string": "X",
+            "replace_all": True,
+        })
+
+        assert "error" in result.data
+        assert "empty" in result.data["error"].lower()
+        assert file_path.read_text() == original
     
     def test_uniqueness_check(self, system_state, temp_dir):
         """Test that Edit fails if old_string is not unique (without replace_all)"""

--- a/chapter5/coding-agent/tools/edit_tool.py
+++ b/chapter5/coding-agent/tools/edit_tool.py
@@ -31,6 +31,10 @@ class EditTool(BaseTool):
         
         if not file_path.exists():
             return {"error": f"File not found: {file_path}"}
+
+        # Empty old_string matches between every character; replace_all would insert everywhere.
+        if old_string == "":
+            return {"error": "old_string cannot be empty"}
         
         try:
             with open(file_path, 'r', encoding='utf-8') as f:


### PR DESCRIPTION
Edit with `old_string=""` and `replace_all=true` inserted between every character (`abcd` → `XaXbXcXdX`). Without replace_all the tool already rejected empty old_string as non-unique.

Reject empty old_string before replace.