### PR TITLE
staged-system-prompt: run_tests must not PASS a hung or failing script

### DIFF
--- a/chapter10/staged-system-prompt/tools.py
+++ b/chapter10/staged-system-prompt/tools.py
@@ -108,7 +108,14 @@ class Workspace:
             + self.files[path]
         )
         result = _run_python_source(harness)
-        ok = "Traceback" not in result and "Error" not in result
+        # PASS 需要：无 Traceback/Error 文本、未超时、且退出码为 0。
+        # 只做子串检查时，超时（"执行超时（>10s)"，不含任何标记词）和
+        # sys.exit(1)（"退出码: 1"）都会被误报为 PASS，误导审查阶段批准坏代码。
+        ok = (
+            "Traceback" not in result
+            and "Error" not in result
+            and "退出码: 0" in result
+        )
         verdict = "PASS" if ok else "FAIL"
         return f"[tests] 冒烟测试结果：{verdict}\n{result}"
 


### PR DESCRIPTION
`run_tests` decided PASS/FAIL by substring only (`"Traceback" not in result and "Error" not in result`), never consulting the exit code. Two wrong-PASS cases (details in #265):

- a hung submission — `_run_python_source` returns `执行超时（>10s）`, which contains neither marker;
- `sys.exit(1)` with no error text — output is just `退出码: 1`.

Both told the review-stage model (whose prompt says it *must* request revision on test failure) that the smoke test passed.

Fix: PASS now also requires the `退出码: 0` line `_run_python_source` appends to every completed run; the timeout string has no exit-code line, so it fails automatically.

Verified against the four output shapes (success, timeout, exit-1, traceback); `py_compile` passes.

Fixes #265