### PR TITLE
fix(collaboration-tools): restore recurring timers

### DIFF
--- a/chapter4/collaboration-tools/src/timer_tools.py
+++ b/chapter4/collaboration-tools/src/timer_tools.py
@@ -252,8 +252,8 @@ async def get_timer_status(timer_id: str) -> Dict[str, Any]:
         
         timer = _active_timers[timer_id]
         
-        # Calculate remaining time for active timers
-        if timer["status"] == "active":
+        # Recurring timers have an interval rather than a fixed expiry time.
+        if timer["status"] == "active" and timer.get("type") != "recurring":
             expiry = datetime.fromisoformat(timer["expiry_time"])
             remaining = (expiry - datetime.now()).total_seconds()
             timer["remaining_seconds"] = max(0, int(remaining))
@@ -340,27 +340,36 @@ async def _run_recurring_timer(
 ):
     """Internal function to run a recurring timer."""
     try:
-        occurrence = 0
+        timer_data = _active_timers.get(timer_id)
+        if timer_data is None:
+            return
+
+        occurrence = timer_data.get("occurrences", 0)
         
         while True:
             await asyncio.sleep(interval_seconds)
+
+            timer_data = _active_timers.get(timer_id)
+            if timer_data is None:
+                return
+
             occurrence += 1
-            
-            if timer_id in _active_timers:
-                timer_data = _active_timers[timer_id]
-                timer_data["occurrences"] = occurrence
-                timer_data["last_occurrence"] = datetime.now().isoformat()
-                
-                logger.info(f"Recurring timer {timer_id} occurrence {occurrence}")
-                
-                await _trigger_timer_callback(timer_data)
-                await _save_timers()
-                
-                # Check if we've reached max occurrences
-                if max_occurrences and occurrence >= max_occurrences:
-                    timer_data["status"] = "completed"
-                    logger.info(f"Recurring timer {timer_id} completed after {occurrence} occurrences")
-                    break
+            timer_data["occurrences"] = occurrence
+            timer_data["last_occurrence"] = datetime.now().isoformat()
+
+            logger.info(f"Recurring timer {timer_id} occurrence {occurrence}")
+
+            await _trigger_timer_callback(timer_data)
+
+            # Persist the terminal state, not an active record at the limit.
+            if max_occurrences and occurrence >= max_occurrences:
+                timer_data["status"] = "completed"
+                logger.info(f"Recurring timer {timer_id} completed after {occurrence} occurrences")
+
+            await _save_timers()
+
+            if timer_data["status"] == "completed":
+                break
                     
     except asyncio.CancelledError:
         if timer_id in _active_timers:
@@ -381,7 +390,7 @@ async def _save_timers():
         # Only save timers with relevant status
         timers_to_save = {
             tid: timer for tid, timer in _active_timers.items()
-            if timer["status"] in ["active", "expired"]
+            if timer["status"] in ["active", "expired", "completed"]
         }
         
         with open(storage_path, 'w') as f:
@@ -404,8 +413,35 @@ async def _load_timers():
             saved_timers = json.load(f)
         
         # Restore active timers
+        state_changed = False
         for timer_id, timer_data in saved_timers.items():
             if timer_data["status"] == "active":
+                if timer_data.get("type") == "recurring":
+                    _active_timers[timer_id] = timer_data
+
+                    max_occurrences = timer_data.get("max_occurrences")
+                    occurrences = timer_data.get("occurrences", 0)
+                    if max_occurrences and occurrences >= max_occurrences:
+                        # Older versions persisted the final occurrence before
+                        # changing the in-memory status to completed.
+                        timer_data["status"] = "completed"
+                        state_changed = True
+                        continue
+
+                    task = asyncio.create_task(
+                        _run_recurring_timer(
+                            timer_id,
+                            timer_data["interval_seconds"],
+                            max_occurrences
+                        )
+                    )
+                    _timer_tasks[timer_id] = task
+                    logger.info(
+                        f"Restored recurring timer {timer_id} after "
+                        f"{occurrences} occurrences"
+                    )
+                    continue
+
                 # Calculate remaining time
                 expiry = datetime.fromisoformat(timer_data["expiry_time"])
                 remaining = (expiry - datetime.now()).total_seconds()
@@ -422,6 +458,9 @@ async def _load_timers():
                     _active_timers[timer_id] = timer_data
             else:
                 _active_timers[timer_id] = timer_data
-                
+
+        if state_changed:
+            await _save_timers()
+
     except Exception as e:
         logger.error(f"Failed to load timers: {e}")

