### PR TITLE
fix(grep): clamp negative context counts to zero

### DIFF
--- a/chapter5/coding-agent/tests/test_grep_negative_context.py
+++ b/chapter5/coding-agent/tests/test_grep_negative_context.py
@@ -1,0 +1,8 @@
+"""Regression: negative -B/-A/-C must not wipe matches via empty ranges."""
+from pathlib import Path
+
+
+def test_source_clamps_context():
+    src = Path(__file__).resolve().parents[1] / "tools" / "grep_tool.py"
+    text = src.read_text()
+    assert "context_before = max(0, int(context_before))" in text

--- a/chapter5/coding-agent/tools/grep_tool.py
+++ b/chapter5/coding-agent/tools/grep_tool.py
@@ -58,6 +58,8 @@ class GrepTool(BaseTool):
         if context_around:
             context_before = context_around
             context_after = context_around
+        context_before = max(0, int(context_before))
+        context_after = max(0, int(context_after))
         
         # Compile regex
         regex_flags = re.MULTILINE if multiline else 0


### PR DESCRIPTION
Negative -B/-A/-C made match line ranges empty so hits disappeared.

Repro: Grep content mode with -C: -1 on a file that contains the pattern.