### PR TITLE
kv-cache: make SLIDING_WINDOW actually send a window and never split a tool-call pair

### DIFF
--- a/chapter2/kv-cache/agent.py
+++ b/chapter2/kv-cache/agent.py
@@ -56,7 +56,7 @@ class KVCacheMode(Enum):
     DYNAMIC_SYSTEM = "dynamic_system"  # Changing system prompt with timestamp
     SHUFFLED_TOOLS = "shuffled_tools"  # Shuffling tool order each request
     DYNAMIC_PROFILE = "dynamic_profile"  # Changing user profile with credits
-    SLIDING_WINDOW = "sliding_window"  # Only keeping recent 5 messages
+    SLIDING_WINDOW = "sliding_window"  # Only keeping recent 6 messages
     TEXT_FORMAT = "text_format"  # Formatting messages as plain text
 
 
@@ -523,13 +523,17 @@ Always think step by step and use tools to gather information. When you have eno
             messages.append(profile_msg)
         
         if self.mode == KVCacheMode.SLIDING_WINDOW:
-            # Preserve all system and user messages, at the most recent 6 messages
+            # Keep only the most recent 6 history messages (the window).
+            # conversation_history holds assistant/tool messages, so the raw
+            # slice could start with a tool message whose paired assistant
+            # tool_calls message was trimmed away — the API rejects such a
+            # history. Walk the window start back to the owning assistant
+            # message so every tool message keeps its pair.
             if self.conversation_history:
-                # Include all system and user messages, and if there are at least 6 messages, include the last 6 messages regardless of role
-                system_user_msgs = [msg for msg in self.conversation_history if msg.get("role") in ("system", "user")]
-                messages.extend(system_user_msgs)
-                if len(self.conversation_history) >= 6:
-                    messages.extend(self.conversation_history[-6:])
+                start = max(0, len(self.conversation_history) - 6)
+                while start > 0 and self.conversation_history[start].get("role") == "tool":
+                    start -= 1
+                messages.extend(self.conversation_history[start:])
         elif self.mode == KVCacheMode.TEXT_FORMAT:
             # Format all history as plain text (breaks KV cache)
             # Reformatting each time breaks structured format


### PR DESCRIPTION
`SLIDING_WINDOW` mode had two defects (details in #190):

1. The "preserve all system and user messages" filter was provably always empty — `conversation_history` only ever receives assistant/tool messages — so iterations 1-3 sent **no history at all** and the model repeated identical tool calls (visible in the shipped `result_sliding_window_20260718_kimi_k2_6.json`: three identical `find(pattern='*.py')` calls).
2. Once history reached 6 messages, the raw `[-6:]` slice could start with a `tool` message whose paired assistant `tool_calls` message was trimmed, which OpenAI-compatible APIs reject with 400 — the same shipped run died this way (`"success": false`, 4 TTFT entries for 5 iterations).

The fix sends the most recent messages as the window (also when fewer than 6 exist) and walks the window start back past leading `tool` messages so a tool message never appears without its owning assistant message. Also aligns the enum comment (5 → 6).

Verified: `py_compile` passes; window logic sanity-checked for the "starts on tool message" and "short history" cases.

Fixes #190