### PR TITLE
fix: declare missing direct experiment dependencies

### DIFF
--- a/chapter2/attention_visualization/requirements.txt
+++ b/chapter2/attention_visualization/requirements.txt
@@ -4,3 +4,4 @@ numpy>=1.24.0
 matplotlib>=3.7.0
 seaborn>=0.12.0
 python-dotenv>=1.0.0
+requests>=2.31.0

--- a/chapter3/structured-index/requirements.txt
+++ b/chapter3/structured-index/requirements.txt
@@ -17,6 +17,7 @@ rich>=13.0.0
 
 # Common dependencies
 python-dotenv>=1.0.0
+requests>=2.31.0
 pandas>=2.0.0
 faiss-cpu>=1.7.4
 sentence-transformers>=2.2.2
@@ -29,6 +30,7 @@ pydantic>=2.5.0
 httpx>=0.25.0
 
 # Document processing
+aiofiles>=24.1.0
 pypdf>=3.17.0
 beautifulsoup4>=4.12.0
 lxml>=5.0.0


### PR DESCRIPTION

## Summary

- declare `requests` for the attention-visualization experiment
- declare `requests` and `aiofiles` for the structured-index experiment

Both experiments directly import packages that their local
`requirements.txt` files do not declare, so installation depends on unrelated
packages providing them transitively. The version floors match versions
already used by other experiments in this repository.

## Validation

- parsed all 41 entries in the two changed requirement files
- AST audit confirming all required direct third-party imports are declared
- fresh venv installation and import of `requests==2.31.0` and
  `aiofiles==24.1.0`
- `pip check`
- `python3 scripts/check_i18n_consistency.py`
- `git diff --check`

The complete ML-heavy requirement sets and live model/API workflows were not
run. `igraph` and `leidenalg` remain optional because structured index catches
their import failure and falls back to NetworkX Louvain.
