### PR TITLE
fix(chunking): keep chunk steps at least 1

### DIFF
--- a/chapter3/agentic-rag/chunking.py
+++ b/chapter3/agentic-rag/chunking.py
@@ -70,7 +70,7 @@ class DocumentChunker:
                 for sent in sentences:
                     if len(sent) > self.config.max_chunk_size:
                         # Force split very long sentences
-                        for i in range(0, len(sent), self.config.chunk_size):
+                        for i in range(0, len(sent), max(1, self.config.chunk_size)):
                             sub_chunk = sent[i:i + self.config.chunk_size]
                             chunks.append(self._create_chunk(sub_chunk, doc_id, len(chunks)))
                     else:
@@ -107,7 +107,7 @@ class DocumentChunker:
         """Simple size-based chunking"""
         chunks = []
         
-        for i in range(0, len(text), self.config.chunk_size - self.config.chunk_overlap):
+        for i in range(0, len(text), max(1, self.config.chunk_size - self.config.chunk_overlap)):
             chunk_text = text[i:i + self.config.chunk_size]
             
             if len(chunk_text) >= self.config.min_chunk_size:

--- a/chapter3/agentic-rag/test_chunk_size_zero.py
+++ b/chapter3/agentic-rag/test_chunk_size_zero.py
@@ -1,0 +1,36 @@
+"""Regression: chunk_size=0 must not crash range() on long sentences."""
+import sys
+import types
+from dataclasses import dataclass
+
+
+def _stub():
+    sys.modules.setdefault("requests", types.ModuleType("requests"))
+    cfg = types.ModuleType("config")
+
+    @dataclass
+    class ChunkingConfig:
+        chunk_size: int = 1000
+        chunk_overlap: int = 100
+        max_chunk_size: int = 2000
+        min_chunk_size: int = 1
+        respect_paragraph_boundary: bool = True
+
+    cfg.ChunkingConfig = ChunkingConfig
+    cfg.KnowledgeBaseConfig = object
+    cfg.KnowledgeBaseType = object
+    sys.modules["config"] = cfg
+
+
+_stub()
+
+from chunking import ChunkingConfig, DocumentChunker  # noqa: E402
+
+
+def test_chunk_size_zero_long_unsplittable_sentence():
+    cfg = ChunkingConfig(chunk_size=0, max_chunk_size=40, min_chunk_size=1)
+    chunker = DocumentChunker(cfg)
+    text = "alpha" * 80  # longer than max_chunk_size, no paragraph breaks
+    chunks = chunker.chunk_text(text, doc_id="d1")
+    assert isinstance(chunks, list)
+    assert len(chunks) >= 1


### PR DESCRIPTION
chunk_size=0 made range() step 0 when force-splitting long paragraphs.

Repro: DocumentChunker with chunk_size=0 on a long unsplittable sentence.