### PR TITLE
fix(cot-distillation): avoid ZeroDivisionError on empty problems JSONL

### DIFF
--- a/chapter7/cot-distillation/generate_data.py
+++ b/chapter7/cot-distillation/generate_data.py
@@ -199,7 +199,9 @@ async def main():
     total_out = sum((r["usage"] or {}).get("completion_tokens", 0) for r in records)
     n_err = sum(1 for r in records if r["error"])
     print(f"\n{'=' * 50}")
-    print(f"验证通过：{len(passed)}/{len(records)}（{len(passed) / len(records) * 100:.1f}%）")
+    # Empty problems JSONL yields zero records; avoid ZeroDivisionError on the rate.
+    pass_rate = (len(passed) / len(records) * 100) if records else 0.0
+    print(f"验证通过：{len(passed)}/{len(records)}（{pass_rate:.1f}%）")
     print(f"API 出错：{n_err}  无思维链返回：{sum(1 for r in records if not r['reasoning'])}")
     print(f"Token 消耗：输入 {total_in}，输出 {total_out}")
     print(f"SFT 数据已写入：{args.sft_output}")

--- a/chapter7/cot-distillation/test_empty_problems.py
+++ b/chapter7/cot-distillation/test_empty_problems.py
@@ -1,0 +1,50 @@
+"""Empty problems JSONL must not ZeroDivisionError in the pass-rate summary."""
+
+import asyncio
+import os
+from types import ModuleType
+import sys
+
+# generate_data imports openai; stub if missing so the test stays offline.
+try:
+    import openai  # noqa: F401
+except ImportError:
+    _oai = ModuleType("openai")
+
+    class _AsyncOpenAI:
+        def __init__(self, *a, **k):
+            pass
+
+    _oai.AsyncOpenAI = _AsyncOpenAI
+    sys.modules["openai"] = _oai
+
+import generate_data as gd
+
+
+def test_empty_problems_summary_does_not_divide_by_zero(tmp_path, monkeypatch):
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("", encoding="utf-8")
+    raw = tmp_path / "raw.jsonl"
+    sft = tmp_path / "sft.jsonl"
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key-not-used")
+
+    argv = [
+        "generate_data.py",
+        "--input",
+        str(empty),
+        "--raw_output",
+        str(raw),
+        "--sft_output",
+        str(sft),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    asyncio.run(gd.main())
+    assert raw.exists() and sft.exists()
+    assert sft.read_text(encoding="utf-8") == ""
+
+
+def test_nonempty_pass_rate_still_computes():
+    records = [{"verified": True, "error": None, "reasoning": "x", "usage": {}}]
+    passed = [r for r in records if r["verified"]]
+    pass_rate = (len(passed) / len(records) * 100) if records else 0.0
+    assert pass_rate == 100.0


### PR DESCRIPTION
An empty problems JSONL made the distill summary do `len(passed)/len(records)` and crash.

Use a 0% rate when there are no records.