### PR TITLE
feat(site): Open Graph + Twitter Card meta, robots.txt

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ docs_dir: _web
 # `{#sec:foo}`, image `{height=55%}`) which Python-Markdown cannot parse.
 hooks:
   - scripts/mkdocs_pandoc_strip.py
+  - scripts/seo_meta.py
 
 theme:
   name: material

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://bojieli.github.io/ai-agent-book/sitemap.xml

--- a/scripts/build_site.sh
+++ b/scripts/build_site.sh
@@ -13,6 +13,9 @@ mkdir -p "$DEST"
 # Site homepage (root index.md).
 cp "$ROOT/index.md" "$DEST/index.md"
 
+# robots.txt at the site root (points crawlers at the auto-generated sitemap).
+[ -f "$ROOT/robots.txt" ] && cp "$ROOT/robots.txt" "$DEST/robots.txt"
+
 # The language editions, each with its images/ subfolder.
 for lang in book book-en book-ta book-vi book-zhtw; do
   mkdir -p "$DEST/$lang"
@@ -50,6 +53,7 @@ find "$DEST" -type f \
   ! -name '*.jpeg' \
   ! -name '*.js' \
   ! -name '*.css' \
+  ! -name '*.txt' \
   -delete
 
 # Drop bulk data files that some experiments bundle as their dataset but

--- a/scripts/seo_meta.py
+++ b/scripts/seo_meta.py
@@ -1,0 +1,38 @@
+"""Inject Open Graph + Twitter Card meta tags into every page so links
+look rich when shared to WeChat / Twitter / Slack.
+
+Material's `social` plugin can do this but needs cairosvg + image
+rendering that silently no-ops in some CI environments. This hook is
+simpler: it derives all tags from page + site config, no images.
+
+(One concession: there's no og:image. We'd need either a pre-generated
+PNG checked into the repo, or cairosvg on the CI runner. Cards still
+render with title + description — they just don't have a hero image.
+If we want images later, add a single default_og_image path here.)
+"""
+import html
+
+
+def on_post_page(output, page, config, **kwargs):
+    meta = page.meta or {}
+    title = meta.get("title") or page.title or config.get("site_name", "")
+    desc = meta.get("description") or config.get("site_description", "")
+    url = page.canonical_url or ""
+    site = config.get("site_name", "")
+
+    def add(attr, key, val):
+        return f'<meta {attr}="{key}" content="{html.escape(str(val), quote=True)}">'
+
+    tags = [
+        add("property", "og:type", "website"),
+        add("property", "og:site_name", site),
+        add("property", "og:title", title),
+        add("property", "og:description", desc),
+        add("property", "og:url", url),
+        add("property", "og:locale", "zh_CN"),
+        add("name", "twitter:card", "summary"),
+        add("name", "twitter:title", title),
+        add("name", "twitter:description", desc),
+    ]
+    block = "\n".join(t for t in tags if 'content=""' not in t)
+    return output.replace("</head>", block + "\n</head>", 1)


### PR DESCRIPTION
Sharing any page from https://bojieli.github.io/ai-agent-book/ to WeChat / Twitter / Slack currently shows a bare URL — the site has **0 \`og:*\` or \`twitter:*\` meta tags** (verified by \`curl\`-ing the production HTML).

## Two small changes (4 files, +47 lines)

**1. \`scripts/seo_meta.py\`** (~40 lines): a MkDocs hook that injects \`og:type\`, \`og:site_name\`, \`og:title\`, \`og:description\`, \`og:url\`, \`og:locale\`, \`twitter:card\`, \`twitter:title\`, \`twitter:description\` into every page's \`<head>\`. Title and description come from page frontmatter / site config, so each page gets its own card. No image generation — Material's \`social\` plugin can do images but needs cairosvg and silently no-ops in some CI environments; this hook is deterministic.

**2. \`robots.txt\`**: explicit \"allow all\" + pointer to the auto-generated sitemap.xml. Without it, crawlers have to guess.

\`build_site.sh\` copies \`robots.txt\` into \`_web/\` (and the existing extension whitelist now allows \`*.txt\`).

## Before / after

\`\`\`bash
# Production (before this PR)
$ curl https://bojieli.github.io/ai-agent-book/ | grep -c 'property=\"og:'
0

# After
$ curl http://localhost:8000/ai-agent-book/ | grep -c 'property=\"og:'
6
\`\`\`

## What's NOT in this PR

- **No custom OG image.** Cards render with title + description only. Adding an image requires either a pre-generated PNG checked into the repo, or cairosvg on the CI runner. Can be a follow-up if needed.
- **No chapter-title fix.** Chinese chapter prose pages still show \"正文\" as their og:title because the nav in mkdocs.yml nests each chapter with a \"正文\" sub-entry. Fixing that cleanly needs a per-chapter title map (~40 lines) — out of scope for this PR.