### PR TITLE
system-hint: run code_interpreter snippets in an explicit exec namespace

### DIFF
--- a/chapter2/system-hint/agent.py
+++ b/chapter2/system-hint/agent.py
@@ -682,8 +682,13 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
             output_buffer = io.StringIO()
             error_buffer = io.StringIO()
             
+            # Run with an explicit namespace: with bare exec(code), top-level
+            # assignments land in this method's locals while functions defined
+            # in the snippet resolve free variables via module globals, so
+            # "x = 5; def f(): return x; f()" raises NameError.
+            exec_ns = {}
             with contextlib.redirect_stdout(output_buffer), contextlib.redirect_stderr(error_buffer):
-                exec(code)
+                exec(code, exec_ns)
             
             # Get output
             stdout = output_buffer.getvalue()


### PR DESCRIPTION
`_tool_code_interpreter` called bare `exec(code)` inside the method, so top-level assignments landed in the method's locals while functions defined in the snippet resolve free variables through module globals. The very common LLM-generated shape

```python
x = 5
def double():
    return x * 2
print(double())
```

raised `NameError: name 'x' is not defined`, and that error was returned to the model with "Check the code syntax" guidance — sending it into retry loops on correct code. (Details in #191.)

Fix: execute with one explicit globals dict (`exec(code, exec_ns)`), which restores normal module-level scoping — the same pattern `chapter2/local_llm_serving/tools.py` already uses.

Verified: `py_compile` passes; the snippet above now prints `10` under the new namespace handling.

Fixes #191