### PR TITLE
staged-system-prompt: lowercase the question in SimulatedUser keyword matching

### DIFF
--- a/chapter10/staged-system-prompt/simulated_user.py
+++ b/chapter10/staged-system-prompt/simulated_user.py
@@ -38,8 +38,9 @@ class SimulatedUser:
 
     def _match(self, q: str) -> str:
         best_reply, best_score = self.default_answer, 0
+        q_lower = q.lower()  # 关键词已小写，问题也必须小写，否则 "Move or Copy?" 匹配不上 "move"
         for keywords, reply in self.playbook:
-            score = sum(1 for kw in keywords if kw.lower() in q)
+            score = sum(1 for kw in keywords if kw.lower() in q_lower)
             if score > best_score:
                 best_reply, best_score = reply, score
         return best_reply


### PR DESCRIPTION
Keywords are lowercased but the question was not, so English playbook keywords missed capitalized model phrasing — "Move or Copy?" matched neither "move" nor "copy" — and the simulated user fell back to the generic default answer, losing the seeded requirement the implementation stage depends on.

Verified: "Move or Copy?" now hits the move/copy playbook entry; lowercase and unrelated questions behave as before.

Fixes #269