### PR TITLE
fix(grep): treat negative head_limit as unlimited

### DIFF
--- a/chapter5/coding-agent/tests/test_grep_negative_head_limit.py
+++ b/chapter5/coding-agent/tests/test_grep_negative_head_limit.py
@@ -1,0 +1,9 @@
+"""Regression: head_limit=-1 must mean unlimited, not stop after first hit."""
+from pathlib import Path
+
+
+def test_source_treats_negative_head_limit_as_unlimited():
+    src = Path(__file__).resolve().parents[1] / "tools" / "grep_tool.py"
+    text = src.read_text()
+    assert "if head_limit is not None and head_limit < 0:" in text
+    assert "head_limit = None" in text.split("head_limit < 0:")[1][:80]

--- a/chapter5/coding-agent/tools/grep_tool.py
+++ b/chapter5/coding-agent/tools/grep_tool.py
@@ -52,6 +52,8 @@ class GrepTool(BaseTool):
         show_line_numbers = params.get("-n", False)
         multiline = params.get("multiline", False)
         head_limit = params.get("head_limit")
+        if head_limit is not None and head_limit < 0:
+            head_limit = None
         file_type = params.get("type")
         
         # Determine context


### PR DESCRIPTION
head_limit=-1 is truthy, so Grep stopped after the first match.

Repro: files_with_matches over 3 hits with head_limit=-1.