### PR TITLE
fix(read): treat negative limit as read-to-EOF

### DIFF
--- a/chapter5/coding-agent/tests/test_read_negative_limit.py
+++ b/chapter5/coding-agent/tests/test_read_negative_limit.py
@@ -1,0 +1,13 @@
+"""Regression: negative Read.limit must not silently drop a file suffix."""
+from pathlib import Path
+
+from tools.read_tool import ReadTool
+from system_state import SystemState
+
+
+def test_negative_limit_reads_to_eof(tmp_path: Path):
+    path = tmp_path / "f.txt"
+    path.write_text("\n".join(f"L{i}" for i in range(1, 11)) + "\n")
+    tool = ReadTool(SystemState(current_directory=str(tmp_path)))
+    out = tool._read_text(path, offset=0, limit=-1)
+    assert "L10" in out["content"]

--- a/chapter5/coding-agent/tools/read_tool.py
+++ b/chapter5/coding-agent/tools/read_tool.py
@@ -69,7 +69,12 @@ class ReadTool(BaseTool):
             
             # Apply offset and limit
             total_lines = len(lines)
-            selected_lines = lines[offset:offset + limit] if offset or limit < total_lines else lines
+            if offset < 0:
+                offset = 0
+            if limit < 0:
+                selected_lines = lines[offset:]
+            else:
+                selected_lines = lines[offset:offset + limit] if offset or limit < total_lines else lines
             
             # Format with line numbers (1-indexed)
             formatted_lines = []


### PR DESCRIPTION
Read.limit=-1 sliced lines[0:-1] and dropped the file suffix.

Repro: Read with limit=-1 on a 10-line file.