### PR TITLE
fix(cot-distillation): skip SFT rows with fewer than 2 messages

### DIFF
--- a/chapter7/cot-distillation/analyze_data.py
+++ b/chapter7/cot-distillation/analyze_data.py
@@ -17,8 +17,14 @@ def main():
 
     think_lens, answer_lens = [], []
     n_reflect = 0
+    n_skipped_short = 0
     for s in samples:
-        assistant = s["messages"][1]["content"]
+        messages = s.get("messages") or []
+        # Incomplete SFT rows (user-only / truncated export) must not IndexError.
+        if len(messages) < 2:
+            n_skipped_short += 1
+            continue
+        assistant = messages[1]["content"]
         m = re.search(r"<think>\n?(.*?)\n?</think>", assistant, re.DOTALL)
         think = m.group(1) if m else ""
         think_lens.append(len(think))
@@ -37,7 +43,10 @@ def main():
 
     stats(think_lens, "思考链长度（字符）")
     stats(answer_lens, "完整回答长度（字符）")
-    print(f"含反思/验算行为的样本：{n_reflect}/{len(samples)}")
+    n_scored = len(samples) - n_skipped_short
+    print(f"含反思/验算行为的样本：{n_reflect}/{n_scored}")
+    if n_skipped_short:
+        print(f"跳过 messages 不足 2 条的样本：{n_skipped_short}")
 
     try:
         with open(args.raw, encoding="utf-8") as f:

--- a/chapter7/cot-distillation/test_analyze_short_messages.py
+++ b/chapter7/cot-distillation/test_analyze_short_messages.py
@@ -1,0 +1,64 @@
+"""SFT rows with messages shorter than 2 must not IndexError in analyze_data."""
+
+import json
+import sys
+from pathlib import Path
+
+import analyze_data as ad
+
+
+def test_short_messages_skipped_without_index_error(tmp_path, monkeypatch, capsys):
+    sft = tmp_path / "sft.jsonl"
+    rows = [
+        {"messages": [{"role": "user", "content": "only user"}]},
+        {"messages": []},
+        {
+            "messages": [
+                {"role": "user", "content": "q"},
+                {
+                    "role": "assistant",
+                    "content": "<think>\n验算一遍\n</think>\nFinal Answer: 1",
+                },
+            ]
+        },
+    ]
+    sft.write_text(
+        "\n".join(json.dumps(r, ensure_ascii=False) for r in rows) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["analyze_data.py", "--sft", str(sft), "--raw", str(tmp_path / "missing.jsonl")],
+    )
+    ad.main()
+    out = capsys.readouterr().out
+    assert "SFT 样本数：3" in out
+    assert "跳过 messages 不足 2 条的样本：2" in out
+    assert "含反思/验算行为的样本：1/1" in out
+
+
+def test_normal_two_message_row_still_scored(tmp_path, monkeypatch, capsys):
+    sft = tmp_path / "sft.jsonl"
+    sft.write_text(
+        json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "q"},
+                    {"role": "assistant", "content": "<think>\nok\n</think>\n1"},
+                ]
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["analyze_data.py", "--sft", str(sft), "--raw", str(tmp_path / "missing.jsonl")],
+    )
+    ad.main()
+    out = capsys.readouterr().out
+    assert "跳过" not in out
+    assert "含反思/验算行为的样本：0/1" in out


### PR DESCRIPTION
SFT rows with fewer than 2 messages raised IndexError on `messages[1]` and aborted analysis.

Skip short rows and continue.