### PR TITLE
collaboration-tools: guard response.usage=None in generate/reasoning tools

### DIFF
--- a/chapter4/collaboration-tools/src/intelligence_tools.py
+++ b/chapter4/collaboration-tools/src/intelligence_tools.py
@@ -76,7 +76,7 @@ Provide clean, well-documented Python code that solves the task."""
             "task": task_description,
             "code": code,
             "model": model,
-            "tokens_used": response.usage.total_tokens
+            "tokens_used": response.usage.total_tokens if response.usage else 0
         }
         
     except Exception as e:
@@ -130,7 +130,7 @@ Think through this problem step by step. Provide {reasoning_steps} clear reasoni
             "problem": problem,
             "reasoning": reasoning,
             "model": model,
-            "tokens_used": response.usage.total_tokens
+            "tokens_used": response.usage.total_tokens if response.usage else 0
         }
         
     except Exception as e:


### PR DESCRIPTION
`generate_python_code` and `complex_problem_reasoning` accessed `response.usage.total_tokens` unguarded. When a provider returns `usage=None` — the exact case this repo regression-tests elsewhere (`chapter4/active-tool-selection/test_usage_none.py`) and which the project's OpenRouter fallback makes reachable — the `AttributeError` was swallowed by the broad `except`, and an already-produced result came back as `{"success": False, "error": "... 'NoneType' object has no attribute 'total_tokens'"}`. Details in #220.

Fix: `response.usage.total_tokens if response.usage else 0` at both sites — the same guard the sibling `subagent_tools.py` already uses.

Verified: `py_compile` passes.

Fixes #220