### PR TITLE
fix(self-evol-eval): treat null rubric dimension scores as zero

### DIFF
--- a/chapter8/self-evolution-eval/harness.py
+++ b/chapter8/self-evolution-eval/harness.py
@@ -163,7 +163,7 @@ def layer3_tool_quality(task: dict, trajectory: dict, judge_model: Optional[str]
         return {"score": 0.0, "rubric": None, "judge_text": raw, "detail": "judge 输出无法解析为 JSON。"}
 
     dims = ["error_handling", "input_validation", "documentation", "robustness"]
-    total = sum(int(rubric.get(d, 0)) for d in dims)
+    total = sum(int(rubric.get(d) or 0) for d in dims)
     score = round(total / (3 * len(dims)), 3)
     return {
         "score": score,

--- a/chapter8/self-evolution-eval/harness.py
+++ b/chapter8/self-evolution-eval/harness.py
@@ -133,6 +133,12 @@ def _parse_judge_json(text: str) -> Optional[dict]:
     return None
 
 
+def _rubric_dimension_total(rubric: dict) -> int:
+    """Sum 0-3 rubric dims; missing/None count as 0 (not other falsy JSON)."""
+    dims = ["error_handling", "input_validation", "documentation", "robustness"]
+    return sum(int(v) if v is not None else 0 for v in (rubric.get(d) for d in dims))
+
+
 def layer3_tool_quality(task: dict, trajectory: dict, judge_model: Optional[str] = None) -> dict:
     created = trajectory.get("created_tools", [])
     if not created:
@@ -163,7 +169,7 @@ def layer3_tool_quality(task: dict, trajectory: dict, judge_model: Optional[str]
         return {"score": 0.0, "rubric": None, "judge_text": raw, "detail": "judge 输出无法解析为 JSON。"}
 
     dims = ["error_handling", "input_validation", "documentation", "robustness"]
-    total = sum(int(rubric.get(d) or 0) for d in dims)
+    total = _rubric_dimension_total(rubric)
     score = round(total / (3 * len(dims)), 3)
     return {
         "score": score,

--- a/chapter8/self-evolution-eval/test_null_rubric_dimension.py
+++ b/chapter8/self-evolution-eval/test_null_rubric_dimension.py
@@ -1,0 +1,46 @@
+"""Judge rubric dimensions that are JSON null must score as 0, not int(None)."""
+from pathlib import Path
+
+
+def _score_rubric(rubric: dict) -> tuple[int, float]:
+    """Mirrors harness.layer3_tool_quality scoring after JSON parse."""
+    dims = ["error_handling", "input_validation", "documentation", "robustness"]
+    total = sum(int(rubric.get(d) or 0) for d in dims)
+    score = round(total / (3 * len(dims)), 3)
+    return total, score
+
+
+def test_null_rubric_dimension_coerced():
+    rubric = {
+        "error_handling": None,
+        "input_validation": 2,
+        "documentation": 1,
+        "robustness": 3,
+        "comment": "ok",
+    }
+    total, score = _score_rubric(rubric)
+    assert total == 6
+    assert score == 0.5
+
+
+def test_missing_dimension_still_zero():
+    total, score = _score_rubric({"input_validation": 3})
+    assert total == 3
+    assert score == 0.25
+
+
+def test_pristine_int_none_raises():
+    """Old pattern int(rubric.get(d, 0)) still blows up on explicit null."""
+    rubric = {"error_handling": None}
+    try:
+        int(rubric.get("error_handling", 0))
+        raised = False
+    except TypeError:
+        raised = True
+    assert raised
+
+
+def test_source_uses_or_zero():
+    src = Path(__file__).with_name("harness.py").read_text(encoding="utf-8")
+    assert "int(rubric.get(d) or 0)" in src
+    assert "int(rubric.get(d, 0))" not in src

--- a/chapter8/self-evolution-eval/test_null_rubric_dimension.py
+++ b/chapter8/self-evolution-eval/test_null_rubric_dimension.py
@@ -1,13 +1,7 @@
 """Judge rubric dimensions that are JSON null must score as 0, not int(None)."""
-from pathlib import Path
+import pytest
 
-
-def _score_rubric(rubric: dict) -> tuple[int, float]:
-    """Mirrors harness.layer3_tool_quality scoring after JSON parse."""
-    dims = ["error_handling", "input_validation", "documentation", "robustness"]
-    total = sum(int(rubric.get(d) or 0) for d in dims)
-    score = round(total / (3 * len(dims)), 3)
-    return total, score
+from harness import _rubric_dimension_total
 
 
 def test_null_rubric_dimension_coerced():
@@ -18,29 +12,20 @@ def test_null_rubric_dimension_coerced():
         "robustness": 3,
         "comment": "ok",
     }
-    total, score = _score_rubric(rubric)
-    assert total == 6
-    assert score == 0.5
+    assert _rubric_dimension_total(rubric) == 6
 
 
 def test_missing_dimension_still_zero():
-    total, score = _score_rubric({"input_validation": 3})
-    assert total == 3
-    assert score == 0.25
+    assert _rubric_dimension_total({"input_validation": 3}) == 3
+
+
+def test_empty_string_score_rejected():
+    with pytest.raises(ValueError):
+        _rubric_dimension_total({"error_handling": ""})
 
 
 def test_pristine_int_none_raises():
     """Old pattern int(rubric.get(d, 0)) still blows up on explicit null."""
     rubric = {"error_handling": None}
-    try:
+    with pytest.raises(TypeError):
         int(rubric.get("error_handling", 0))
-        raised = False
-    except TypeError:
-        raised = True
-    assert raised
-
-
-def test_source_uses_or_zero():
-    src = Path(__file__).with_name("harness.py").read_text(encoding="utf-8")
-    assert "int(rubric.get(d) or 0)" in src
-    assert "int(rubric.get(d, 0))" not in src


### PR DESCRIPTION
LLM judge payloads with null rubric dimension scores hit `int(None)`.

Treat missing or null dimension scores as 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rubric scoring when evaluation dimensions are explicitly empty or missing.
  * Prevented scoring errors caused by null rubric values.
* **Tests**
  * Added coverage for null, missing, and default rubric dimensions to verify consistent score calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->