### PR TITLE
elo-leaderboard: align the parallel win-rate matrix with the serial one on ties and missing pairs

### DIFF
--- a/chapter6/elo-leaderboard/parallel_processing.py
+++ b/chapter6/elo-leaderboard/parallel_processing.py
@@ -123,15 +123,18 @@ def calculate_pairwise_win_rates_chunk(args: Tuple) -> List[dict]:
         total = len(matches)
         
         for _, row in matches.iterrows():
+            # Arena data has four winner values; any non-win outcome
+            # ('tie' and 'tie (bothbad)') is worth 0.5, matching the
+            # serial calculate_win_rate_matrix_from_data.
             if row['model_a'] == model_a:
                 if row['winner'] == 'model_a':
                     wins_a += 1
-                elif row['winner'] == 'tie':
+                elif row['winner'] != 'model_b':
                     wins_a += 0.5
             else:  # model_a is model_b in the row
                 if row['winner'] == 'model_b':
                     wins_a += 1
-                elif row['winner'] == 'tie':
+                elif row['winner'] != 'model_a':
                     wins_a += 0.5
         
         win_rate = wins_a / total if total > 0 else 0.5
@@ -189,8 +192,11 @@ def calculate_win_rate_matrix_parallel(df: pd.DataFrame,
     # Flatten results
     all_results = [item for chunk in results_chunks for item in chunk]
     
-    # Build matrix
-    win_rates = {model: {opponent: 0.5 for opponent in models} for model in models}
+    # Build matrix. Pairs with no data stay NaN (the serial version's
+    # convention) — 0.5 would misreport "no data" as an even record;
+    # the diagonal is 0.5 by definition.
+    win_rates = {model: {opponent: (0.5 if opponent == model else np.nan)
+                         for opponent in models} for model in models}
     
     for result in all_results:
         model_a = result['model_a']


### PR DESCRIPTION
Two divergences from the serial `calculate_win_rate_matrix_from_data` (details in #224):

1. The parallel pairwise counter credited 0.5 only for the exact string `'tie'`; real Arena data also contains `'tie (bothbad)'`, which counted in the denominator while awarding 0 — and `win_rates[model_b][model_a] = 1.0 - win_rate` then handed the missing mass to the opponent. Example: 1 a-win + 1 bothbad → serial 0.75/0.25, parallel 0.5/0.5. (The Elo core was already fixed for this outcome — `test_tie_bothbad.py` — this path was missed.) Now any non-win outcome scores 0.5, mirroring the serial `else: # tie` catch-all.
2. Missing pairs were initialized to 0.5 where the serial version uses `np.nan`, misreporting "no data" as an even record. Now NaN, with the diagonal kept at 0.5.

Verified with a 2-battle repro through the real `calculate_pairwise_win_rates_chunk`: A-vs-B now returns 0.75 (was 0.5); `py_compile` passes.

Fixes #224