### PR TITLE
fix(tts): extend number scales and reject non-finite values

### DIFF
--- a/chapter9/live-audio/backend/utils/test_number_to_words.js
+++ b/chapter9/live-audio/backend/utils/test_number_to_words.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+const Module = require('module');
+const orig = Module.prototype.require;
+Module.prototype.require = function (id) {
+  if (id === 'emoji-regex') return () => /(?!)/g;
+  return orig.apply(this, arguments);
+};
+const { numberToWords } = require('./textProcessor.js');
+assert.strictEqual(numberToWords(0), 'zero');
+assert.ok(!numberToWords(1e12).includes('undefined'));
+assert.ok(numberToWords(1e12).includes('trillion'));
+assert.strictEqual(numberToWords(Infinity), 'Infinity');
+console.log('ok');

--- a/chapter9/live-audio/backend/utils/textProcessor.js
+++ b/chapter9/live-audio/backend/utils/textProcessor.js
@@ -40,9 +40,10 @@ function numberToWords(num) {
   const ones = ['', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'];
   const tens = ['', '', 'twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy', 'eighty', 'ninety'];
   const teens = ['ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen', 'eighteen', 'nineteen'];
-  const scales = ['', 'thousand', 'million', 'billion'];
+  const scales = ['', 'thousand', 'million', 'billion', 'trillion', 'quadrillion'];
 
   if (num === 0) return 'zero';
+  if (!Number.isFinite(num)) return String(num);
 
   function convertGroup(n) {
     let result = '';
@@ -73,7 +74,8 @@ function numberToWords(num) {
   while (num > 0) {
     const group = num % 1000;
     if (group !== 0) {
-      result = convertGroup(group) + scales[groupIndex] + ' ' + result;
+      const scale = scales[groupIndex] || '';
+      result = convertGroup(group) + scale + ' ' + result;
     }
     num = Math.floor(num / 1000);
     groupIndex++;
@@ -186,5 +188,7 @@ function preprocessSentence(sentence, language = 'en') {
 }
 
 module.exports = {
-  preprocessSentence
+  preprocessSentence,
+  numberToWords,
+  markdownToText,
 };


### PR DESCRIPTION
numberToWords stopped at billion (spoke undefined for trillions) and hung on Infinity from huge digit runs.

Repro: numberToWords(1e12); preprocessSentence with a 309-digit token.