### PR TITLE
fix(ollama): expose thinking stream output

### DIFF
--- a/chapter2/local_llm_serving/ollama_native.py
+++ b/chapter2/local_llm_serving/ollama_native.py
@@ -25,6 +25,7 @@ class OllamaNativeAgent:
         self.client = ollama.Client()
         self.tool_registry = ToolRegistry()
         self.conversation_history = []
+        self._think_disabled: set[str] = set()
         
         # Check if Ollama is running
         try:
@@ -42,6 +43,35 @@ class OllamaNativeAgent:
             tools.append(tool_def)
         return tools
     
+    def _chat_with_think_fallback(self, **kwargs) -> dict:
+        """Call client.chat with think=True when supported, falling back gracefully.
+
+        Models without thinking support (qwen2.5, llama3.2, gemma, etc.) return
+        a 400 error when think=True. This method catches the error once per
+        model and retries without think, caching the result so subsequent calls
+        are free. Also catches unexpected errors (old client, unknown issues)
+        and retries — if the error wasn't think-related the retry will fail
+        again and the exception propagates naturally.
+        """
+        if self.model in self._think_disabled:
+            return self.client.chat(**kwargs)
+
+        try:
+            return self.client.chat(think=True, **kwargs)
+        except ollama.ResponseError as e:
+            if e.status_code == 400:
+                logger.info("Model '%s' does not support thinking, disabling", self.model)
+                self._think_disabled.add(self.model)
+                return self.client.chat(**kwargs)
+            raise
+        except Exception:
+            # Unknown failure with think=True (old client, unexpected issues).
+            # Retry without think; if the error was unrelated the retry will
+            # also fail and the exception propagates naturally.
+            logger.warning("think=True failed for '%s', retrying without think", self.model)
+            self._think_disabled.add(self.model)
+            return self.client.chat(**kwargs)
+
     def _execute_tool_calls(self, tool_calls: List[Dict[str, Any]]) -> List[str]:
         """
         Execute tool calls and return results in order.
@@ -102,12 +132,11 @@ class OllamaNativeAgent:
         
         try:
             # Call Ollama with tools
-            response = self.client.chat(
+            response = self._chat_with_think_fallback(
                 model=self.model,
                 messages=self.conversation_history,
                 tools=tools,
                 options={"temperature": temperature},
-                think=True
             )
             
             # Check if model made tool calls
@@ -136,12 +165,11 @@ class OllamaNativeAgent:
                     })
                 
                 # Get final response with tool results (still include tools!)
-                final_response = self.client.chat(
+                final_response = self._chat_with_think_fallback(
                     model=self.model,
                     messages=self.conversation_history,
                     tools=tools,  # IMPORTANT: Keep tools available
                     options={"temperature": temperature},
-                    think=True
                 )
                 
                 final_content = final_response.get('message', {}).get('content', '')
@@ -198,13 +226,12 @@ class OllamaNativeAgent:
             
             try:
                 # Get response from model
-                stream_response = self.client.chat(
+                stream_response = self._chat_with_think_fallback(
                     model=self.model,
                     messages=self.conversation_history,
                     tools=tools,
                     options={"temperature": temperature},
                     stream=True,
-                    think=True
                 )
                 
                 collected_content = []

--- a/chapter2/local_llm_serving/ollama_native.py
+++ b/chapter2/local_llm_serving/ollama_native.py
@@ -106,7 +106,8 @@ class OllamaNativeAgent:
                 model=self.model,
                 messages=self.conversation_history,
                 tools=tools,
-                options={"temperature": temperature}
+                options={"temperature": temperature},
+                think=True
             )
             
             # Check if model made tool calls
@@ -139,7 +140,8 @@ class OllamaNativeAgent:
                     model=self.model,
                     messages=self.conversation_history,
                     tools=tools,  # IMPORTANT: Keep tools available
-                    options={"temperature": temperature}
+                    options={"temperature": temperature},
+                    think=True
                 )
                 
                 final_content = final_response.get('message', {}).get('content', '')
@@ -201,7 +203,8 @@ class OllamaNativeAgent:
                     messages=self.conversation_history,
                     tools=tools,
                     options={"temperature": temperature},
-                    stream=True
+                    stream=True,
+                    think=True
                 )
                 
                 collected_content = []
@@ -214,7 +217,11 @@ class OllamaNativeAgent:
                 for chunk in stream_response:
                     # Extract message content from chunk
                     message_chunk = chunk.get('message', {})
+                    thinking_chunk = message_chunk.get('thinking', '')
                     content_chunk = message_chunk.get('content', '')
+                    
+                    if thinking_chunk:
+                        yield {"type": "thinking", "content": thinking_chunk}
                     
                     if content_chunk:
                         collected_content.append(content_chunk)

--- a/chapter2/local_llm_serving/requirements.txt
+++ b/chapter2/local_llm_serving/requirements.txt
@@ -14,7 +14,7 @@ uvicorn>=0.24.0
 python-weather>=2.0.0
 
 # For Ollama support (Mac/local development)
-ollama>=0.1.0
+ollama>=0.5.1
 
 # For additional tools
 PyPDF2>=3.0.0

--- a/chapter2/local_llm_serving/test_ollama_thinking.py
+++ b/chapter2/local_llm_serving/test_ollama_thinking.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Regression tests for Ollama thinking stream handling."""
+
+import sys
+import types
+
+
+fake_ollama_module = types.ModuleType("ollama")
+setattr(fake_ollama_module, "Client", lambda: None)
+sys.modules.setdefault("ollama", fake_ollama_module)
+
+from ollama_native import OllamaNativeAgent
+
+
+class FakeOllamaClient:
+    def chat(self, **kwargs):
+        self.last_kwargs = kwargs
+        return iter([
+            {"message": {"thinking": "Need current data. "}},
+            {"message": {"content": "Final answer."}},
+        ])
+
+
+def test_streaming_yields_ollama_thinking_field():
+    agent = OllamaNativeAgent(model="qwen3:0.6b")
+    fake_client = FakeOllamaClient()
+    agent.client = fake_client
+
+    chunks = list(agent.chat_stream("hello", use_tools=False, temperature=0.1))
+
+    assert fake_client.last_kwargs["think"] is True
+    assert {"type": "thinking", "content": "Need current data. "} in chunks
+    assert {"type": "content", "content": "Final answer."} in chunks
+
+
+if __name__ == "__main__":
+    test_streaming_yields_ollama_thinking_field()
+    print("ok")

