### PR TITLE
elo-leaderboard: fix quickstart scoring every match as a tie

### DIFF
--- a/chapter6/elo-leaderboard/quickstart.py
+++ b/chapter6/elo-leaderboard/quickstart.py
@@ -34,8 +34,12 @@ def demo_basic_elo():
     for i, (model_a, model_b, winner) in enumerate(matches, 1):
         old_rating_a = elo.get_rating(model_a)
         old_rating_b = elo.get_rating(model_b)
-        
-        new_rating_a, new_rating_b = elo.update_ratings(model_a, model_b, winner)
+
+        # update_ratings expects 'model_a' / 'model_b' / 'tie', not the
+        # winning model's name (anything unrecognized is scored as a tie).
+        outcome = ("model_a" if winner == model_a
+                   else "model_b" if winner == model_b else "tie")
+        new_rating_a, new_rating_b = elo.update_ratings(model_a, model_b, outcome)
         
         print(f"Match {i}: {model_a} vs {model_b} -> {winner} wins")
         print(f"  {model_a}: {old_rating_a:.1f} → {new_rating_a:.1f} ({new_rating_a-old_rating_a:+.1f})")


### PR DESCRIPTION
`EloRatingSystem.update_ratings` recognizes only `'model_a'` / `'model_b'` / `'tie'`; anything else lands in the tie branch. The quickstart passed the winning **model's name** (`"GPT-4"`), so all 10 demo matches were scored 0.5-0.5: every rating change printed `+0.0`, the final leaderboard showed every model at exactly 1000.0, and every win-probability prediction was 50% vs 50% — while the narration next to it said "-> GPT-4 wins". Details in #195.

Fix: map the winner name to the expected outcome literal before calling `update_ratings`.

Verified by running `python quickstart.py`: ratings now move each match and the leaderboard spreads (GPT-4 on top, Llama-2 at the bottom).

Fixes #195