### PR TITLE
Align external-repo clone script with chapter READMEs (AdaptThink, AWorld, lighteval)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@
 
 ## 📦 附录 · 外部仓库获取
 
-第 6、7、9、10 章的评测基准、训练框架、机器人平台等 20 个外部仓库**未内置**（出于体积与版权），需要自行克隆到对应目录。
+第 6、7、9、10 章的评测基准、训练框架、机器人平台等 19 个外部仓库**未内置**（出于体积与版权），需要自行克隆到对应目录。
 
 ### 一键克隆脚本
 
 <details>
-<summary><b>🔧 展开克隆命令</b>（共 20 个外部仓库）</summary>
+<summary><b>🔧 展开克隆命令</b>（共 19 个外部仓库）</summary>
 
 ```bash
 # 第 6 章 · 评测基准
@@ -96,7 +96,6 @@ git clone https://github.com/bojieli/AWorld.git                        chapter7/
 git clone https://github.com/bojieli/SFTvsRL.git                       chapter7/SFTvsRL
 git clone https://github.com/bojieli/verl.git                          chapter7/verl
 git clone https://github.com/thinking-machines-lab/tinker-cookbook.git chapter7/tinker-cookbook
-git clone https://github.com/bojieli/lighteval.git                     chapter7/Intuitor/lighteval
 git clone https://github.com/19PINE-AI/rlvp.git                        chapter7/RLVP/rlvp                       # 实验 7-14 RLVP 论文代码
 git clone https://github.com/PRIME-RL/SimpleVLA-RL.git                 chapter7/SimpleVLA-RL/SimpleVLA-RL       # 实验 7-13 视觉-语言-动作 RL
 

--- a/chapter7/AWorld-train/README.md
+++ b/chapter7/AWorld-train/README.md
@@ -377,9 +377,10 @@ sudo apt-get install -y build-essential git wget
 # 3. 安装 PyTorch（匹配 CUDA 版本）
 pip install torch==2.4.0 torchvision==0.19.0 --index-url https://download.pytorch.org/whl/cu121
 
-# 4. 克隆 AWorld 仓库
-git clone https://github.com/inclusionAI/AWorld.git ~/AWorld
-cd ~/AWorld
+# 4. 克隆 AWorld 仓库（与主 README 一键克隆脚本一致；bojieli/AWorld 为本书
+#    锁定的 fork，也可改用上游 inclusionAI/AWorld）
+git clone https://github.com/bojieli/AWorld.git chapter7/AWorld
+cd chapter7/AWorld
 
 # 5. 安装 VeRL 和依赖（会自动安装 transformers、vllm、deepspeed 等）
 cd /path/to/verl

--- a/chapter7/AdaptThink/README.md
+++ b/chapter7/AdaptThink/README.md
@@ -313,7 +313,7 @@ conda create -n adapt_think python=3.13
 conda activate adapt_think
 
 # 安装依赖
-cd projects/week7/AdaptThink-original
+cd chapter7/AdaptThink-original
 pip install -r requirements.txt
 pip install flash-attn --no-build-isolation
 ```


### PR DESCRIPTION
Cross-checking the appendix's clone lines against the corresponding project READMEs found 3 mismatches (details in #257); the other 17 targets check out.

- **AdaptThink**: `chapter7/AdaptThink/README.md` said `cd projects/week7/AdaptThink-original` — a leftover from a different repo layout; now `cd chapter7/AdaptThink-original`, matching the script's clone target.
- **AWorld**: `chapter7/AWorld-train/README.md` cloned upstream `inclusionAI/AWorld` into `~/AWorld` while the script clones the pinned `bojieli/AWorld` fork into `chapter7/AWorld` — following either doc broke the other's paths. The README now uses the script's target, with a note that the upstream repo is also usable.
- **lighteval**: dropped the `bojieli/lighteval → chapter7/Intuitor/lighteval` line — nothing reads that path (`chapter7/Intuitor/README.md` installs lighteval via `pip install lighteval` and edits the pip-installed source) — and updated "20 个外部仓库" → 19 in both places.

Fixes #257