### PR TITLE
user-memory: make background-processed memories visible to the interactive agent

### DIFF
--- a/chapter3/user-memory/conversational_agent.py
+++ b/chapter3/user-memory/conversational_agent.py
@@ -154,9 +154,15 @@ You MUST analyze the context, user's questions and memories in detail, and provi
         """Get current memory context as a string"""
         if not self.config.enable_memory_context:
             return ""
-        
+
         context_parts = []
-        
+
+        # The background processor writes memory through its own manager
+        # instance; reload from disk so its updates are visible within the
+        # session (same reason main.py reloads after processing, and the
+        # same fix ConversationHistory got for issue #181).
+        self.memory_manager.load_memory()
+
         # Add memory summary
         memory_str = self.memory_manager.get_context_string()
         if memory_str:

--- a/chapter3/user-memory/main.py
+++ b/chapter3/user-memory/main.py
@@ -197,6 +197,9 @@ def interactive_mode(user_id: str, memory_mode: MemoryMode = MemoryMode.NOTES,
             elif user_input.lower() == 'memory':
                 print("\n💭 Current Memory State:")
                 print("-"*40)
+                # Reload first: the background processor writes through its
+                # own manager instance, so the agent's copy can be stale.
+                agent.memory_manager.load_memory()
                 print(agent.memory_manager.get_context_string())
                 
             elif user_input.lower() == 'process':


### PR DESCRIPTION
`ConversationalAgent` and `BackgroundMemoryProcessor` hold independent memory-manager instances; the processor writes `{user}_notes.json` to disk, but the agent's `_get_memory_context()` read only the in-memory copy loaded at construction. In `--mode interactive` — the README's headline "Separated Architecture" flow — memories extracted in the background therefore never reached the model's prompt for the rest of the session, and the `memory` command displayed the stale copy. Details in #207.

Fix: `self.memory_manager.load_memory()` at the top of `_get_memory_context()` (and before the `memory` command prints). This mirrors the reload `main.py` already performs for the demo flow ("The processor and agent have separate memory manager instances, so we need to reload") and the fix `ConversationHistory` received for #181.

Verified: `py_compile` passes on both files; all memory-manager variants (notes / JSON cards / advanced) implement `load_memory`, so the reload is safe in every mode.

Fixes #207