### PR TITLE
fix(log-sanitization): redact truncated PEM without END marker

### DIFF
--- a/chapter2/log-sanitization/regex_sanitizer.py
+++ b/chapter2/log-sanitization/regex_sanitizer.py
@@ -60,9 +60,10 @@ def _cn_id_ok(value: str) -> bool:
 _RULES = [
     (
         "private_key", "[REDACTED_PRIVATE_KEY]",
+        # Truncated PEM (BEGIN without END) must still redact through EOF.
         re.compile(
             r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----"
-            r"[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----"
+            r"[\s\S]*?(?:-----END (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----|(?=\Z))"
         ),
         0, None,
     ),

--- a/chapter2/log-sanitization/test_truncated_pem.py
+++ b/chapter2/log-sanitization/test_truncated_pem.py
@@ -1,0 +1,33 @@
+"""Truncated PEM (BEGIN without END) must be redacted, not leaked."""
+
+from regex_sanitizer import sanitize
+
+
+def test_truncated_rsa_pem_without_end_redacted():
+    blob = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEowIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF6PZGFw7\n"
+        "ygWyF6PZGFw7morekeymaterialHERE"
+    )
+    text, hits = sanitize(f"key dump:\n{blob}\n")
+    assert "MIIEowIBAAKCAQEA" not in text
+    assert "[REDACTED_PRIVATE_KEY]" in text
+    assert any(h["category"] == "private_key" for h in hits)
+
+
+def test_complete_pem_still_redacted():
+    blob = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEowIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF6PZGFw7\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    text, hits = sanitize(blob)
+    assert "MIIEowIBAAKCAQEA" not in text
+    assert text.strip() == "[REDACTED_PRIVATE_KEY]"
+    assert any(h["category"] == "private_key" for h in hits)
+
+
+def test_non_key_text_unchanged():
+    text, hits = sanitize("no secrets here, only BEGIN of a story")
+    assert text == "no secrets here, only BEGIN of a story"
+    assert hits == []


### PR DESCRIPTION
Log lines with `BEGIN … PRIVATE KEY` but no matching `END` (truncated dumps) left the key body in plaintext.

Also redact from BEGIN through EOF when END is missing.