### PR TITLE
streaming-speech: don't duplicate the final full-length endpoint

### DIFF
--- a/chapter9/streaming-speech/demo.py
+++ b/chapter9/streaming-speech/demo.py
@@ -158,7 +158,11 @@ def build_endpoints(total: float, chunk_step: float):
     while t < total:
         endpoints.append(round(t, 3))
         t += chunk_step
-    endpoints.append(round(total, 3))
+    # 浮点累加可能让 t 略小于 total（如 20 × 0.3 = 5.999999999999998），
+    # 此时循环末尾已追加过 round(total, 3)，再追加一次会重复计算一次
+    # 完整音频的 Whisper 转写。
+    if not endpoints or endpoints[-1] != round(total, 3):
+        endpoints.append(round(total, 3))
     return endpoints
 
 


### PR DESCRIPTION
Float accumulation can leave `t` fractionally below `total` (20 × 0.3 = 5.999999999999998 < 6.0), so `build_endpoints(6.0, 0.3)` appended `6.0` twice — one extra paid full-length Whisper transcription per granularity.

The epilogue append is now skipped when the loop already produced `round(total, 3)`. Verified: `(6.0, 0.3)` ends in `[5.7, 6.0]` with a single 6.0; binary-exact steps (0.5/1.0/2.0) and non-divisor steps (0.7) unchanged.

Fixes #268