### PR TITLE
chapter1/context: don't crash the whole task when a tool result contains a non-JSON type

### DIFF
--- a/chapter1/context/agent.py
+++ b/chapter1/context/agent.py
@@ -763,7 +763,11 @@ Important: When you have gathered all necessary information and computed the fin
                         tool_msg = {
                             "role": "tool",
                             "tool_call_id": tool_call.id,
-                            "content": json.dumps(result)
+                            # default=str: code_interpreter returns the raw
+                            # namespace in `variables`, which can hold sets,
+                            # dict views etc. that json can't encode — that
+                            # must not abort the whole task.
+                            "content": json.dumps(result, default=str)
                         }
                     else:
                         tool_msg = {


### PR DESCRIPTION
`code_interpreter` returns the executed snippet's namespace in `variables`, filtered only by `not callable(v)`. Model code as routine as `unique = set(amounts)` or `keys = data.keys()` therefore puts a non-JSON type into the tool result; `json.dumps(result)` raised `TypeError: Object of type set is not JSON serializable`, and the outer handler failed the **entire** ReAct task instead of that one tool call. Details in #206.

Fix: `json.dumps(result, default=str)` — non-encodable values render as their `repr`, which is what the model needs to see anyway.

Verified: `py_compile` passes; `json.dumps({'variables': {'s': {1, 2}}}, default=str)` now serializes instead of raising.

Fixes #206