### PR TITLE
fix(multiedit): create file only after all edits succeed

### DIFF
--- a/chapter5/coding-agent/tests/test_multi_edit_tool.py
+++ b/chapter5/coding-agent/tests/test_multi_edit_tool.py
@@ -103,6 +103,30 @@ def old_function():
         assert file_path.exists()
         assert "def hello" in file_path.read_text()
         assert result.data["edit_results"][0]["action"] == "created"
+
+    def test_atomic_create_no_orphan_on_later_failure(self, system_state, temp_dir):
+        """Create-new-file must not leave an empty file if a later edit fails."""
+        tool = MultiEditTool(system_state)
+        file_path = temp_dir / "orphan_create.py"
+        assert not file_path.exists()
+
+        result = tool.execute({
+            "file_path": str(file_path),
+            "edits": [
+                {
+                    "old_string": "",
+                    "new_string": "def hello():\n    pass\n",
+                },
+                {
+                    "old_string": "NONEXISTENT",
+                    "new_string": "x",
+                },
+            ],
+        })
+
+        assert "error" in result.data
+        assert result.data["completed_edits"] == 1
+        assert not file_path.exists()
     
     def test_create_and_modify(self, system_state, temp_dir):
         """Test creating file and then modifying it in subsequent edits"""

--- a/chapter5/coding-agent/tools/multi_edit_tool.py
+++ b/chapter5/coding-agent/tools/multi_edit_tool.py
@@ -29,22 +29,25 @@ class MultiEditTool(BaseTool):
         edits = params.get("edits")
         if edits is None:
             edits = []
-        
+
+        creating_new = False
         if not file_path.exists():
-            # Check if this is a file creation (first edit has empty old_string)
+            # Defer create/write until every edit succeeds (atomic).
             if edits and edits[0]["old_string"] == "":
+                creating_new = True
                 try:
                     file_path.parent.mkdir(parents=True, exist_ok=True)
-                    with open(file_path, 'w', encoding='utf-8') as f:
-                        f.write("")
                 except Exception as e:
                     return {"error": f"Error creating file: {str(e)}"}
             else:
                 return {"error": f"File not found: {file_path}"}
         
         try:
-            with open(file_path, 'r', encoding='utf-8') as f:
-                content = f.read()
+            if creating_new:
+                content = ""
+            else:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    content = f.read()
             
             original_content = content
             results = []


### PR DESCRIPTION
MultiEdit create (empty old_string) wrote an empty file before applying edits. If a later edit failed, an orphan empty file remained despite the atomic contract.

Apply edits in memory and create the file only after every edit succeeds.