### PR TITLE
attention_visualization: replace the duplicated Ġ replace with the SentencePiece ▁ marker

### DIFF
--- a/chapter2/attention_visualization/visualization.py
+++ b/chapter2/attention_visualization/visualization.py
@@ -427,7 +427,7 @@ def clean_token_labels(tokens: List[str], max_len: int = 14) -> List[str]:
     for tok in tokens:
         label = tok.replace("\n", "\\n").replace("\t", "\\t")
         # Qwen byte-level space marker and plain spaces -> visible middle dot
-        label = label.replace("Ġ", " ").replace("Ġ", " ")
+        label = label.replace("Ġ", " ").replace("▁", " ")
         if label.strip() == "":
             label = "␣"
         if len(label) > max_len:


### PR DESCRIPTION
`clean_token_labels` did `label.replace("Ġ", " ").replace("Ġ", " ")` — a hexdump confirms both literals are the same U+0120, so the second call was dead, and SentencePiece's `▁` (U+2581) was never handled: tokens from Llama/Qwen-style tokenizers rendered with the literal `▁` glyph in the heatmap axis labels. Details in #258.

The second replace now targets `▁`. `py_compile` passes.

Fixes #258