### PR TITLE
fix(site): 首页章节速览卡片间露出大块灰底

### DIFF
--- a/extras/book-theme.css
+++ b/extras/book-theme.css
@@ -379,8 +379,15 @@
   overflow: hidden;
   margin: 1.4rem 0;
 }
+/* Markdown 会把每个 exp-card 包一层 <p>:清零其边距并让卡片撑满
+   格子,否则模拟 1px 边框的灰底会从缝隙里透出成大块灰带。 */
+.exp-grid > p {
+  margin: 0;
+}
 .exp-card {
   display: block;
+  height: 100%;
+  box-sizing: border-box;
   background: var(--fenix-bg);
   padding: 14px 16px;
   text-decoration: none;


### PR DESCRIPTION
## 问题

首页"章节速览"的卡片网格中,行与行之间出现大块灰色横带,同一行里较矮的卡片下方也露出灰色,视觉上像布局错乱。

## 原因

`.exp-grid` 用"容器铺灰色背景(`--fenix-border`) + 卡片间留 1px gap"的手法模拟细边框,前提是每个格子被不透明的白色卡片完全填满。

但首页卡片写在 `<div class="exp-grid" markdown>` 里,Python-Markdown 渲染时给每个 `<a class="exp-card">` 包了一层 `<p>`:

- `<p>` 自带 `margin-block: 0.9em`,grid 布局中 margin 不合并,行间露出约 28px 灰带;
- 卡片高度只随内容走,不撑满格子,同行较矮的卡片下方也露灰。

(同文件 `.stat-row p { margin: 0 }` 已在首页统计行上处理过同一问题,`.exp-grid` 漏掉了。)

## 修复

```css
.exp-grid > p { margin: 0; }
.exp-card { height: 100%; box-sizing: border-box; /* 原有属性不变 */ }
```

`<p>` 清零边距后由 grid 默认的 stretch 撑满格子,卡片再 `height: 100%` 填满,灰底只透出 1px 缝隙的细线。已在本地 `mkdocs serve` 前后对比验证。

| 修复前 | 修复后 |
| --- | --- |
| <img width="1510" height="1154" alt="CleanShot 2026-07-22 at 22 04 38@2x" src="https://github.com/user-attachments/assets/4efdd81c-dd68-4525-a26a-3a38d1626e42" /> | <img width="1438" height="952" alt="CleanShot 2026-07-22 at 21 59 21@2x" src="https://github.com/user-attachments/assets/4cd526bc-523e-4c6e-aaa5-e5e032ffdfce" /> |