### PR TITLE
staged-system-prompt: case-insensitive keyword matching in SimulatedUser

### DIFF
--- a/chapter10/staged-system-prompt/simulated_user.py
+++ b/chapter10/staged-system-prompt/simulated_user.py
@@ -37,9 +37,13 @@ class SimulatedUser:
         self._asked_count: Dict[str, int] = {}
 
     def _match(self, q: str) -> str:
+        # 两边都小写再比：关键词只在自己一侧 lower 时，英文问句里
+        # 大写开头的 "Move or Copy?" 会全部落空，退回泛化默认答案，
+        # 丢掉实现阶段依赖的关键需求。
+        q_lower = q.lower()
         best_reply, best_score = self.default_answer, 0
         for keywords, reply in self.playbook:
-            score = sum(1 for kw in keywords if kw.lower() in q)
+            score = sum(1 for kw in keywords if kw.lower() in q_lower)
             if score > best_score:
                 best_reply, best_score = reply, score
         return best_reply


### PR DESCRIPTION
`_match` lowercased the keywords but compared them against the **raw** question (the lowercased `norm` nearby is only used for repeat-question dedup), so English playbook keywords missed capitalized phrasing — "Move or Copy?" matched neither `move` nor `copy` — and the simulated user answered with the generic default, dropping the seeded requirement the implementation stage depends on. Details in #269.

Fix: lowercase the question once and compare both sides lowercased.

`py_compile` passes.

Fixes #269