### PR TITLE
contextual-retrieval-for-user-memory: guard tool-arg parsing; stop streaming path from mis-reporting success

### DIFF
--- a/chapter3/contextual-retrieval-for-user-memory/contextual_agent.py
+++ b/chapter3/contextual-retrieval-for-user-memory/contextual_agent.py
@@ -334,9 +334,14 @@ Remember: Good service answers the question. Great service anticipates what come
                         
                         # Handle tool calls in stream
                         if chunk.choices[0].delta.tool_calls:
-                            for tc in chunk.choices[0].delta.tool_calls:
-                                # Build tool calls from stream
-                                pass  # Simplified for brevity
+                            # Tool-call deltas are not accumulated on this
+                            # path; silently dropping them would produce an
+                            # empty answer marked success=True. Fail loudly
+                            # until streaming tool support is implemented.
+                            raise NotImplementedError(
+                                "stream=True does not support tool calls yet; "
+                                "use stream=False"
+                            )
                     
                     # Process complete response
                     assistant_message = {
@@ -373,8 +378,20 @@ Remember: Good service answers the question. Great service anticipates what come
                     
                     for tool_call in assistant_message["tool_calls"]:
                         tool_name = tool_call["function"]["name"]
-                        tool_args = json.loads(tool_call["function"]["arguments"])
-                        
+                        # The assistant message with tool_calls is already in
+                        # the conversation; answer malformed arguments with an
+                        # error tool message instead of failing the question
+                        # (same guard as the sibling agents).
+                        try:
+                            tool_args = json.loads(tool_call["function"]["arguments"] or "{}")
+                        except json.JSONDecodeError as exc:
+                            messages.append({
+                                "role": "tool",
+                                "tool_call_id": tool_call["id"],
+                                "content": json.dumps({"error": f"Invalid tool arguments (not valid JSON): {exc}"})
+                            })
+                            continue
+
                         # Execute tool
                         tool_result = self._execute_tool(tool_name, tool_args)
                         


### PR DESCRIPTION
Two defects in `contextual_agent.answer_question` (details in #241):

1. `json.loads(tool_call["function"]["arguments"])` was unguarded while the four sibling agents in this repo guard the identical line — malformed or empty arguments raised into the per-iteration `except`, which `break`s and fails the whole evaluation question. Now the parse failure is answered with a `role: "tool"` error message for that `tool_call_id` and the loop continues, keeping the history valid and letting the model retry.

2. The public, docstring-documented `stream=True` path dropped every tool-call delta (`pass  # Simplified for brevity`), so a tool-using model produced an empty assistant message that landed in the final-answer branch as `final_answer=""` with `success=True` — a silently wrong "success". Until streaming tool-call accumulation is implemented, that path now raises `NotImplementedError` (all current callers pass `stream=False`, so nothing functional changes for them).

Verified: `py_compile` passes; the error tool message appends to the same `messages` list the normal tool-result path uses.

Fixes #241