### PR TITLE
fix(video): skip slowmo when factor is not positive

### DIFF
--- a/chapter5/video-edit/test_slowmo_factor_zero.py
+++ b/chapter5/video-edit/test_slowmo_factor_zero.py
@@ -1,0 +1,18 @@
+"""Regression: slowmo factor<=0 must not ZeroDivisionError."""
+from pathlib import Path
+
+
+def test_source_skips_nonpositive_factor():
+    src = Path(__file__).with_name("video_editor.py").read_text()
+    assert "if factor <= 0:" in src
+    assert "continue" in src.split("if factor <= 0:")[1][:80]
+
+
+def test_division_guard_math():
+    factor = 0.0
+    if factor <= 0:
+        skipped = True
+    else:
+        _ = 1.0 / factor
+        skipped = False
+    assert skipped is True

--- a/chapter5/video-edit/video_editor.py
+++ b/chapter5/video-edit/video_editor.py
@@ -91,6 +91,8 @@ def _apply_edit_ffmpeg(source: str, plan: dict, out_path: str) -> str:
             vf_chain.append("drawtext=" + ":".join(opts))
         elif etype == "slowmo":
             factor = float(eff.get("factor", 2.0))
+            if factor <= 0:
+                continue
             vf_chain.append(f"setpts={factor}*PTS")
             # atempo 只支持 0.5~2.0，用 1/factor 放慢音频。
             af_chain.append(f"atempo={max(0.5, min(2.0, 1.0 / factor))}")


### PR DESCRIPTION
ffmpeg slowmo used 1.0/factor and ZeroDivisionError on factor 0.

Repro: plan effect {"type":"slowmo","factor":0} on the ffmpeg backend.