### PR TITLE
test: add offline CI for web search agent

### DIFF
--- a/.github/workflows/web-search-agent-tests.yml
+++ b/.github/workflows/web-search-agent-tests.yml
@@ -1,0 +1,42 @@
+name: web-search-agent tests
+
+on:
+  pull_request:
+    paths:
+      - "chapter1/web-search-agent/**"
+      - ".github/workflows/web-search-agent-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "chapter1/web-search-agent/**"
+      - ".github/workflows/web-search-agent-tests.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: chapter1/web-search-agent
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: chapter1/web-search-agent/requirements.txt
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run offline unit tests
+        env:
+          MOONSHOT_API_KEY: ""
+          KIMI_API_KEY: ""
+          OPENROUTER_API_KEY: ""
+        run: python -m pytest

--- a/chapter1/web-search-agent/pytest.ini
+++ b/chapter1/web-search-agent/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -ra --strict-markers

--- a/chapter1/web-search-agent/tests/conftest.py
+++ b/chapter1/web-search-agent/tests/conftest.py
@@ -1,0 +1,80 @@
+"""Shared pytest fixtures for the web search agent test suite."""
+
+import json
+import socket
+from types import SimpleNamespace
+
+import pytest
+
+PROVIDER_ENV_VARS = (
+    "MOONSHOT_API_KEY",
+    "KIMI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "OPENROUTER_BASE_URL",
+    "OPENROUTER_MODEL",
+)
+
+
+@pytest.fixture(autouse=True)
+def isolate_provider_environment(monkeypatch):
+    """Keep developer credentials and provider overrides out of every test."""
+    for variable in PROVIDER_ENV_VARS:
+        monkeypatch.delenv(variable, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def block_external_network(monkeypatch):
+    """Fail fast if a unit test accidentally attempts a network connection."""
+
+    def deny_network(*args, **kwargs):
+        raise AssertionError("Unit tests must not access the external network")
+
+    monkeypatch.setattr(socket, "create_connection", deny_network)
+    monkeypatch.setattr(socket, "getaddrinfo", deny_network)
+    monkeypatch.setattr(socket.socket, "connect", deny_network)
+    monkeypatch.setattr(socket.socket, "connect_ex", deny_network)
+
+
+@pytest.fixture
+def make_tool_call():
+    """Build a minimal SDK-shaped tool-call object for mocked model replies."""
+
+    def factory(
+        *,
+        name="$web_search",
+        arguments=None,
+        call_id="call-1",
+    ):
+        payload = arguments if arguments is not None else {"query": "example"}
+        return SimpleNamespace(
+            id=call_id,
+            function=SimpleNamespace(
+                name=name,
+                arguments=json.dumps(payload, ensure_ascii=False),
+            ),
+        )
+
+    return factory
+
+
+@pytest.fixture
+def make_choice():
+    """Build a minimal SDK-shaped chat choice for deterministic Agent tests."""
+
+    def factory(
+        *,
+        finish_reason="stop",
+        content="",
+        reasoning_content=None,
+        tool_calls=None,
+    ):
+        return SimpleNamespace(
+            finish_reason=finish_reason,
+            message=SimpleNamespace(
+                content=content,
+                reasoning_content=reasoning_content,
+                tool_calls=list(tool_calls or []),
+            ),
+        )
+
+    return factory

--- a/chapter1/web-search-agent/tests/test_agent.py
+++ b/chapter1/web-search-agent/tests/test_agent.py
@@ -1,0 +1,164 @@
+"""Unit tests for ReAct formatting, tools, and the agent loop."""
+
+from unittest.mock import Mock
+
+import agent as agent_module
+from agent import WebSearchAgent, _reasoning_safe_temperature, format_trace_step
+
+
+def build_agent(*choices):
+    """Create an Agent without constructing a real OpenAI client."""
+    instance = WebSearchAgent.__new__(WebSearchAgent)
+    instance.verbose = False
+    instance.using_openrouter = False
+    instance.trace = []
+    instance.conversation_history = []
+    instance._chat = Mock(side_effect=choices)
+    return instance
+
+
+def test_format_trace_step_formats_action_with_unicode_arguments():
+    rendered = format_trace_step(
+        {
+            "iteration": 2,
+            "type": "action",
+            "tool": "$web_search",
+            "args": {"query": "서울 날씨"},
+        }
+    )
+
+    assert rendered == (
+        '🔧 [2] 行动: 调用工具 $web_search  参数={"query": "서울 날씨"}'
+    )
+
+
+def test_format_trace_step_truncates_long_content():
+    rendered = format_trace_step(
+        {"iteration": 1, "type": "thought", "content": "abcdef"},
+        max_len=3,
+    )
+
+    assert rendered == "💭 [1] 思考: abc…（省略 3 字）"
+
+
+def test_reasoning_models_force_supported_temperature():
+    assert _reasoning_safe_temperature("kimi-k3", 0.2) == 1
+    assert _reasoning_safe_temperature("openai/gpt-5.6-luna", 0.2) == 1
+    assert _reasoning_safe_temperature("deepseek-chat", 0.2) == 0.2
+
+
+def test_tool_definition_is_available_for_moonshot_only():
+    instance = WebSearchAgent.__new__(WebSearchAgent)
+    instance.using_openrouter = False
+
+    assert instance._get_tools() == [
+        {
+            "type": "builtin_function",
+            "function": {"name": "$web_search"},
+        }
+    ]
+
+    instance.using_openrouter = True
+    assert instance._get_tools() == []
+
+
+def test_agent_loop_records_tool_flow_and_final_answer(
+    monkeypatch, make_choice, make_tool_call
+):
+    tool_call = make_tool_call(arguments={"query": "Moonshot caching"})
+    tool_choice = make_choice(
+        finish_reason="tool_calls",
+        reasoning_content="공식 설명을 검색해야 한다.",
+        tool_calls=[tool_call],
+    )
+    answer_choice = make_choice(content="Context Caching 설명입니다.")
+    instance = build_agent(tool_choice, answer_choice)
+    search = Mock(return_value={"query": "Moonshot caching"})
+    monkeypatch.setattr(agent_module, "search_impl", search)
+
+    answer = instance.search_and_answer("Context Caching이 뭐야?")
+
+    assert answer == "Context Caching 설명입니다."
+    assert [step["type"] for step in instance.get_trace()] == [
+        "thought",
+        "action",
+        "observation",
+        "answer",
+    ]
+    search.assert_called_once_with({"query": "Moonshot caching"})
+    assert instance._chat.call_count == 2
+    assert instance.conversation_history[2] == {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {
+                    "name": "$web_search",
+                    "arguments": '{"query": "Moonshot caching"}',
+                },
+            }
+        ],
+    }
+    assert instance.conversation_history[3] == {
+        "role": "tool",
+        "tool_call_id": "call-1",
+        "name": "$web_search",
+        "content": '{"query": "Moonshot caching"}',
+    }
+    assert instance.conversation_history[-1] == {
+        "role": "assistant",
+        "content": answer,
+    }
+
+
+def test_agent_loop_handles_multiple_tool_calls(make_choice, make_tool_call):
+    first = make_tool_call(arguments={"query": "first"}, call_id="call-1")
+    second = make_tool_call(arguments={"query": "second"}, call_id="call-2")
+    instance = build_agent(
+        make_choice(finish_reason="tool_calls", tool_calls=[first, second]),
+        make_choice(content="combined answer"),
+    )
+
+    assert instance.search_and_answer("compare") == "combined answer"
+    assert [step["type"] for step in instance.get_trace()] == [
+        "action",
+        "observation",
+        "action",
+        "observation",
+        "answer",
+    ]
+    tool_messages = [
+        message
+        for message in instance.conversation_history
+        if message["role"] == "tool"
+    ]
+    assert [message["tool_call_id"] for message in tool_messages] == [
+        "call-1",
+        "call-2",
+    ]
+
+
+def test_agent_loop_stops_at_iteration_limit(make_choice, make_tool_call):
+    instance = build_agent(
+        make_choice(
+            finish_reason="tool_calls",
+            tool_calls=[make_tool_call()],
+        )
+    )
+
+    answer = instance.search_and_answer("keep searching", max_iterations=1)
+
+    assert answer == "抱歉，搜索过程超过了最大迭代次数，请稍后重试。"
+    assert instance._chat.call_count == 1
+
+
+def test_agent_loop_returns_a_readable_error():
+    instance = build_agent()
+    instance._chat = Mock(side_effect=RuntimeError("provider unavailable"))
+
+    answer = instance.search_and_answer("question")
+
+    assert answer == "搜索过程中出现错误: provider unavailable"
+    assert instance.get_trace() == []

--- a/chapter1/web-search-agent/tests/test_config.py
+++ b/chapter1/web-search-agent/tests/test_config.py
@@ -1,0 +1,70 @@
+"""Unit tests for model mapping and provider selection."""
+
+import pytest
+
+from config import map_model_to_openrouter, resolve_llm_backend
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("openai/gpt-5.6-luna", "openai/gpt-5.6-luna"),
+        ("gpt-5.6-luna", "openai/gpt-5.6-luna"),
+        ("o3-mini", "openai/o3-mini"),
+        ("claude-sonnet-4.6", "anthropic/claude-sonnet-4.6"),
+        ("claude-haiku-4.5", "anthropic/claude-haiku-4.5"),
+        ("claude-opus-4.8", "anthropic/claude-opus-4.8"),
+        ("kimi-k3", "moonshotai/kimi-k2.6"),
+    ],
+)
+def test_map_model_to_openrouter(model, expected):
+    assert map_model_to_openrouter(model) == expected
+
+
+def test_unknown_model_uses_configured_openrouter_default(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_MODEL", "vendor/fallback-model")
+
+    assert map_model_to_openrouter("unknown-model") == "vendor/fallback-model"
+
+
+def test_primary_provider_is_preserved_when_its_key_exists():
+    assert resolve_llm_backend(
+        "moonshot-key", "https://moonshot.test/v1", "kimi-k3"
+    ) == (
+        "moonshot-key",
+        "https://moonshot.test/v1",
+        "kimi-k3",
+        False,
+    )
+
+
+def test_openrouter_is_used_when_primary_key_is_missing(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-key")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://openrouter.test/v1")
+
+    assert resolve_llm_backend(None, "https://moonshot.test/v1", "kimi-k3") == (
+        "openrouter-key",
+        "https://openrouter.test/v1",
+        "moonshotai/kimi-k2.6",
+        True,
+    )
+
+
+def test_gpt5_prefers_openrouter_when_both_keys_exist(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-key")
+
+    resolved = resolve_llm_backend(
+        "primary-key", "https://primary.test/v1", "gpt-5.6-luna"
+    )
+
+    assert resolved == (
+        "openrouter-key",
+        "https://openrouter.ai/api/v1",
+        "openai/gpt-5.6-luna",
+        True,
+    )
+
+
+def test_provider_resolution_requires_a_key():
+    with pytest.raises(ValueError, match="No API key found"):
+        resolve_llm_backend(None, "https://moonshot.test/v1", "kimi-k3")

--- a/chapter1/web-search-agent/tests/test_main.py
+++ b/chapter1/web-search-agent/tests/test_main.py
@@ -1,0 +1,81 @@
+"""Tests for CLI parsing, offline dispatch, and JSON output."""
+
+import json
+
+import main as cli
+from config import Config
+
+
+def test_parser_defaults_to_interactive_kimi_mode():
+    args = cli.build_parser().parse_args([])
+
+    assert args.query == []
+    assert args.provider == "kimi"
+    assert args.model == Config.DEFAULT_MODEL
+    assert args.max_steps == Config.MAX_SEARCH_ITERATIONS
+    assert args.base_url == Config.KIMI_BASE_URL
+    assert args.output is None
+    assert args.quiet is False
+
+
+def test_parser_accepts_cli_overrides():
+    args = cli.build_parser().parse_args(
+        [
+            "first",
+            "question",
+            "--provider",
+            "offline-demo",
+            "--model",
+            "custom-model",
+            "--max-steps",
+            "3",
+            "--base-url",
+            "https://provider.test/v1",
+            "--api-key",
+            "explicit-key",
+            "--output",
+            "result.json",
+            "--quiet",
+        ]
+    )
+
+    assert args.query == ["first", "question"]
+    assert args.provider == "offline-demo"
+    assert args.model == "custom-model"
+    assert args.max_steps == 3
+    assert args.base_url == "https://provider.test/v1"
+    assert args.api_key == "explicit-key"
+    assert args.output == "result.json"
+    assert args.quiet is True
+
+
+def test_offline_cli_writes_utf8_json_without_api_credentials(tmp_path, capsys):
+    output_path = tmp_path / "offline-result.json"
+
+    cli.main(
+        [
+            "한국어",
+            "질문",
+            "--provider",
+            "offline-demo",
+            "--quiet",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    output = capsys.readouterr().out
+    assert payload["question"] == "한국어 질문"
+    assert set(payload) == {"question", "trace", "answer"}
+    assert payload["trace"][-1]["type"] == "answer"
+    assert payload["answer"] == payload["trace"][-1]["content"]
+    assert "💭" not in output
+    assert "结果已保存到" in output
+
+
+def test_offline_cli_uses_default_question_when_query_is_omitted(capsys):
+    cli.main(["--provider", "offline-demo", "--quiet"])
+
+    output = capsys.readouterr().out
+    assert "Moonshot AI 的 Context Caching 是什么技术？" in output

--- a/chapter1/web-search-agent/tests/test_offline_demo.py
+++ b/chapter1/web-search-agent/tests/test_offline_demo.py
@@ -1,0 +1,37 @@
+"""Tests for the deterministic offline ReAct demonstration."""
+
+from agent import run_offline_demo
+
+
+def test_offline_demo_returns_a_complete_deterministic_trace():
+    result = run_offline_demo("캐싱이 뭐야?", verbose=False)
+
+    assert result["question"] == "캐싱이 뭐야?"
+    assert [step["type"] for step in result["trace"]] == [
+        "thought",
+        "action",
+        "observation",
+        "thought",
+        "action",
+        "observation",
+        "answer",
+    ]
+    assert result["answer"] == result["trace"][-1]["content"]
+    assert "离线示例轨迹" in result["answer"]
+
+
+def test_offline_demo_verbose_mode_prints_each_trace_step(capsys):
+    result = run_offline_demo("question", verbose=True)
+
+    output = capsys.readouterr().out
+    assert output.count("💭") == 2
+    assert output.count("🔧") == 2
+    assert output.count("👀") == 2
+    assert output.count("✅") == 1
+    assert result["answer"] in output
+
+
+def test_offline_demo_quiet_mode_prints_nothing(capsys):
+    run_offline_demo("question", verbose=False)
+
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Summary

- add deterministic offline unit tests for `chapter1/web-search-agent`
- cover ReAct trace formatting, provider configuration, tool definitions, offline demo behavior, CLI/JSON output, and mocked Agent loops
- add a path-scoped GitHub Actions workflow for this companion project

## Why

The companion project is documented as independently runnable, but its behavior was not previously exercised in CI. Requiring real model APIs would make those checks dependent on credentials, external network access, and potentially paid requests.

These tests isolate provider environment variables, block external DNS/socket connections, and use mocked model responses so regressions can be detected deterministically.

## Validation

- `python -m pytest` — 27 passed on Python 3.12
- `black --check tests`
- offline CLI run without `MOONSHOT_API_KEY`, `KIMI_API_KEY`, or `OPENROUTER_API_KEY`
- UTF-8 JSON output validation

Closes #80
