### PR TITLE
fix(elo): align Bradley-Terry pivots for small battle samples

### DIFF
--- a/chapter6/elo-leaderboard/bradley_terry.py
+++ b/chapter6/elo-leaderboard/bradley_terry.py
@@ -54,7 +54,7 @@ def compute_mle_elo(df: pd.DataFrame,
             fill_value=0,
             observed=False
         )
-        ptbl_tie = ptbl_tie + ptbl_tie.T
+        ptbl_tie = (ptbl_tie + ptbl_tie.T).fillna(0)
     
     ptbl_b_win = pd.pivot_table(
         df[df["winner"] == "model_b"],
@@ -65,8 +65,14 @@ def compute_mle_elo(df: pd.DataFrame,
         observed=False
     )
     
+    # Align pivots on the full model universe (small samples otherwise leave NaNs).
+    models = sorted(set(df["model_a"]) | set(df["model_b"]))
+    ptbl_a_win = ptbl_a_win.reindex(index=models, columns=models, fill_value=0)
+    ptbl_b_win = ptbl_b_win.reindex(index=models, columns=models, fill_value=0)
+    ptbl_tie = ptbl_tie.reindex(index=models, columns=models, fill_value=0)
+
     # Compute win matrix (A wins * 2 + B wins * 2 + ties)
-    ptbl_win = ptbl_a_win * 2 + ptbl_b_win.T * 2 + ptbl_tie
+    ptbl_win = (ptbl_a_win * 2 + ptbl_b_win.T * 2 + ptbl_tie).fillna(0)
     
     # Map models to indices
     models = pd.Series(np.arange(len(ptbl_win.index)), index=ptbl_win.index)

--- a/chapter6/elo-leaderboard/test_bt_small_sample.py
+++ b/chapter6/elo-leaderboard/test_bt_small_sample.py
@@ -1,0 +1,11 @@
+"""Regression: compute_mle_elo must work on small Arena-shaped battle sets."""
+import pandas as pd
+from battle_simulator import simulate_battles
+from bradley_terry import compute_mle_elo
+
+
+def test_small_two_model_sample():
+    df = pd.DataFrame(simulate_battles({"gpt-4": 1200.0, "llama-3": 1000.0}, 10, seed=1))
+    ratings = compute_mle_elo(df)
+    assert len(ratings) == 2
+    assert set(ratings.index) == {"gpt-4", "llama-3"}


### PR DESCRIPTION
Small Arena-shaped samples left NaNs in the win matrix (especially after tie transpose), so LogisticRegression saw 0 rows.

Repro: simulate_battles with 2 models and 10 battles, then compute_mle_elo(df).