### PR TITLE
fix(book-ru): 修复配图标签溢出 / figure label overflow (4 figures)

### DIFF
--- a/book-ru/images/fig0-1.svg
+++ b/book-ru/images/fig0-1.svg
@@ -8,7 +8,8 @@
 <!-- Central Agent circle -->
 <circle cx="390" cy="230" r="68" fill="#e8e8e8" stroke="#333333" stroke-width="2.5"/>
 <text x="390" y="222" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="22" fill="#333333" text-anchor="middle" font-weight="bold">Агент</text>
-<text x="390" y="248" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle">Автономная система принятия решений</text>
+<text x="390" y="244" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12" fill="#666666" text-anchor="middle">Автономная система</text>
+<text x="390" y="260" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12" fill="#666666" text-anchor="middle">принятия решений</text>
 
 <!-- LLM (top) -->
 <rect x="295" y="62" width="190" height="72" rx="8" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>

--- a/book-ru/images/fig1-5.svg
+++ b/book-ru/images/fig1-5.svg
@@ -25,8 +25,8 @@
 <polygon points="410.0,137.0 440.0,157 410.0,177.0 380.0,157" fill="#ffffff" stroke="#333333" stroke-width="2"/>
 <text x="410.0" y="157" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.0" fill="#333333" text-anchor="middle" dominant-baseline="central">Гейтинг</text>
 <line x1="410.0" y1="120" x2="410.0" y2="137" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="70.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">"Заметки о выпуске продукта"</text>
-<text x="215.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ План из 5 разделов</text>
-<text x="360.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ Документ на 3000 слов</text>
-<text x="505.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ EN / JP / KR</text>
+<text x="70.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="10" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">"Заметки о выпуске продукта"</text>
+<text x="215.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ План из 5 разделов</text>
+<text x="360.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ Документ на 3000 слов</text>
+<text x="505.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ EN / JP / KR</text>
 </svg>

--- a/book-ru/images/fig1-wf-chaining.svg
+++ b/book-ru/images/fig1-wf-chaining.svg
@@ -20,8 +20,8 @@
 <polygon points="410.0,137.0 440.0,157 410.0,177.0 380.0,157" fill="#ffffff" stroke="#333333" stroke-width="2"/>
 <text x="410.0" y="157" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#333333" text-anchor="middle" dominant-baseline="central">Гейтинг</text>
 <line x1="410.0" y1="120" x2="410.0" y2="137" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="70.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">&amp;quot;Заметки о релизе продукта&amp;quot;</text>
-<text x="215.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ план из 5 разделов</text>
-<text x="360.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ документ на 3000 слов</text>
-<text x="505.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ EN / JP / KR</text>
+<text x="70.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="10" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">«Заметки о релизе продукта»</text>
+<text x="215.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ план из 5 разделов</text>
+<text x="360.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ документ на 3000 слов</text>
+<text x="505.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ EN / JP / KR</text>
 </svg>

--- a/book-ru/images/fig2-10.svg
+++ b/book-ru/images/fig2-10.svg
@@ -27,13 +27,13 @@
 <rect x="80" y="330" width="660" height="130" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
 <text x="410" y="355" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="19" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Сравнение производительности (общий контекст 3000 токенов)</text>
 <line x1="100" y1="370" x2="720" y2="370" stroke="#999999" stroke-width="2"/>
-<text x="250" y="390" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Попадание в кэш</text>
+<text x="290" y="390" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Попадание в кэш</text>
 <text x="490" y="390" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Промах кэша</text>
 <line x1="100" y1="405" x2="720" y2="405" stroke="#999999" stroke-width="2"/>
 <text x="130" y="425" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">TTFT</text>
-<text x="250" y="425" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">~0.5 секунды</text>
+<text x="290" y="425" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">~0.5 секунды</text>
 <text x="490" y="425" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">3-5 секунд</text>
 <text x="130" y="450" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">Стоимость</text>
-<text x="250" y="450" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Только новые токены</text>
-<text x="490" y="450" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Все токены пересчитываются заново</text>
+<text x="290" y="450" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Только новые токены</text>
+<text x="490" y="450" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Все токены пересчитываются заново</text>
 </svg>


### PR DESCRIPTION
## 修复 book-ru 配图标签溢出 / Fix figure label overflow in book-ru

这是对 #187（俄语翻译 `book-ru`）的小修复。下列标签是**独立文本**（不在方框内），因此俄语译文比原文长之后发生溢出：

- **fig0-1**：中心副标题「Автономная система принятия решений」拆成两行，放入「Агент」圆圈内（原来是一行，压到了两侧箭头上）。
- **fig1-5 / fig1-wf-chaining**：底部示例文字不再互相重叠（字号 14 → 10/11）；并修复了 `fig1-wf-chaining` 中被双重转义的 `&quot;`（`&amp;quot;` → 「«»」）。
- **fig2-10**：「缓存命中」列右移，两处较宽的单元格字号 16 → 13，使「Стоимость」（成本）行标签不再与「Только новые токены」重叠。

已通过 SVG→PDF 渲染与俄语 PDF 完整重建验证。**仅改动 4 个 SVG 文件**。

---

Small follow-up to #187 (Russian `book-ru`). These labels are free-standing text (not inside a box), so the Russian translations overflowed:

- **fig0-1** — the center subtitle *"Автономная система принятия решений"* is split into two lines inside the Agent circle (was one line overlapping the arrows).
- **fig1-5 / fig1-wf-chaining** — the bottom example runs no longer overlap (font 14 → 10/11); also fixed a double-escaped `&quot;` in `fig1-wf-chaining` (`&amp;quot;` → `«»`).
- **fig2-10** — the "cache hit" column is shifted right and two wide cells shrink 16 → 13, so the *"Стоимость"* (Cost) row label no longer collides with *"Только новые токены"*.

Verified by SVG→PDF render and a full rebuild of the Russian PDF. Only 4 SVG files changed.

Russian translation by **@ui99ru**. 🙏
