### PR TITLE
ci: build and publish Russian (book-ru) PDF and EPUB

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -12,6 +12,7 @@ on:
       - 'book/**'
       - 'book-zhtw/**'
       - 'book-en/**'
+      - 'book-ru/**'
       - 'book-ta/**'
       - 'book-vi/**'
       - 'build_epub.sh'
@@ -58,7 +59,7 @@ jobs:
           PANGOCAIRO_BACKEND: fontconfig
         run: |
           set -e
-          for dir in book book-zhtw book-en book-vi book-ta; do
+          for dir in book book-zhtw book-en book-ru book-vi book-ta; do
             (cd "$dir" && bash build_pdf.sh)
           done
 
@@ -80,11 +81,13 @@ jobs:
           cp "book/深入理解-AI-Agent-李博杰-v1.2.pdf"              "$out/AI-Agents-in-Depth-zh-CN.pdf"
           cp "book-zhtw/深入理解-AI-Agent-李博杰-v1.2-zhtw.pdf"   "$out/AI-Agents-in-Depth-zh-TW.pdf"
           cp book-en/AI-Agents-in-Depth-Bojie-Li-v1.2.pdf        "$out/AI-Agents-in-Depth-en.pdf"
+          cp book-ru/AI-Agents-in-Depth-ru.pdf                   "$out/AI-Agents-in-Depth-ru.pdf"
           cp book-ta/AI-Agents-in-Depth-Bojie-Li-v1.2-ta.pdf     "$out/AI-Agents-in-Depth-ta.pdf"
           cp book-vi/AI-Agents-in-Depth-Bojie-Li-v1.2-vi.pdf     "$out/AI-Agents-in-Depth-vi.pdf"
           cp "book/深入理解-AI-Agent-李博杰-v1.2.epub"             "$out/AI-Agents-in-Depth-zh-CN.epub"
           cp "book-zhtw/深入理解-AI-Agent-李博杰-v1.2-zhtw.epub"   "$out/AI-Agents-in-Depth-zh-TW.epub"
           cp book-en/AI-Agents-in-Depth-Bojie-Li-v1.2.epub       "$out/AI-Agents-in-Depth-en.epub"
+          cp book-ru/AI-Agents-in-Depth-ru.epub                  "$out/AI-Agents-in-Depth-ru.epub"
           cp book-ta/AI-Agents-in-Depth-Bojie-Li-v1.2-ta.epub    "$out/AI-Agents-in-Depth-ta.epub"
           cp book-vi/AI-Agents-in-Depth-Bojie-Li-v1.2-vi.epub    "$out/AI-Agents-in-Depth-vi.epub"
           gh release upload latest "$out"/* --clobber --repo "${{ github.repository }}"

--- a/build_epub.sh
+++ b/build_epub.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Build EPUB 3 editions from the Markdown sources.
-# Usage: ./build_epub.sh [all|zh-CN|zh-TW|en|ta|vi]
+# Usage: ./build_epub.sh [all|zh-CN|zh-TW|en|ru|ta|vi]
 
 set -euo pipefail
 
@@ -15,9 +15,9 @@ for command in pandoc pdftoppm python3; do
 done
 
 case "$SELECTION" in
-    all|zh-CN|zh-TW|en|ta|vi) ;;
+    all|zh-CN|zh-TW|en|ru|ta|vi) ;;
     *)
-        echo "Usage: $0 [all|zh-CN|zh-TW|en|ta|vi]" >&2
+        echo "Usage: $0 [all|zh-CN|zh-TW|en|ru|ta|vi]" >&2
         exit 2
         ;;
 esac
@@ -59,6 +59,16 @@ build_edition() {
             output="AI-Agents-in-Depth-Bojie-Li-v1.2.epub"
             title_label="Title Page"
             toc_label="Table of Contents"
+            chapters=(introduction.md chapter{1..10}.md afterword.md)
+            ;;
+        ru)
+            directory="book-ru"
+            title="Глубокое понимание AI Agent: принципы проектирования и инженерная практика"
+            author="Ли Боцзе (李博杰); русский перевод: ui99ru"
+            pdf="AI-Agents-in-Depth-ru.pdf"
+            output="AI-Agents-in-Depth-ru.epub"
+            title_label="Титульный лист"
+            toc_label="Содержание"
             chapters=(introduction.md chapter{1..10}.md afterword.md)
             ;;
         ta)
@@ -129,7 +139,7 @@ build_edition() {
 }
 
 if [ "$SELECTION" = "all" ]; then
-    for language in zh-CN zh-TW en ta vi; do
+    for language in zh-CN zh-TW en ru ta vi; do
         build_edition "$language"
     done
 else


### PR DESCRIPTION
Follow-up to #187 (Russian translation). Wires `book-ru` into the rolling **latest** release build so the Russian PDF and EPUB are produced and published automatically, alongside the other languages.

## Changes
- **`.github/workflows/build-latest.yml`**
  - trigger on `book-ru/**` changes
  - add `book-ru` to the PDF build loop
  - copy `AI-Agents-in-Depth-ru.{pdf,epub}` into the release upload
- **`build_epub.sh`**
  - add a `ru` edition (title/author metadata, Russian title-page & TOC labels)
  - include it in the `all` build; usage string updated

## Verified locally (macOS)
- `book-ru/build_pdf.sh` → **453-page PDF (27M)**, Cyrillic body text and SVG figures render correctly.
- `./build_epub.sh ru` → **EPUB (3.7M)**, correct `dc:title` / `dc:creator` / `dc:language=ru`.
- Preamble font fallbacks resolve to CI-installed fonts (**DejaVu Serif/Sans**, **Noto Sans CJK SC**) when PT Serif is absent, and SVG figure text (`…, sans-serif`) falls back to DejaVu Sans — so the runner has full Cyrillic coverage.

Once merged, the ebook links in the Russian READMEs can be switched from local `build_pdf.sh` to the released `latest` assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcszUnvHDVVGfgAuqtNpUT