### PR TITLE
fix(chapter4): give code interpreter an explicit namespace

### DIFF
--- a/chapter4/agent-with-event-trigger/agent.py
+++ b/chapter4/agent-with-event-trigger/agent.py
@@ -925,8 +925,11 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
             output_buffer = io.StringIO()
             error_buffer = io.StringIO()
             
+            # Use one namespace so functions defined by the snippet can resolve
+            # names assigned earlier in the same snippet.
+            exec_ns = {}
             with contextlib.redirect_stdout(output_buffer), contextlib.redirect_stderr(error_buffer):
-                exec(code)
+                exec(code, exec_ns)
             
             stdout = output_buffer.getvalue()
             stderr = error_buffer.getvalue()

--- a/chapter4/agent-with-event-trigger/test_code_interpreter.py
+++ b/chapter4/agent-with-event-trigger/test_code_interpreter.py
@@ -1,0 +1,73 @@
+"""Regression tests for the code interpreter's execution namespace."""
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_agent_module():
+    openai = types.ModuleType("openai")
+    openai.OpenAI = type("OpenAI", (), {})
+
+    mcp = types.ModuleType("mcp")
+    mcp.__path__ = []
+    mcp.ClientSession = type("ClientSession", (), {})
+    mcp.StdioServerParameters = type("StdioServerParameters", (), {})
+
+    mcp_client = types.ModuleType("mcp.client")
+    mcp_client.__path__ = []
+    mcp_stdio = types.ModuleType("mcp.client.stdio")
+    mcp_stdio.stdio_client = lambda *args, **kwargs: None
+    mcp_types = types.ModuleType("mcp.types")
+    mcp_types.TextContent = type("TextContent", (), {})
+
+    stubs = {
+        "openai": openai,
+        "mcp": mcp,
+        "mcp.client": mcp_client,
+        "mcp.client.stdio": mcp_stdio,
+        "mcp.types": mcp_types,
+    }
+    module_path = Path(__file__).with_name("agent.py")
+    module_name = "_event_trigger_agent_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+
+    with patch.dict(sys.modules, stubs):
+        sys.modules[module_name] = module
+        sys.path.insert(0, str(module_path.parent))
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            sys.path.pop(0)
+
+    return module
+
+
+class CodeInterpreterNamespaceTests(unittest.TestCase):
+    def test_code_interpreter_shares_names_with_defined_functions(self):
+        agent_module = _load_agent_module()
+        agent = agent_module.EventTriggeredAgent.__new__(agent_module.EventTriggeredAgent)
+
+        result = agent._tool_code_interpreter(
+            "value = 5\n"
+            "def double():\n"
+            "    return value * 2\n"
+            "print(double())"
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "success": True,
+                "stdout": "10\n",
+                "stderr": "",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Summary

- execute event-trigger agent snippets in one explicit namespace
- add an offline regression test for functions that reference earlier snippet
  assignments

`_tool_code_interpreter()` calls bare `exec(code)` inside a method. Top-level
assignments then use the method's local namespace, while functions defined by
the snippet resolve names through module globals. A snippet that assigns
`value = 5` and reads it inside `double()` therefore raises `NameError`. One
explicit namespace restores module-like name resolution and mirrors the
chapter 2 fix merged in #199.

## Validation

- `python3 chapter4/agent-with-event-trigger/test_code_interpreter.py -v`
  (`1 test passed`)
- `python3 -m py_compile` for the changed source and test
- `python3 scripts/check_i18n_consistency.py`
- `git diff --check`

This is a namespace correctness fix, not a Python sandbox: snippets retain
normal builtins and can import modules. Code that relied on accidental access
to `self` or modules imported by `agent.py` must import or define its own
dependencies.
