### PR TITLE
chapter1/context: make the $/S$ currency normalization reachable

### DIFF
--- a/chapter1/context/agent.py
+++ b/chapter1/context/agent.py
@@ -138,9 +138,11 @@ class ToolRegistry:
             Dictionary with conversion result
         """
         try:
-            # Normalize currency codes (handle S$ notation)
-            from_currency = from_currency.replace("S$", "SGD").replace("$", "USD") if from_currency.startswith("S$") else from_currency
-            to_currency = to_currency.replace("S$", "SGD").replace("$", "USD") if to_currency.startswith("S$") else to_currency
+            # Normalize currency codes (handle S$ / $ notation). Must be
+            # unconditional: gated on startswith("S$"), the "$" -> USD
+            # replacement could never fire (no "$" survives the S$ replace).
+            from_currency = from_currency.upper().replace("S$", "SGD").replace("$", "USD")
+            to_currency = to_currency.upper().replace("S$", "SGD").replace("$", "USD")
             
             logger.info(f"Converting {amount} {from_currency} to {to_currency}")
             


### PR DESCRIPTION
The `"$" → USD` replacement in `convert_currency` only ran when the code started with `"S$"` — and after `replace("S$", "SGD")` no `$` remains — so it could never fire; a model passing `"$"` got `Unsupported currency: $`. Details in #243.

Fix: apply the normalization unconditionally with `.upper()`, exactly as `chapter2/local_llm_serving/tools.py` already does. Checked cases: `$`→USD, `S$`→SGD, `usd`→USD, `EUR` unchanged; `py_compile` passes.

Fixes #243