### PR TITLE
fix(site): 侧栏滚动时章节名与 sticky 站点标题重叠

### DIFF
--- a/extras/book-theme.css
+++ b/extras/book-theme.css
@@ -122,6 +122,13 @@
   position: relative;
   cursor: pointer;
 }
+/* 桌面端 sticky 站点标题(Material 默认 z-index:1)必须盖过章节
+   label(z-index:2),否则侧栏滚动时章节名会叠在站点标题上。 */
+@media screen and (min-width: 76.25em) {
+  .md-nav--primary > .md-nav__title {
+    z-index: 3;
+  }
+}
 /* 当前激活的章节 —— 左侧一条墨绿色竖线(像 fenix 当前章节的视觉提示) */
 .md-nav__item--active {
   border-left-color: var(--fenix-link-hover);


### PR DESCRIPTION
## 问题

网页版在桌面端(≥1220px)滚动左侧栏时,章节折叠标题("第1章 Agent基础知识"等)会绘制在侧栏顶部 sticky 的站点标题 "AI Agents in Depth" 上层,两行文字重叠在一起无法阅读。每一章标题滚过侧栏顶部时都会出现。

## 原因

`extras/book-theme.css` 中为修复"章节点不开"的问题,给章节折叠 label 设置了 `position: relative; z-index: 2`;而 Material 主题桌面端的 sticky 站点标题默认只有 `z-index: 1`,靠自身不透明背景遮住滚动上来的内容。`2 > 1`,章节 label 反而画在了站点标题上层。

## 修复

在与 Material 相同的断点(`min-width: 76.25em`)下把 `.md-nav--primary > .md-nav__title` 提升到 `z-index: 3`,恢复 sticky 标题对下方滚动内容的遮挡。章节 label 的 `z-index: 2` 保持不动,不影响原有的点击修复。

断点沿用 Material 自己的 `76.25em`(而非换算成 1220px):media query 的 em 相对浏览器默认字号,用户调整浏览器字号时两条规则仍会同时生效/失效,不会出现只有一边生效的错位区间。

已在本地 `mkdocs serve` 验证:滚动侧栏后章节名不再叠到站点标题上。