### PR TITLE
MultilingualReasoning: honor --hub_model_id when pushing to the Hub

### DIFF
--- a/chapter7/MultilingualReasoning/gpt_oss_20b_sft.py
+++ b/chapter7/MultilingualReasoning/gpt_oss_20b_sft.py
@@ -298,8 +298,11 @@ def save_and_push_model(trainer, output_dir, push_to_hub=False, hub_model_id=Non
     if push_to_hub:
         if hub_model_id is None:
             raise ValueError("需要提供 hub_model_id 才能推送到 Hub")
-        
+
         print(f"\n推送模型到 Hugging Face Hub: {hub_model_id}")
+        # Trainer.push_to_hub 从 args.hub_model_id 取仓库名；不设置的话会
+        # 忽略用户传入的 --hub_model_id，推到 output_dir 同名的默认仓库。
+        trainer.args.hub_model_id = hub_model_id
         trainer.push_to_hub(
             dataset_name="HuggingFaceH4/Multilingual-Thinking",
         )


### PR DESCRIPTION
`--hub_model_id` was validated as required and printed, but never passed anywhere: `SFTConfig` sets neither `push_to_hub` nor `hub_model_id`, and `Trainer.push_to_hub()` derives the repo from `args.hub_model_id` (falling back to `output_dir`'s basename) — so the model always pushed to `<user>/gpt-oss-20b-multilingual-reasoner` while the console claimed the user's requested id. Details in #261.

Fix: set `trainer.args.hub_model_id = hub_model_id` right before the push — the path `Trainer.push_to_hub → init_hf_repo` reads exactly that field, and this works across trl/transformers versions without changing the training config.

`py_compile` passes.

Fixes #261