### PR TITLE
user-memory: send the history/memory context transiently instead of persisting it every turn

### DIFF
--- a/chapter3/user-memory/conversational_agent.py
+++ b/chapter3/user-memory/conversational_agent.py
@@ -223,14 +223,19 @@ You MUST analyze the context, user's questions and memories in detail, and provi
                 logger.info(f"Memory context added: {memory_context}")
             logger.info(f"Full prompt sent to API: {full_message}")
         
-        # Add to conversation
-        self.conversation.append({"role": "user", "content": full_message})
-        
+        # Persist only the raw message; the memory/history context block is
+        # sent transiently as this call's last message. Persisting
+        # full_message would embed the entire history inside every user turn
+        # of a conversation that already contains the previous turns natively,
+        # so tokens per turn would grow O(N^2) across the session.
+        self.conversation.append({"role": "user", "content": message})
+        api_messages = self.conversation[:-1] + [{"role": "user", "content": full_message}]
+
         try:
             # Call the model with streaming
             stream = self.client.chat.completions.create(
                 model=self.model,
-                messages=self.conversation,
+                messages=api_messages,
                 temperature=_reasoning_safe_temperature(self.model, self.config.temperature),
                 max_tokens=self.config.max_tokens,
                 stream=True


### PR DESCRIPTION
`chat()` appended `full_message` — the user message plus a context block containing the **entire conversation history** — to the persistent `self.conversation`, which already contains all previous turns natively, each previous user message carrying *its own* embedded history block. Tokens per turn grew O(N²): after 10 exchanges of ~100 tokens, turn 11 shipped ~65 duplicated turn-copies instead of 10, burning budget and hitting the context limit early. Details in #240.

Fix: persist only the raw `message`; build `api_messages = conversation[:-1] + [context-augmented message]` and send that to the API. The model still sees the memory notes + full history on every call — the stored conversation just stops nesting copies of itself.

Verified: `py_compile` passes; the single `chat.completions.create` site now uses the transient list.

Fixes #240