### PR TITLE
context-compression: don't compare cumulative token spend against the per-request context window

### DIFF
--- a/chapter2/context-compression/agent.py
+++ b/chapter2/context-compression/agent.py
@@ -52,6 +52,11 @@ class AgentTrajectory:
     total_tokens_used: int = 0
     prompt_tokens_used: int = 0
     completion_tokens_used: int = 0
+    # Prompt tokens of the most recent API call = the current context size.
+    # prompt_tokens_used above is a cumulative COST counter (each call's
+    # prompt re-counts the shared prefix), so it must not be compared
+    # against the per-request context window.
+    last_prompt_tokens: int = 0
     context_overflows: int = 0
     compression_strategy: CompressionStrategy = CompressionStrategy.NO_COMPRESSION
     start_time: float = field(default_factory=time.time)
@@ -243,14 +248,17 @@ TODAY'S DATE: {date_string}"""
         if self.compression_strategy != CompressionStrategy.WINDOWED_CONTEXT:
             return messages
         
-        # Check if we should start compressing (80% context usage)
+        # Check if we should start compressing (80% context usage).
+        # Use the LAST call's prompt size (current context), not the
+        # cumulative cost counter, which grows quadratically and would
+        # trigger compression long before the window is actually near full.
         context_threshold = Config.CONTEXT_WINDOW_SIZE * 0.8
-        
-        if self.trajectory.prompt_tokens_used <= context_threshold:
-            logger.debug(f"Windowed compression: Context usage below threshold ({self.trajectory.prompt_tokens_used:,}/{context_threshold:.0f} tokens)")
+
+        if self.trajectory.last_prompt_tokens <= context_threshold:
+            logger.debug(f"Windowed compression: Context usage below threshold ({self.trajectory.last_prompt_tokens:,}/{context_threshold:.0f} tokens)")
             return messages  # No compression needed yet
-        
-        logger.info(f"⚠️ Context usage exceeds 80% threshold ({self.trajectory.prompt_tokens_used:,}/{Config.CONTEXT_WINDOW_SIZE} tokens) - Starting compression")
+
+        logger.info(f"⚠️ Context usage exceeds 80% threshold ({self.trajectory.last_prompt_tokens:,}/{Config.CONTEXT_WINDOW_SIZE} tokens) - Starting compression")
         
         # Compression marker to identify already-compressed messages
         COMPRESSION_MARKER = "[COMPRESSED]"
@@ -403,8 +411,9 @@ TODAY'S DATE: {date_string}"""
                 total_tokens = usage_data.total_tokens if hasattr(usage_data, 'total_tokens') else 0
                 
                 logger.info(f"🔢 Kimi API Token Usage - Prompt: {prompt_tokens}, Completion: {completion_tokens}, Total: {total_tokens}")
-                
+
                 # Update trajectory
+                self.trajectory.last_prompt_tokens = prompt_tokens
                 self.trajectory.prompt_tokens_used += prompt_tokens
                 self.trajectory.completion_tokens_used += completion_tokens
                 self.trajectory.total_tokens_used += total_tokens
@@ -453,8 +462,9 @@ TODAY'S DATE: {date_string}"""
             total_tokens = response.usage.total_tokens
             
             logger.info(f"🔢 Kimi API Token Usage - Prompt: {prompt_tokens}, Completion: {completion_tokens}, Total: {total_tokens}")
-            
+
             # Update trajectory
+            self.trajectory.last_prompt_tokens = prompt_tokens
             self.trajectory.prompt_tokens_used += prompt_tokens
             self.trajectory.completion_tokens_used += completion_tokens
             self.trajectory.total_tokens_used += total_tokens
@@ -522,15 +532,18 @@ TODAY'S DATE: {date_string}"""
                 
                 # Check if we're approaching token limit based on actual usage
                 if self.trajectory.total_tokens_used > 0:  # Only check after first call
-                    # Compression demo uses a 128k context budget
-                    if self.trajectory.prompt_tokens_used > Config.CONTEXT_WINDOW_SIZE * 0.8:
-                        logger.warning(f"Approaching context limit: {self.trajectory.prompt_tokens_used:,} prompt tokens used")
+                    # Compression demo uses a 128k context budget. Compare the
+                    # LAST call's prompt size (the actual context) against the
+                    # window — the cumulative counter re-counts the shared
+                    # prefix every call and overstates usage quadratically.
+                    if self.trajectory.last_prompt_tokens > Config.CONTEXT_WINDOW_SIZE * 0.8:
+                        logger.warning(f"Approaching context limit: {self.trajectory.last_prompt_tokens:,} prompt tokens in last request")
                         self.trajectory.context_overflows += 1
-                        
+
                         if self.compression_strategy == CompressionStrategy.NO_COMPRESSION:
                             print("\n⚠️ Context overflow detected! This demonstrates the limitation of no compression.")
                             return {
-                                "error": f"Context window exceeded - {self.trajectory.prompt_tokens_used:,} tokens used (limit: {Config.CONTEXT_WINDOW_SIZE})",
+                                "error": f"Context window exceeded - {self.trajectory.last_prompt_tokens:,} tokens in last request (limit: {Config.CONTEXT_WINDOW_SIZE})",
                                 "trajectory": self.trajectory,
                                 "iterations": iteration
                             }


### PR DESCRIPTION
`trajectory.prompt_tokens_used` is summed over **all** API calls, and each call's prompt embeds the entire prior context, so the counter grows ~quadratically and crosses `CONTEXT_WINDOW_SIZE * 0.8` long before any single request nears 128K. Both places that compared it against the window misbehaved (details in #205):

- the NO_COMPRESSION run aborted with a false "Context window exceeded" (cumulative 122k while the largest actual request was 32k — 25% of the window);
- windowed compression ("Only compresses when context usage exceeds 80% threshold") kicked in far too early.

Fix: add `AgentTrajectory.last_prompt_tokens` — the most recent call's prompt size, i.e. the actual current context — set it in both the streaming and non-streaming usage handlers, and use it in the two threshold checks. `prompt_tokens_used` stays as the cumulative cost counter (still printed as "Cumulative Token Usage").

Verified: `py_compile` passes; both threshold sites now read `last_prompt_tokens`, and the only remaining uses of the cumulative counter are the cost printouts.

Fixes #205