### PR TITLE
browser-use-rpa: make workflow replay use the new task's parameters

### DIFF
--- a/chapter8/browser-use-rpa/learning_agent/agent.py
+++ b/chapter8/browser-use-rpa/learning_agent/agent.py
@@ -432,22 +432,39 @@ class LearningAgent:
                 description=f"Learned workflow for: {self.task}",
                 initial_url=self.captured_steps[0].get('url') if self.captured_steps else None
             )
-            
+
+            # Template the captured literals with the learning task's
+            # parameters: captured steps store the exact values typed during
+            # learning, and parameterize() only substitutes {placeholder}
+            # tokens — without this step a replay would silently re-send the
+            # learning run's recipient/subject/content.
+            example_params = self._extract_task_parameters(self.task, workflow)
+            workflow.example_parameters = dict(example_params)
+
             # Convert captured steps to workflow steps
             for step_data in self.captured_steps:
+                parameters = dict(step_data['parameters'])
+                for key, value in parameters.items():
+                    if isinstance(value, str):
+                        for param_key, param_value in example_params.items():
+                            pv = str(param_value)
+                            if pv and pv in value:
+                                value = value.replace(pv, f"{{{param_key}}}")
+                        parameters[key] = value
+
                 step = WorkflowStep(
                     action_type=step_data['type'],
-                    parameters=step_data['parameters']
+                    parameters=parameters
                 )
-                
+
                 # Add element info if available
                 if step_data.get('element_info'):
                     element_info = step_data['element_info']
                     step.xpath = element_info.get('xpath')
                     step.element_attributes = element_info.get('attributes', {})
-                
+
                 workflow.add_step(step)
-            
+
             # Save to knowledge base
             self.knowledge_base.save_workflow(workflow)
             


### PR DESCRIPTION
`Workflow.parameterize()` substitutes only `{placeholder}` tokens, but capture stored the **literal** values typed during learning, nothing ever wrote placeholders, and `example_parameters` stayed empty — so the parameters `_extract_task_parameters` pulled from the new task were computed and then silently discarded, and replay re-typed the learning run's recipient/subject/content. `demo_email.py` explicitly promises "Phase 2 replays it with different parameters". Details in #235. (This became user-visible once #208 made capture record input steps at all.)

Fix, at `_save_learned_workflow` time: extract the learning task's parameters, replace their occurrences inside captured string values with the matching `{recipient}`/`{subject}`/`{content}` tokens, and store the originals in `workflow.example_parameters`. `parameterize()` then does exactly what it was designed to do.

Verified with a round-trip through the real `Workflow.parameterize()`: learning with `test@example.com` / `"Hello"` / `"First message"`, then replaying a task with `another@example.com` / `"Workflow Test"` / `"Replayed"`, produces input steps carrying the **new** values. `py_compile` passes.

Fixes #235