### PR TITLE
fix(kv-cache): treat negative read size as read-to-EOF

### DIFF
--- a/chapter2/kv-cache/agent.py
+++ b/chapter2/kv-cache/agent.py
@@ -135,7 +135,8 @@ class LocalFileTools:
                 }
             
             # Determine end line
-            if size is None:
+            if size is None or size < 0:
+                # Negative size is a common "read all" sentinel; avoid lines[i:-n].
                 end = total_lines
             else:
                 end = min(offset + size, total_lines)

--- a/chapter2/kv-cache/test_negative_size.py
+++ b/chapter2/kv-cache/test_negative_size.py
@@ -1,0 +1,26 @@
+"""Regression: negative size must read to EOF, not drop a suffix."""
+import sys
+import types
+from pathlib import Path
+
+
+def _stub():
+    sys.modules.setdefault("openai", types.ModuleType("openai"))
+    sys.modules["openai"].OpenAI = object
+    # other optional deps
+    for name in ["openrouter_fallback"]:
+        sys.modules.setdefault(name, types.ModuleType(name))
+
+
+_stub()
+
+from agent import LocalFileTools  # noqa: E402
+
+
+def test_negative_size_reads_all(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("a\nb\nc\n", encoding="utf-8")
+    tools = LocalFileTools(str(tmp_path))
+    out = tools.read_file("a.txt", offset=0, size=-1)
+    assert out["success"] is True
+    assert out["content"] == "a\nb\nc\n"
+    assert out["lines_read"] == 3


### PR DESCRIPTION
size=-1 used lines[offset:offset+size] and dropped a suffix while success stayed true.

Repro: read_file(..., size=-1) on a 3-line file.