### PR TITLE
coding-agent: accumulate streamed tool-input JSON fragments before parsing

### DIFF
--- a/chapter5/coding-agent/agent.py
+++ b/chapter5/coding-agent/agent.py
@@ -184,7 +184,8 @@ class CodingAgent:
                 assistant_message = {"role": "assistant", "content": []}
                 current_text = ""
                 current_tool_use = None
-                
+                current_tool_json = ""
+
                 for event in stream:
                     if event.type == "content_block_start":
                         if event.content_block.type == "text":
@@ -196,7 +197,8 @@ class CodingAgent:
                                 "name": event.content_block.name,
                                 "input": {}
                             }
-                    
+                            current_tool_json = ""
+
                     elif event.type == "content_block_delta":
                         if event.delta.type == "text_delta":
                             current_text += event.delta.text
@@ -206,15 +208,11 @@ class CodingAgent:
                                 "accumulated": current_text
                             }
                         elif event.delta.type == "input_json_delta":
-                            # Accumulate tool input
+                            # Accumulate tool input; partial_json is a fragment,
+                            # only the concatenation of all fragments parses.
                             if current_tool_use:
-                                try:
-                                    current_tool_use["input"] = json.loads(
-                                        event.delta.partial_json
-                                    )
-                                except:
-                                    pass
-                    
+                                current_tool_json += event.delta.partial_json
+
                     elif event.type == "content_block_stop":
                         if current_text:
                             assistant_message["content"].append({
@@ -223,6 +221,12 @@ class CodingAgent:
                             })
                             current_text = ""
                         elif current_tool_use:
+                            try:
+                                current_tool_use["input"] = json.loads(
+                                    current_tool_json or "{}"
+                                )
+                            except json.JSONDecodeError:
+                                pass
                             assistant_message["content"].append(current_tool_use)
                             yield {
                                 "type": "tool_call",

--- a/chapter5/coding-agent/agent_new.py
+++ b/chapter5/coding-agent/agent_new.py
@@ -143,7 +143,8 @@ class CodingAgent:
                     assistant_message = {"role": "assistant", "content": []}
                     current_text = ""
                     current_tool_use = None
-                    
+                    current_tool_json = ""
+
                     for event in stream:
                         if event.type == "content_block_start":
                             if event.content_block.type == "text":
@@ -155,7 +156,8 @@ class CodingAgent:
                                     "name": event.content_block.name,
                                     "input": {}
                                 }
-                        
+                                current_tool_json = ""
+
                         elif event.type == "content_block_delta":
                             if event.delta.type == "text_delta":
                                 current_text += event.delta.text
@@ -165,15 +167,11 @@ class CodingAgent:
                                     "accumulated": current_text
                                 }
                             elif event.delta.type == "input_json_delta":
-                                # Accumulate tool input
+                                # Accumulate tool input; partial_json is a fragment,
+                                # only the concatenation of all fragments parses.
                                 if current_tool_use:
-                                    try:
-                                        current_tool_use["input"] = json.loads(
-                                            event.delta.partial_json
-                                        )
-                                    except:
-                                        pass
-                        
+                                    current_tool_json += event.delta.partial_json
+
                         elif event.type == "content_block_stop":
                             if current_text:
                                 assistant_message["content"].append({
@@ -182,6 +180,12 @@ class CodingAgent:
                                 })
                                 current_text = ""
                             elif current_tool_use:
+                                try:
+                                    current_tool_use["input"] = json.loads(
+                                        current_tool_json or "{}"
+                                    )
+                                except json.JSONDecodeError:
+                                    pass
                                 assistant_message["content"].append(current_tool_use)
                                 yield {
                                     "type": "tool_call",


### PR DESCRIPTION
The Anthropic streaming handler parsed **each** `input_json_delta` fragment with `json.loads` and swallowed the failures with a bare `except: pass`. `partial_json` is a fragment (`{"file_` → `path": "a.py", "cont` → `ent": "..."}`), so any tool input spanning more than one delta left `input = {}` — tools like `Write`/`Edit` executed with empty parameters and the agent degraded into error-retry loops on the primary `--provider anthropic` path. The comment "Accumulate tool input" described the intended behavior; the code never accumulated. Details in #194.

Fix: concatenate fragments into `current_tool_json` per content block and parse once at `content_block_stop` (empty string → `{}` for no-arg tool calls). Same change in `agent.py` and `agent_new.py`, which duplicate the handler.

Verified: `py_compile` on both files; fragment-concatenation semantics sanity-checked.

Fixes #194