### PR TITLE
build_site.sh: fix broken back-to-main-README links on translated chapter pages

### DIFF
--- a/scripts/build_site.sh
+++ b/scripts/build_site.sh
@@ -91,9 +91,14 @@ find "$DEST" -name '*.md.bak' -delete
 #
 # Only touches README.<lang>.md (not README.md, where the links already work),
 # and only relative links that don't start with . / # http or contain :
+#
+# The "back to main README" links ](../docs/<locale>/README.md) point into
+# docs/, which is never copied into the site's docs_dir — MkDocs leaves the
+# raw href and it 404s. Map them to ../../ (the site home) instead.
 find "$DEST/chapter"* -type f -name 'README.[a-zA-Z-]*.md' -print0 \
   | xargs -0 sed -i.bak -E \
-      -e 's|\]\(([a-zA-Z][a-zA-Z0-9_-]*)/\)|](../\1/)|g'
+      -e 's|\]\(([a-zA-Z][a-zA-Z0-9_-]*)/\)|](../\1/)|g' \
+      -e 's|\]\(\.\./docs/[a-zA-Z-]+/README\.md\)|](../../)|g'
 find "$DEST" -name '*.md.bak' -delete
 
 echo "Assembled docs into $DEST"


### PR DESCRIPTION
The translated chapter index pages (`chapterN/README.<lang>.md`) link back via `](../docs/<locale>/README.md)`, but `docs/` is never copied into the site's `docs_dir`, so MkDocs leaves the raw href and it 404s on all 4 locales × 10 chapters (live-verified in #267).

Added one sed rule mapping those links to `../../` (the site home). Verified the rule against a simulated site tree; existing experiment-link rewrite is unaffected.

Fixes #267