### PR TITLE
collaboration-tools: fix guard_reasoning_process approving rejected actions

### DIFF
--- a/chapter4/collaboration-tools/src/intelligence_tools.py
+++ b/chapter4/collaboration-tools/src/intelligence_tools.py
@@ -192,9 +192,19 @@ Provide:
         )
         
         evaluation = response.choices[0].message.content
-        
-        # Try to extract structured response
-        approved = "approved: true" in evaluation.lower() or "safe to execute" in evaluation.lower()
+
+        # Try to extract structured response. Approval must be explicit and
+        # not contradicted: "safe to execute" alone is unusable as a signal
+        # because it is a substring of "not safe to execute" (and the prompt
+        # itself contains the phrase), which inverted rejections into
+        # approvals. Default to not approved when the verdict is unclear.
+        low = evaluation.lower()
+        approved = (
+            "approved: true" in low
+            and "approved: false" not in low
+            and "not safe" not in low
+            and "unsafe" not in low
+        )
         
         return {
             "success": True,


### PR DESCRIPTION
The approval extraction used

```python
approved = "approved: true" in evaluation.lower() or "safe to execute" in evaluation.lower()
```

and `"safe to execute"` is a substring of `"not safe to execute"` — so a rejection like *"approved: false. This command is not safe to execute because it deletes files."* returned `{"approved": True}`. The guard's own prompt asks the model to analyze "1. Safe to execute", making the phrase appear in nearly every response, approvals and rejections alike. Details in #193.

Fix: approval requires an explicit `approved: true` and no contradicting marker (`approved: false` / `not safe` / `unsafe`); anything unclear defaults to **not approved** — the safe direction for a guard.

Verified: `py_compile` passes; checked against approval, plain rejection, contradictory, and unclear responses.

Fixes #193