### PR TITLE
voice-werewolf: stop resolving P10+ targets to P1 in big games

### DIFF
--- a/chapter10/voice-werewolf/werewolf/agent.py
+++ b/chapter10/voice-werewolf/werewolf/agent.py
@@ -269,15 +269,17 @@ class PlayerAgent:
             target = raw
         if allow_none and target.lower() in ("none", "", "弃票", "放弃"):
             return None
-        # 归一化：精确匹配优先，否则模糊匹配（找出现的候选名）
+        # 归一化：精确匹配优先，其次按整 token 正则找 Pn，最后才做
+        # 子串模糊匹配（按候选名长度从长到短）。子串匹配不能先做：
+        # 候选按座位序迭代时 "P1" in "P10（他最可疑）" 会先命中，
+        # 把投给 P10+ 的票/刀/查验悄悄改到 P1 头上（≥10 人局）。
         if target in candidates:
             return target
-        for c in candidates:
-            if c in (target or ""):
-                return c
-        # 最后兜底：从原始串里搜 Pn
         m = re.search(r"P\d+", target or "")
         if m and m.group(0) in candidates:
             return m.group(0)
+        for c in sorted(candidates, key=len, reverse=True):
+            if c in (target or ""):
+                return c
         # 实在解析不出：好人默认弃票，狼人/必须选的场景由调用方兜底
         return None if allow_none else (candidates[0] if candidates else None)


### PR DESCRIPTION
`_parse_target`'s fuzzy fallback iterated candidates in seat order with a plain substring test — `"P1" in "P10（他最可疑）"` matched first — so votes, night kills and seer checks aimed at P10-P19 silently landed on **P1** whenever the model's answer wasn't an exact candidate string (decorated answers, or raw text on the JSON-parse fallback). The correct `P\d+` whole-token regex existed but sat *after* the substring loop, unreachable for exactly these inputs. `demo.py --players 12` is a supported configuration. Details in #266.

Fix: exact match → whole-token `P\d+` regex → longest-first substring as last resort.

Verified against decorated JSON (`"P10。"`), raw fallback text (`P10（他最可疑）`), plain (`P3`), free text (`我投 P11`), and `none`; `py_compile` passes.

Fixes #266