### PR TITLE
fix(bash): treat timeout_ms 0 like omit

### DIFF
--- a/chapter5/coding-agent/tests/test_bash_tool.py
+++ b/chapter5/coding-agent/tests/test_bash_tool.py
@@ -206,3 +206,25 @@ class TestBashTool:
         })
         assert result.data["exit_code"] == -1
         assert "timed out" in result.data["output"].lower()
+
+    def test_timeout_ms_zero_like_omit(self, system_state):
+        """timeout=0 must not skip the command (DataLoss via immediate 0s deadline)."""
+        tool = BashTool(system_state)
+        result = tool.execute({
+            "command": "echo zero-ok",
+            "timeout": 0,
+        })
+        assert result.success
+        assert result.data["exit_code"] == 0
+        assert "zero-ok" in result.data["output"]
+        assert "timed out" not in result.data["output"].lower()
+
+    def test_timeout_ms_negative_like_omit(self, system_state):
+        tool = BashTool(system_state)
+        result = tool.execute({
+            "command": "echo neg-ok",
+            "timeout": -1,
+        })
+        assert result.success
+        assert "neg-ok" in result.data["output"]
+        assert result.data["exit_code"] == 0

--- a/chapter5/coding-agent/tools/bash_tool.py
+++ b/chapter5/coding-agent/tools/bash_tool.py
@@ -28,7 +28,8 @@ class BashTool(BaseTool):
         """
         command = params["command"]
         timeout_ms = params.get("timeout")
-        if timeout_ms is None:
+        # None/<=0: treat like omit. Exact 0 used to become timeout=0s and drop all output.
+        if timeout_ms is None or timeout_ms <= 0:
             timeout_ms = 120000
         timeout = timeout_ms / 1000  # Convert ms to seconds
         run_in_background = params.get("run_in_background", False)


### PR DESCRIPTION
`timeout_ms: 0` became a 0-second timeout and skipped the command with an immediate timeout error.

Treat 0 like omit and use the default timeout.