### PR TITLE
system-hint: stop rejecting compound commands that start with cd

### DIFF
--- a/chapter2/system-hint/agent.py
+++ b/chapter2/system-hint/agent.py
@@ -711,9 +711,14 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
             elif not os.path.isabs(working_dir):
                 working_dir = os.path.join(self.current_directory, working_dir)
             
-            # Update current directory if 'cd' command
-            if command.strip().startswith('cd '):
-                new_dir = command.strip()[3:].strip()
+            # Update current directory if the command is a PURE 'cd'.
+            # Compound commands like `cd proj && make` must fall through to
+            # the subprocess below (which runs with cwd=working_dir) —
+            # intercepting them here would treat "proj && make" as the
+            # directory name and fail with "Directory not found".
+            stripped = command.strip()
+            if stripped.startswith('cd ') and not any(t in stripped for t in ('&&', ';', '|')):
+                new_dir = stripped[3:].strip()
                 if not os.path.isabs(new_dir):
                     new_dir = os.path.join(self.current_directory, new_dir)
                 


### PR DESCRIPTION
`_tool_execute_command` treated everything after `cd ` as a directory name, so `cd /tmp && ls` became `new_dir = "/tmp && ls"` → `FileNotFoundError: Directory not found` — failing one of the most common command shapes LLM agents emit. Details in #244.

Fix: only intercept **pure** `cd` (no `&&` / `;` / `|`); compound commands fall through to `subprocess.run(..., shell=True, cwd=working_dir)`, where the embedded `cd` works normally. Pure `cd` still updates the agent's tracked `current_directory`.

Verified: `py_compile` passes.

Fixes #244