### PR TITLE
Fix false claim of an in-repo pointer doc for use-computer-while-calling

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ git clone https://github.com/19PINE-AI/TalkAct.git                     chapter10
 git clone https://github.com/joonspk-research/generative_agents.git    chapter10/generative_agents             # 实验 10-7 斯坦福 AI 小镇
 ```
 
-> 各项目 README 如标注了特定 commit，请按说明 `git checkout` 到对应版本以保证复现一致。第 10 章 `use-computer-while-calling` 已发展为独立维护的 [19PINE-AI/TalkAct](https://github.com/19PINE-AI/TalkAct)，本仓库只保留指向它的说明文档。
+> 各项目 README 如标注了特定 commit，请按说明 `git checkout` 到对应版本以保证复现一致。第 10 章 `use-computer-while-calling` 已发展为独立维护的 [19PINE-AI/TalkAct](https://github.com/19PINE-AI/TalkAct)，本仓库不内置该目录，用上面的克隆命令获取。
 
 </details>
 

--- a/chapter10/README.md
+++ b/chapter10/README.md
@@ -8,7 +8,7 @@
 
 | 项目 | 类型 | 一句话说明 |
 | --- | :--: | --- |
-| `use-computer-while-calling/` | 📖 | 电话 Agent（Node.js）与浏览器 Agent（Python）经 WebSocket 直接通信无协调器并行协作；代码已独立为 [TalkAct](https://github.com/19PINE-AI/TalkAct)，本目录仅保留说明 |
+| `use-computer-while-calling/` | 📖 | 电话 Agent（Node.js）与浏览器 Agent（Python）经 WebSocket 直接通信无协调器并行协作；代码已独立为 [TalkAct](https://github.com/19PINE-AI/TalkAct)，本仓库不内置该目录（克隆命令见主 README 附录） |
 | [staged-system-prompt](staged-system-prompt/) | ✅ | 同一 Coding Agent 在需求澄清/实现/审查三阶段加载不同提示词与工具集，对话历史跨阶段共享，审查不通过可回退 |
 | [multi-role-transfer](multi-role-transfer/) | ✅ | 共享上下文下的链式 handoff：多角色各有独立提示词与工具，通过 `transfer_to_agent` 自主切换 |
 | [book-translation](book-translation/) | ✅ | 管理者模式拆分翻译给术语表/翻译/审校专职 Agent，Manager 只存索引、译文全落盘，上下文基本恒定 |


### PR DESCRIPTION
`README.md` said the repo "只保留指向它的说明文档" and `chapter10/README.md` said "本目录仅保留说明" for `use-computer-while-calling` — but no such directory or file exists (`find -iname '*use-computer*'` returns only these mentions). Deliberately **not** adding a doc at that path: the appendix's `git clone … chapter10/use-computer-while-calling` only works because the directory is absent. Both spots now say the directory is not bundled and point at the clone command / TalkAct. Details in #256.

Fixes #256