### PR TITLE
streaming-speech: fix duplicated final endpoint from float accumulation

### DIFF
--- a/chapter9/streaming-speech/demo.py
+++ b/chapter9/streaming-speech/demo.py
@@ -158,7 +158,12 @@ def build_endpoints(total: float, chunk_step: float):
     while t < total:
         endpoints.append(round(t, 3))
         t += chunk_step
-    endpoints.append(round(total, 3))
+    # 浮点累加可能让最后一次循环的 t 略小于 total（如 20×0.3 = 5.999…<6.0），
+    # 循环里已 append 了 round=total 的值；避免再补一个重复的完整端点
+    # （每个重复端点 = 一次多余的整段付费转写 + 一行重复结果）。
+    final = round(total, 3)
+    if not endpoints or endpoints[-1] != final:
+        endpoints.append(final)
     return endpoints
 
 


### PR DESCRIPTION
`build_endpoints` accumulated `t += chunk_step` and then unconditionally appended `round(total, 3)`. Repeated float addition can leave `t` fractionally below `total` (20 × 0.3 = 5.999999999999998 < 6.0), so the loop's last iteration already appended `6.0` — and the epilogue appended `6.0` **again**: `build_endpoints(6.0, 0.3)` → `[..., 5.7, 6.0, 6.0]`. Each duplicate is one extra paid full-length Whisper transcription plus a duplicate row in every results table (per granularity under `--compare-chunks`). The binary-exact defaults are unaffected. Details in #268.

Fix: append the final endpoint only when the loop didn't already produce it.

Verified: step 0.3 now yields a single `6.0`; the 0.5 default series and the short-audio (`total < step`) case are unchanged; `py_compile` passes.

Fixes #268