### PR TITLE
test(ch1): fix local pytest imports and enforce black in CI

### DIFF
--- a/.github/workflows/web-search-agent-tests.yml
+++ b/.github/workflows/web-search-agent-tests.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install dependencies
         run: python -m pip install -r requirements.txt
 
+      - name: Check formatting
+        run: python -m black --check tests
+
       - name: Run offline unit tests
         env:
           MOONSHOT_API_KEY: ""

--- a/chapter1/web-search-agent/pytest.ini
+++ b/chapter1/web-search-agent/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
+pythonpath = .
 addopts = -ra --strict-markers


### PR DESCRIPTION
Follow-up to #292 addressing the two actionable review notes.

## Changes
- **`pytest.ini`**: add `pythonpath = .` so a bare `pytest` resolves the `agent`/`config`/`main` imports. Previously only `python -m pytest` worked (CI uses that form, so CI was unaffected); a developer's reflexive `pytest` failed with an `ImportError`.
- **`.github/workflows/web-search-agent-tests.yml`**: add a `black --check tests` step so formatting regressions are caught in CI, matching the validation stated in #292.

## Validation
- `pytest` (bare) → **27 passed** (previously `ImportError`)
- `python -m pytest` → **27 passed**
- `black --check tests` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)