### PR TITLE
fix(user-memory): remove unsupported config option

### DIFF
--- a/chapter3/user-memory/PROVIDERS.md
+++ b/chapter3/user-memory/PROVIDERS.md
@@ -132,8 +132,7 @@ processor = BackgroundMemoryProcessor(
     user_id="user789",
     provider="kimi",  # or "moonshot"
     config=MemoryProcessorConfig(
-        conversation_interval=2,
-        update_threshold=0.7
+        conversation_interval=2
     ),
     memory_mode=MemoryMode.JSON_CARDS
 )
@@ -144,8 +143,7 @@ processor = BackgroundMemoryProcessor(
     provider="openrouter",
     model="google/gemini-3.5-flash",  # or "openai/gpt-5", "anthropic/claude-sonnet-4"
     config=MemoryProcessorConfig(
-        conversation_interval=1,
-        update_threshold=0.6
+        conversation_interval=1
     ),
     memory_mode=MemoryMode.ENHANCED_NOTES
 )

--- a/chapter3/user-memory/demo_conversation_processing.py
+++ b/chapter3/user-memory/demo_conversation_processing.py
@@ -51,7 +51,6 @@ def demonstrate_conversation_processing():
         config=MemoryProcessorConfig(
             conversation_interval=1,  # Process after each conversation
             min_conversation_turns=1,
-            update_threshold=0.6,
             output_operations=True
         ),
         verbose=False

--- a/chapter3/user-memory/quickstart.py
+++ b/chapter3/user-memory/quickstart.py
@@ -65,7 +65,6 @@ def quickstart():
         config=MemoryProcessorConfig(
             conversation_interval=1,  # Process after each conversation
             min_conversation_turns=1,
-            update_threshold=0.6,
             output_operations=True
         ),
         verbose=False


### PR DESCRIPTION
## Summary

- remove the obsolete `update_threshold` option from the quickstart and
  conversation-processing demos
- update both provider examples to use the current `MemoryProcessorConfig` API

`update_threshold` was removed when memory updates moved to direct agent tool
calls, but these examples still passed it to the dataclass and failed during
construction before any provider request.

## Validation

- `python -m pytest -q` (`5 passed`)
- real `MemoryProcessorConfig` constructor smoke test
- AST scan confirming demo keywords match supported dataclass fields
- `python -m py_compile` for the changed Python entry points
- `python3 scripts/check_i18n_consistency.py`
- `git diff --check`

Live LLM-backed demos were not run because they require external API
credentials. This patch changes example configuration only; it does not alter
memory-processing behavior.