--- a/chapter2/local_llm_serving/test_ollama_thinking.py
+++ b/chapter2/local_llm_serving/test_ollama_thinking.py
@@ -28,9 +28,18 @@ def test_streaming_yields_ollama_thinking_field():
 
     chunks = list(agent.chat_stream("hello", use_tools=False, temperature=0.1))
 
-    assert fake_client.last_kwargs["think"] is True
-    assert {"type": "thinking", "content": "Need current data. "} in chunks
-    assert {"type": "content", "content": "Final answer."} in chunks
+    assert fake_client.last_kwargs.get("think") is True
+
+    thinking_event = {"type": "thinking", "content": "Need current data. "}
+    content_event = {"type": "content", "content": "Final answer."}
+
+    assert thinking_event in chunks
+    assert content_event in chunks
+
+    # Verify ordering: thinking must be emitted before final content
+    assert chunks.index(thinking_event) < chunks.index(content_event), \
+        f"thinking (at index {chunks.index(thinking_event)}) should come " \
+        f"before content (at index {chunks.index(content_event)})"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Enable Ollama thinking mode for native chat/tool-calling requests with `think=True`.
- Surface Ollama's structured `message.thinking` stream chunks through the existing CLI `thinking` event path.
- Add a regression test that fakes an Ollama stream containing `message.thinking` and verifies it is emitted before final content.

## Background
When running the chapter 2 local LLM serving experiment with Ollama native structured tool calling, the logs showed structured `tool_calls`, but no visible `<think>` output. That path uses Ollama's chat/tool-calling API, where thinking-capable models such as Qwen3 can expose reasoning separately as `message.thinking` instead of embedding literal `<think>...</think>` text in `message.content`.

This change requests thinking output from Ollama and maps the returned `message.thinking` chunks into the agent's existing streaming UI, so the CLI can display the model's thinking when Ollama provides it.

## Test Plan
- [x] `python test_ollama_thinking.py`