### PR TITLE
docs: install mkdocs-material[imaging] so the social-cards plugin actually runs

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -6,5 +6,5 @@
 # break the site build (it has happened — see PR #73). A pinned range lets
 # us upgrade deliberately rather than discovering the breakage in CI.
 
-mkdocs-material >= 9.5, < 10
+mkdocs-material[imaging] >= 9.5, < 10
 mkdocs-git-revision-date-localized-plugin >= 1.2, < 2


### PR DESCRIPTION
`mkdocs.yml` enables the Material `social:` plugin, but `requirements-docs.txt` installs plain `mkdocs-material` without the `[imaging]` extra (pillow + cairosvg), so (all verified — details in #196):

- a clean local `mkdocs build` **aborts** (`The "social" plugin is not installed`);
- CI silently no-ops the plugin (`ModuleNotFoundError("No module named 'cairosvg'")` per page in the deploy-pages logs);
- the live site has zero `og:*`/`twitter:*` meta tags and `assets/images/social/index.png` 404s — links shared to WeChat/Twitter/Slack render bare.

One-line fix: `mkdocs-material[imaging] >= 9.5, < 10`. ubuntu-latest runners already ship libcairo, so no workflow change is needed.

Fixes #196