### PR TITLE
fix(chapter5): make coding-agent SystemState cross-platform (Windows startup crash)

### DIFF
--- a/chapter5/coding-agent/system_state.py
+++ b/chapter5/coding-agent/system_state.py
@@ -3,7 +3,7 @@ System state tracking for the coding agent
 """
 
 import os
-import subprocess
+import platform
 from dataclasses import dataclass, field
 from typing import Dict, Any, List
 from datetime import datetime
@@ -20,8 +20,8 @@ class SystemState:
     # Byte offset already returned by BashOutput, per bash_id, so each call can
     # return "only new output since the last check" as the tool documents.
     bash_output_offsets: Dict[str, int] = field(default_factory=dict)
-    os_type: str = field(default_factory=lambda: os.uname().sysname)
-    python_version: str = field(default_factory=lambda: subprocess.getoutput("python3 --version"))
+    os_type: str = field(default_factory=lambda: platform.system())
+    python_version: str = field(default_factory=lambda: f"Python {platform.python_version()}")
     
     def get_system_hint(self) -> str:
         """Generate system hint message to append to context"""


### PR DESCRIPTION
## Summary

`chapter5/coding-agent`'s `SystemState` crashes at construction time on Windows, so the coding agent can't start there at all.

## Problem

`system_state.py` uses `os.uname()` in a dataclass `default_factory`:

```python
os_type: str = field(default_factory=lambda: os.uname().sysname)
```

`os.uname()` is Unix-only. On Windows the `os` module has no `uname` attribute, so simply constructing `SystemState()` raises:

```
AttributeError: module 'os' has no attribute 'uname'
```

Because `SystemState()` is instantiated inside the agent constructors (`agent.py`, `agent_new.py`), the agent fails to initialize on Windows **before any LLM call is made** — it's not a runtime edge case, it's a hard startup crash on the whole platform.

The adjacent line has a milder portability issue:

```python
python_version: str = field(default_factory=lambda: subprocess.getoutput("python3 --version"))
```

On Windows the interpreter is usually `python`, not `python3`, so this stores an error string (e.g. `'python3' is not recognized...`) into the system hint rather than a version.

## Fix

Use the cross-platform `platform` module:

```python
os_type: str = field(default_factory=lambda: platform.system())
python_version: str = field(default_factory=lambda: f"Python {platform.python_version()}")
```

- `platform.system()` returns `"Linux"` / `"Darwin"` / `"Windows"`, matching `os.uname().sysname` on Unix — **no behaviour change on Linux/macOS**.
- `platform.python_version()` reports the running interpreter cross-platform.

The now-unused `subprocess` import is removed.

## Verification

On Windows, before the fix `SystemState()` raised `AttributeError`; after the fix it constructs cleanly:

```
os_type = Windows
python_version = Python 3.11.8
```

On Unix the values are unchanged (`Linux`/`Darwin`, plus the interpreter version).
