### PR TITLE
context-compression: remove code comments leaking into LLM prompts

### DIFF
--- a/chapter2/context-compression/compression_strategies.py
+++ b/chapter2/context-compression/compression_strategies.py
@@ -156,7 +156,7 @@ class ContextCompressor:
 Focus on information relevant to: {query}
 
 Original content:
-{content[:10000]}  # Limit for history compression
+{content[:10000]}
 
 Requirements:
 1. Keep all important facts, names, dates, and affiliations
@@ -279,7 +279,7 @@ Title: {result.get('title', 'N/A')}
 URL: {result.get('url', 'N/A')}
 
 Content:
-{original_content[:5000]}  # Limit to prevent token overflow
+{original_content[:5000]}
 
 Provide a concise summary:"""
 
@@ -490,7 +490,7 @@ Analyze the following search results and provide a focused summary that directly
 Focus on extracting information most relevant to answering: {query}
 
 Search Results:
-{combined_content}  # Already limited per page
+{combined_content}
 
 Requirements:
 1. Focus only on information relevant to the query
@@ -601,7 +601,7 @@ Content: {limited_content}
 Analyze the following search results and provide a focused summary with citations.
 
 Search Results (with source IDs):
-{combined_content}  # Already limited per page
+{combined_content}
 
 Requirements:
 1. Focus on information relevant to: {query}


### PR DESCRIPTION
Four prompt templates in `compression_strategies.py` contained Python-style comments **inside** the f-string literals (`{content[:10000]}  # Limit for history compression`, `{original_content[:5000]}  # Limit to prevent token overflow`, `{combined_content}  # Already limited per page` ×2), so every summarization prompt shipped stray pseudo-comments to the model right after the embedded content. Clearly intended as code comments — the slicing they describe happens in the expressions themselves. Details in #242.

Removed all four; no functional slicing changed. `py_compile` passes.

Fixes #242