### PR TITLE
fix: update web-search-agent model name from Kimi K2 to K3

### DIFF
--- a/chapter1/README.md
+++ b/chapter1/README.md
@@ -9,7 +9,7 @@
 | 项目 | 类型 | 一句话说明 |
 | --- | :--: | --- |
 | [learning-from-experience](learning-from-experience/) | ✅ | 对比 Q-learning 与基于 LLM 的上下文学习，复现 Shunyu Yao 的 "The Second Half"：LLM 以 250–400 倍样本效率超越传统 RL |
-| [web-search-agent](web-search-agent/) | ✅ | Kimi K2 模型即 Agent，具备基础深度搜索能力，能进行多轮搜索和信息整合 |
+| [web-search-agent](web-search-agent/) | ✅ | Kimi K3 模型即 Agent，具备基础深度搜索能力，能进行多轮搜索和信息整合 |
 | [search-codegen](search-codegen/) | ✅ | GPT-5 原生工具集成，综合利用网络搜索与代码沙盒实现复杂分析 |
 | [context](context/) | ✅ | 系统性消融实验展示 Agent 上下文各组件的重要性；支持 SiliconFlow Qwen、字节 Doubao、月之暗面 Kimi 等多提供商 |
 

--- a/chapter1/README.zh-TW.md
+++ b/chapter1/README.zh-TW.md
@@ -9,7 +9,7 @@
 | 專案 | 型別 | 一句話說明 |
 | --- | :--: | --- |
 | [learning-from-experience](learning-from-experience/) | ✅ | 對比 Q-learning 與基於 LLM 的上下文學習，復現 Shunyu Yao 的 "The Second Half"：LLM 以 250–400 倍樣本效率超越傳統 RL |
-| [web-search-agent](web-search-agent/) | ✅ | Kimi K2 模型即 Agent，具備基礎深度搜尋能力，能進行多輪搜尋和資訊整合 |
+| [web-search-agent](web-search-agent/) | ✅ | Kimi K3 模型即 Agent，具備基礎深度搜尋能力，能進行多輪搜尋和資訊整合 |
 | [search-codegen](search-codegen/) | ✅ | GPT-5 原生工具整合，綜合利用網路搜尋與程式碼沙箱實現複雜分析 |
 | [context](context/) | ✅ | 系統性消融實驗展示 Agent 上下文各元件的重要性；支援 SiliconFlow Qwen、字節 Doubao、月之暗面 Kimi 等多提供商 |
 


### PR DESCRIPTION
## 问题

`chapter1/README.md` 和 `chapter1/README.zh-TW.md` 中 `web-search-agent` 实验的模型描述仍为 **Kimi K2**，但：

- 正文 `book/chapter1.md:202` 已写明 **Kimi K3**
- 实验代码 `chapter1/web-search-agent/config.py:73` 默认模型为 `kimi-k3`

## 改动

- `chapter1/README.md:12` — K2 → K3
- `chapter1/README.zh-TW.md:12` — K2 → K3

en/ta/vi 翻译未提及具体型号，不受影响。