### PR TITLE
fix(sanitize): redact github_pat fine-grained tokens

### DIFF
--- a/chapter2/log-sanitization/regex_sanitizer.py
+++ b/chapter2/log-sanitization/regex_sanitizer.py
@@ -84,7 +84,7 @@ _RULES = [
     ),
     (
         "github_token", "[REDACTED_GITHUB_TOKEN]",
-        re.compile(r"\bgh[pousr]_[A-Za-z0-9]{36,}\b"),
+        re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{20,})\b"),
         0, None,
     ),
     (

--- a/chapter2/log-sanitization/test_github_pat.py
+++ b/chapter2/log-sanitization/test_github_pat.py
@@ -1,0 +1,18 @@
+"""Regression: fine-grained github_pat_* tokens must be redacted."""
+from regex_sanitizer import sanitize
+
+
+def test_github_pat_fine_grained_redacted():
+    token = "github_pat_" + "A" * 20 + "_" + "B" * 40
+    text, hits = sanitize(f"Authorization: {token}")
+    assert token not in text
+    assert "[REDACTED_GITHUB_TOKEN]" in text
+    assert any(h["category"] == "github_token" for h in hits)
+
+
+def test_classic_ghp_token_still_redacted():
+    token = "ghp_" + "x" * 36
+    text, hits = sanitize(token)
+    assert token not in text
+    assert "[REDACTED_GITHUB_TOKEN]" in text
+    assert any(h["category"] == "github_token" for h in hits)


### PR DESCRIPTION
The github_token rule only matched `gh[pousr]_…`. Fine-grained `github_pat_…` tokens in logs stayed in plaintext.

Extend the rule to also match `github_pat_` prefixes.