### PR TITLE
voice-werewolf: resolve P10/P11+ targets correctly in fuzzy match

### DIFF
--- a/chapter10/voice-werewolf/werewolf/agent.py
+++ b/chapter10/voice-werewolf/werewolf/agent.py
@@ -269,15 +269,17 @@ class PlayerAgent:
             target = raw
         if allow_none and target.lower() in ("none", "", "弃票", "放弃"):
             return None
-        # 归一化：精确匹配优先，否则模糊匹配（找出现的候选名）
+        # 归一化：精确匹配优先
         if target in candidates:
             return target
-        for c in candidates:
-            if c in (target or ""):
-                return c
-        # 最后兜底：从原始串里搜 Pn
+        # 其次：从原始串里搜 Pn 精确 token。必须先于子串匹配——
+        # 否则 10 人以上的局里 "P10（他最可疑）" 会先命中 "P1"。
         m = re.search(r"P\d+", target or "")
         if m and m.group(0) in candidates:
             return m.group(0)
+        # 最后兜底：子串匹配，最长的候选名优先（避免 P1 抢先命中 P10）
+        for c in sorted(candidates, key=len, reverse=True):
+            if c in (target or ""):
+                return c
         # 实在解析不出：好人默认弃票，狼人/必须选的场景由调用方兜底
         return None if allow_none else (candidates[0] if candidates else None)


### PR DESCRIPTION
In games with 10+ players, a decorated answer like `P10（他最可疑）` hit the substring loop first and `P1` matched before `P10`, silently redirecting votes/night-kills/checks onto P1.

The exact-token `P\d+` regex now runs before the substring loop, and the loop is longest-first. Verified: `P10（…）` → P10, `我投 P12` → P12, small games and `none`/弃票 handling unchanged.

Fixes #266