### PR TITLE
fix(ph-eval): coerce blank CSV integer cells to zero

### DIFF
--- a/chapter6/public-health-reporting-eval/reporting_tools.py
+++ b/chapter6/public-health-reporting-eval/reporting_tools.py
@@ -26,7 +26,9 @@ class ReportingEnvironment:
             for raw_row in csv.DictReader(handle):
                 row: dict[str, Any] = dict(raw_row)
                 for field in INTEGER_FIELDS:
-                    row[field] = int(row[field])
+                    raw = row[field]
+                    # Blank / whitespace cells are common in CSV exports; treat as 0.
+                    row[field] = int(raw) if str(raw).strip() else 0
                 self.rows.append(row)
 
     def _select(self, **filters: str) -> list[dict[str, Any]]:

--- a/chapter6/public-health-reporting-eval/reporting_tools.py
+++ b/chapter6/public-health-reporting-eval/reporting_tools.py
@@ -27,7 +27,6 @@ class ReportingEnvironment:
                 row: dict[str, Any] = dict(raw_row)
                 for field in INTEGER_FIELDS:
                     raw = row[field]
-                    # Blank / whitespace cells are common in CSV exports; treat as 0.
                     row[field] = int(raw) if str(raw).strip() else 0
                 self.rows.append(row)
 

--- a/chapter6/public-health-reporting-eval/test_blank_csv_int.py
+++ b/chapter6/public-health-reporting-eval/test_blank_csv_int.py
@@ -1,0 +1,61 @@
+"""Blank integer CSV cells must load as 0, not ValueError from int('')."""
+import csv
+from pathlib import Path
+
+from reporting_tools import ReportingEnvironment
+
+
+def _write_csv(path: Path, tests_value: str) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "row_id",
+                "org_unit_id",
+                "period",
+                "parent_org_unit",
+                "tests",
+                "confirmed_cases",
+                "deaths",
+                "report_expected",
+                "report_submitted",
+                "stockout_days",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "row_id": "r1",
+                "org_unit_id": "ou1",
+                "period": "2024Q1",
+                "parent_org_unit": "p1",
+                "tests": tests_value,
+                "confirmed_cases": "5",
+                "deaths": "0",
+                "report_expected": "1",
+                "report_submitted": "1",
+                "stockout_days": "0",
+            }
+        )
+
+
+def test_blank_tests_field_loads_as_zero(tmp_path):
+    path = tmp_path / "blank.csv"
+    _write_csv(path, "")
+    env = ReportingEnvironment(path)
+    assert env.rows[0]["tests"] == 0
+    assert env.rows[0]["confirmed_cases"] == 5
+
+
+def test_whitespace_tests_field_loads_as_zero(tmp_path):
+    path = tmp_path / "space.csv"
+    _write_csv(path, "  ")
+    env = ReportingEnvironment(path)
+    assert env.rows[0]["tests"] == 0
+
+
+def test_numeric_tests_unchanged(tmp_path):
+    path = tmp_path / "ok.csv"
+    _write_csv(path, "12")
+    env = ReportingEnvironment(path)
+    assert env.rows[0]["tests"] == 12


### PR DESCRIPTION
Blank integer cells in the public-health reporting CSV raised `ValueError` on `int("")`.

Coerce blank or whitespace cells to 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV reporting imports to handle blank or whitespace-only numeric fields as zero instead of producing an error.
  * Numeric values continue to be parsed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->