### PR TITLE
build_site: fix the 404 back-to-README link on translated chapter pages

### DIFF
--- a/scripts/build_site.sh
+++ b/scripts/build_site.sh
@@ -93,7 +93,8 @@ find "$DEST" -name '*.md.bak' -delete
 # and only relative links that don't start with . / # http or contain :
 find "$DEST/chapter"* -type f -name 'README.[a-zA-Z-]*.md' -print0 \
   | xargs -0 sed -i.bak -E \
-      -e 's|\]\(([a-zA-Z][a-zA-Z0-9_-]*)/\)|](../\1/)|g'
+      -e 's|\]\(([a-zA-Z][a-zA-Z0-9_-]*)/\)|](../\1/)|g' \
+      -e 's|\]\(\.\./docs/[a-zA-Z-]+/README\.md\)|](../../)|g'
 find "$DEST" -name '*.md.bak' -delete
 
 echo "Assembled docs into $DEST"


### PR DESCRIPTION
The sed rewrite block converts the Chinese `../README.md` links but not the translated chapter indexes' `](../docs/<locale>/README.md)` pattern, and `docs/` is never copied into the site's `docs_dir` — so MkDocs leaves the raw href and all 4 locales × 10 chapter pages ship a broken back-link, live-verified:

```
$ curl -s .../chapter9/README.en/ | grep -o 'href="[^"]*docs/en/README[^"]*"'
href="../docs/en/README.md"
$ curl -s -o /dev/null -w '%{http_code}' .../chapter9/docs/en/README.md
404
```

Fix: one additional sed rule in the translated-README block mapping the pattern to `](../../)` (the site home). Details in #267.

Verified: `bash -n` passes; the combined sed run against the real `chapter9/README.en.md` removes the old link and produces `](../../)`.

Fixes #267