--- a/chapter4/collaboration-tools/test_timer_tools.py
+++ b/chapter4/collaboration-tools/test_timer_tools.py
@@ -1,0 +1,160 @@
+"""Offline regression tests for recurring timer persistence."""
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
+import timer_tools
+
+
+class RecurringTimerPersistenceTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.storage_path = Path(self.temp_dir.name) / "timers.json"
+
+        fake_config = types.ModuleType("config")
+        fake_config.config = types.SimpleNamespace(
+            timer=types.SimpleNamespace(storage_path=str(self.storage_path))
+        )
+        self.config_patch = patch.dict(sys.modules, {"config": fake_config})
+        self.config_patch.start()
+
+        timer_tools._active_timers.clear()
+        timer_tools._timer_tasks.clear()
+
+    async def asyncTearDown(self):
+        tasks = list(timer_tools._timer_tasks.values())
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        timer_tools._timer_tasks.clear()
+        timer_tools._active_timers.clear()
+        self.config_patch.stop()
+        self.temp_dir.cleanup()
+
+    def recurring_timer(self, *, occurrences=1, max_occurrences=3, interval_seconds=3600):
+        return {
+            "timer_id": "recurring",
+            "name": "heartbeat",
+            "type": "recurring",
+            "interval_seconds": interval_seconds,
+            "max_occurrences": max_occurrences,
+            "occurrences": occurrences,
+            "callback_message": None,
+            "status": "active",
+            "created_at": datetime.now().isoformat(),
+        }
+
+    def one_shot_timer(self):
+        now = datetime.now()
+        return {
+            "timer_id": "one-shot",
+            "name": "later",
+            "duration_seconds": 3600,
+            "start_time": now.isoformat(),
+            "expiry_time": (now + timedelta(hours=1)).isoformat(),
+            "callback_message": None,
+            "callback_data": {},
+            "status": "active",
+            "created_at": now.isoformat(),
+        }
+
+    def write_timers(self, timers):
+        self.storage_path.write_text(json.dumps(timers), encoding="utf-8")
+
+    def read_timers(self):
+        return json.loads(self.storage_path.read_text(encoding="utf-8"))
+
+    async def test_load_restores_recurring_and_following_one_shot_timers(self):
+        self.write_timers({
+            "recurring": self.recurring_timer(),
+            "one-shot": self.one_shot_timer(),
+        })
+
+        await timer_tools._load_timers()
+
+        self.assertEqual(
+            set(timer_tools._active_timers),
+            {"recurring", "one-shot"},
+        )
+        self.assertEqual(
+            set(timer_tools._timer_tasks),
+            {"recurring", "one-shot"},
+        )
+
+    async def test_status_for_active_recurring_timer_does_not_require_expiry(self):
+        timer_tools._active_timers["recurring"] = self.recurring_timer()
+
+        result = await timer_tools.get_timer_status("recurring")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["timer"]["status"], "active")
+        self.assertNotIn("remaining_seconds", result["timer"])
+
+    async def test_restored_timer_resumes_count_and_persists_completion(self):
+        self.write_timers({
+            "recurring": self.recurring_timer(
+                occurrences=1,
+                max_occurrences=2,
+                interval_seconds=0,
+            )
+        })
+
+        with patch.object(
+            timer_tools,
+            "_trigger_timer_callback",
+            new_callable=AsyncMock,
+        ) as callback:
+            await timer_tools._load_timers()
+            await asyncio.wait_for(timer_tools._timer_tasks["recurring"], timeout=1)
+
+        timer = timer_tools._active_timers["recurring"]
+        persisted = self.read_timers()["recurring"]
+        self.assertEqual(callback.await_count, 1)
+        self.assertEqual(timer["occurrences"], 2)
+        self.assertEqual(timer["status"], "completed")
+        self.assertEqual(persisted["occurrences"], 2)
+        self.assertEqual(persisted["status"], "completed")
+
+    async def test_load_completes_legacy_active_timer_already_at_limit(self):
+        self.write_timers({
+            "recurring": self.recurring_timer(
+                occurrences=2,
+                max_occurrences=2,
+                interval_seconds=0,
+            )
+        })
+
+        with patch.object(
+            timer_tools,
+            "_trigger_timer_callback",
+            new_callable=AsyncMock,
+        ) as callback:
+            await timer_tools._load_timers()
+
+        self.assertNotIn("recurring", timer_tools._timer_tasks)
+        self.assertEqual(callback.await_count, 0)
+        self.assertEqual(
+            timer_tools._active_timers["recurring"]["status"],
+            "completed",
+        )
+        self.assertEqual(
+            self.read_timers()["recurring"]["status"],
+            "completed",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- restore persisted recurring timers without requiring the one-shot-only
  `expiry_time` field
- resume persisted occurrence counts and save the terminal `completed` state
- add offline async regression coverage for reload, status, mixed timer types,
  and legacy terminal records

Recurring records store an interval rather than an expiry timestamp. The
existing reload and status paths treated every active timer as one-shot, so a
persisted recurring timer raised `KeyError` and could prevent later timers from
being restored. Restarted runners also reset their occurrence count, while the
terminal state was saved as `active` before being changed in memory.

Completed recurring records now remain queryable after restart, matching their
existing in-memory visibility and the persistence of expired one-shot timers.

## Validation

- `python3 -m unittest -v test_timer_tools.py` (`4 passed`)
- `python -m pytest -q test_timer_tools.py` (`4 passed`)
- async debug/warnings-as-errors run and 10 repeated focused runs
- existing one-shot timer smoke test
- `python3 scripts/check_i18n_consistency.py`
- `python -m py_compile` and whitespace checks

The full MCP experiment suite was not run because its optional browser and
service dependencies are not installed. Persisted records do not include a
next-fire timestamp, so a restored recurring timer still waits one complete
interval after restart; this patch intentionally keeps the existing storage
schema.
