### PR TITLE
prompt-distillation: don't score teacher-unlabeled sentences as wrong

### DIFF
--- a/chapter8/prompt-distillation/evaluate.py
+++ b/chapter8/prompt-distillation/evaluate.py
@@ -128,8 +128,11 @@ def evaluate_model(
         pred_label = parse_language_label(response)
         predictions.append(pred_label)
         
-        # Check correctness and show real-time progress
-        if ground_truth_labels and idx < len(ground_truth_labels):
+        # Check correctness and show real-time progress. Rows without ground
+        # truth (teacher never labeled the sentence) are excluded from the
+        # accuracy denominator — counting them as wrong deflated the reported
+        # fidelity by exactly the unmatched fraction.
+        if ground_truth_labels and idx < len(ground_truth_labels) and ground_truth_labels[idx] is not None:
             gt_label = ground_truth_labels[idx]
             is_correct = pred_label == gt_label
             if is_correct:
@@ -185,18 +188,20 @@ def build_confusion_matrix(predictions: List[str], ground_truth: List[str],
     Returns:
         Dict with confusion matrix, per-language stats, and error examples
     """
-    # Get all unique labels
-    all_labels = sorted(set(ground_truth) | set(p for p in predictions if p))
-    
+    # Get all unique labels (rows without ground truth are excluded)
+    all_labels = sorted(set(g for g in ground_truth if g is not None) | set(p for p in predictions if p))
+
     # Initialize confusion matrix
     confusion = defaultdict(lambda: defaultdict(int))
     per_language_stats = defaultdict(lambda: {"correct": 0, "total": 0, "errors": []})
-    
+
     # Build matrix
     for idx, (pred, gt, sentence) in enumerate(zip(predictions, ground_truth, sentences)):
+        if gt is None:
+            continue
         if pred is None:
             pred = "None"
-        
+
         confusion[gt][pred] += 1
         per_language_stats[gt]["total"] += 1
         
@@ -398,12 +403,14 @@ def main():
                         assistant_content = messages[1].get("content", "")
                         sentence_to_label[user_content] = assistant_content
         
-        # Match test sentences to ground truth labels
+        # Match test sentences to ground truth labels. None = no ground truth
+        # for this sentence; such rows are skipped in accuracy and the
+        # confusion matrix instead of being scored as wrong under a phantom
+        # "?" language.
         for sentence in test_sentences:
-            label = sentence_to_label.get(sentence)
-            ground_truth.append(label if label else "?")
-        
-        matched = sum(1 for gt in ground_truth if gt != "?")
+            ground_truth.append(sentence_to_label.get(sentence))
+
+        matched = sum(1 for gt in ground_truth if gt is not None)
         print(f"Matched {matched}/{len(test_sentences)} test sentences to training data")
         
         if matched == 0:


### PR DESCRIPTION
When ground truth is derived from the training JSONL (the default path), sentences the teacher failed to label were assigned gt `"?"` — which then (a) scored as wrong and **incremented the accuracy denominator**, deflating the reported distillation fidelity by exactly the unmatched fraction (2% unmatched on 500 → 94.0% reported vs 95.9% true matched-set accuracy), and (b) entered the confusion matrix as a phantom `"?"` language that typically topped "MOST PROBLEMATIC LANGUAGES" at 0%. Details in #259.

Fix: unmatched rows carry `None`; both the accuracy loop and `build_confusion_matrix` skip them. The `Matched N/M` line still reports coverage.

Verified: `py_compile` passes; no remaining `"?"` sentinel in the file.

Fixes #259