### PR TITLE
system-hint: actually record tool duration_ms in the trajectory

### DIFF
--- a/chapter2/system-hint/agent.py
+++ b/chapter2/system-hint/agent.py
@@ -462,12 +462,12 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
         
         return tools
     
-    def _execute_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Tuple[Any, Optional[str]]:
+    def _execute_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Tuple[Any, Optional[str], Optional[int]]:
         """
         Execute a tool and return the result with detailed error information
-        
+
         Returns:
-            Tuple of (result, error_detail)
+            Tuple of (result, error_detail, duration_ms)
         """
         start_time = datetime.now()
         
@@ -486,10 +486,10 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                 result = self._tool_update_todo_status(**arguments)
             else:
                 error = f"Unknown tool: {tool_name}"
-                return {"error": error}, error
-            
+                return {"error": error}, error, None
+
             duration_ms = int((datetime.now() - start_time).total_seconds() * 1000)
-            return result, None
+            return result, None, duration_ms
             
         except Exception as e:
             duration_ms = int((datetime.now() - start_time).total_seconds() * 1000)
@@ -498,9 +498,9 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
             error_detail = self._get_detailed_error(e, tool_name, arguments)
             
             if self.config.enable_detailed_errors:
-                return {"error": error_detail}, error_detail
+                return {"error": error_detail}, error_detail, duration_ms
             else:
-                return {"error": str(e)}, str(e)
+                return {"error": str(e)}, str(e), duration_ms
     
     def _get_detailed_error(self, exception: Exception, tool_name: str, arguments: Dict[str, Any]) -> str:
         """Get detailed error information for debugging"""
@@ -893,7 +893,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                             logger.info(f"  📥 Args: {args_str}")
                         
                         # Execute the tool
-                        result, error = self._execute_tool(function_name, function_args)
+                        result, error, duration_ms = self._execute_tool(function_name, function_args)
                         
                         # Print tool result in a concise format
                         if error:
@@ -935,7 +935,8 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                             arguments=function_args,
                             result=result if not error else None,
                             error=error,
-                            call_number=call_number
+                            call_number=call_number,
+                            duration_ms=duration_ms
                         )
                         self.tool_calls.append(tool_call_record)
                         


### PR DESCRIPTION
`_execute_tool` measured `duration_ms` on both the success and error paths, then returned only `(result, error)`; the `ToolCall` record was constructed without it, so every entry in `trajectory.json` carried `"duration_ms": null` even though the dataclass documents the field and the timing was already computed. Details in #222.

Fix: `_execute_tool` now returns `(result, error_detail, duration_ms)` (all three paths, including unknown-tool), and the single caller passes it into `ToolCall`.

Verified: `py_compile` passes; the only call site was updated.

Fixes #222