### PR TITLE
chapter9/10: degrade gracefully when the model rejects a custom temperature

### DIFF
--- a/chapter10/multi-role-transfer/orchestrator.py
+++ b/chapter10/multi-role-transfer/orchestrator.py
@@ -104,12 +104,21 @@ class MultiRoleOrchestrator:
         """
         self._log_role_banner()
 
-        response = self.client.chat.completions.create(
+        kwargs = dict(
             model=self.model,
             messages=self._messages_for_api(),
             tools=self._tools_for_current_role(),
             temperature=0,
         )
+        try:
+            response = self.client.chat.completions.create(**kwargs)
+        except Exception as e:
+            # 推理模型（如 gpt-5.x）只接受默认 temperature，会拒绝自定义值；
+            # 移除该参数重试一次（同 book-translation / voice-werewolf 的做法）。
+            if "temperature" not in str(e).lower():
+                raise
+            kwargs.pop("temperature", None)
+            response = self.client.chat.completions.create(**kwargs)
         msg = response.choices[0].message
 
         # 没有工具调用 => 最终回复

--- a/chapter9/end-to-end-speech/speech_model.py
+++ b/chapter9/end-to-end-speech/speech_model.py
@@ -243,7 +243,7 @@ class CascadedSpeechModel:
     # -- 阶段 2：LLM 思考 ----------------------------------------------------
     def think(self, question_text: str) -> StageResult:
         t0 = time.perf_counter()
-        resp = self.llm_client.chat.completions.create(
+        kwargs = dict(
             model=self.llm_model,
             messages=[
                 {"role": "system", "content": self.system_prompt},
@@ -251,6 +251,15 @@ class CascadedSpeechModel:
             ],
             temperature=0.3,
         )
+        try:
+            resp = self.llm_client.chat.completions.create(**kwargs)
+        except Exception as e:
+            # 推理模型（如 gpt-5.x）只接受默认 temperature，会拒绝自定义值；
+            # 移除该参数重试一次（同 book-translation / voice-werewolf 的做法）。
+            if "temperature" not in str(e).lower():
+                raise
+            kwargs.pop("temperature", None)
+            resp = self.llm_client.chat.completions.create(**kwargs)
         latency = time.perf_counter() - t0
         return StageResult(
             name="LLM 思考",

--- a/chapter9/phone-agent/agent.py
+++ b/chapter9/phone-agent/agent.py
@@ -20,6 +20,18 @@ from typing import Any, Callable
 # 复用 pine_voice 里的统一 client/模型解析（OPENAI_API_KEY 直连，缺失则回退 OpenRouter）。
 from pine_voice import make_phone_call, _get_client, default_model
 
+
+def _create_chat(**kwargs):
+    """推理模型（如 gpt-5.x）只接受默认 temperature，会拒绝自定义值；
+    失败时移除 temperature 重试一次（同 book-translation / voice-werewolf）。"""
+    try:
+        return _get_client().chat.completions.create(**kwargs)
+    except Exception as e:
+        if "temperature" not in str(e).lower() or "temperature" not in kwargs:
+            raise
+        kwargs.pop("temperature", None)
+        return _get_client().chat.completions.create(**kwargs)
+
 # 最多允许 Agent 发起几次工具调用（含追问/再拨），防止死循环。
 _MAX_STEPS = 6
 
@@ -122,7 +134,7 @@ def run_agent(
     ]
 
     for _ in range(_MAX_STEPS):
-        resp = _get_client().chat.completions.create(
+        resp = _create_chat(
             model=model,
             messages=messages,
             tools=_TOOLS,
@@ -180,7 +192,7 @@ def run_agent(
             "content": "请根据以上通话记录，立即给用户一份最终汇报，不要再打电话了。",
         }
     )
-    resp = _get_client().chat.completions.create(
+    resp = _create_chat(
         model=model, messages=messages, temperature=0.3
     )
     final = resp.choices[0].message.content or ""

--- a/chapter9/phone-agent/pine_voice.py
+++ b/chapter9/phone-agent/pine_voice.py
@@ -128,11 +128,20 @@ def _chat(
     temperature: float = 0.7,
     model: str | None = None,
 ) -> str:
-    resp = _get_client().chat.completions.create(
+    kwargs = dict(
         model=model or default_model(),
         messages=messages,
         temperature=temperature,
     )
+    try:
+        resp = _get_client().chat.completions.create(**kwargs)
+    except Exception as e:
+        # 推理模型（如 gpt-5.x）只接受默认 temperature，会拒绝自定义值；
+        # 移除该参数重试一次（同 book-translation / voice-werewolf 的做法）。
+        if "temperature" not in str(e).lower():
+            raise
+        kwargs.pop("temperature", None)
+        resp = _get_client().chat.completions.create(**kwargs)
     return (resp.choices[0].message.content or "").strip()
 
 


### PR DESCRIPTION
Four call sites send a custom `temperature` (0.0 / 0.3 / 0.7) to the default model `gpt-5.6-luna`. This repo's own sibling projects assert three times — with working fallbacks — that gpt-5.x rejects non-default temperature ("推理模型（如 gpt-5.x）只接受默认 temperature，会拒绝自定义值" in book-translation; "显式传 temperature 会 400" in staged-system-prompt; `_safe_create` in voice-werewolf), so a default-configuration online run of these projects 400s — in the end-to-end-speech demo *after* the paid TTS + e2e + ASR legs already ran. Details in #236.

This applies the existing remove-temperature-and-retry pattern at all four sites:

- `chapter9/end-to-end-speech/speech_model.py` (`think()`)
- `chapter9/phone-agent/agent.py` (both `create` calls, via a small `_create_chat` helper)
- `chapter9/phone-agent/pine_voice.py` (`_chat`, which covers both of its temperature call sites)
- `chapter10/multi-role-transfer/orchestrator.py` (`_run_one_llm_turn`)

Non-reasoning models keep their requested temperature; only the rejection path drops it. Verified: `py_compile` passes on all four files.

Fixes #236