### PR TITLE
fix(code-for-math): avoid ZeroDivisionError on empty problems summary

### DIFF
--- a/chapter5/code-for-math/demo.py
+++ b/chapter5/code-for-math/demo.py
@@ -446,13 +446,20 @@ def main(argv=None):
         )
     print("-" * 78)
     summary_line = f"{'准确率':<5}{'':<26}{'':>7}"
-    if run_cot:
-        summary_line += f"{cot_correct}/{n} = {cot_correct/n:5.0%}".rjust(14)
-    if run_code:
-        summary_line += f"{code_correct}/{n} = {code_correct/n:5.0%}".rjust(18)
+    # Empty --problems JSON is valid; avoid ZeroDivisionError on the rate line.
+    if n == 0:
+        if run_cot:
+            summary_line += f"{cot_correct}/{n} =   N/A".rjust(14)
+        if run_code:
+            summary_line += f"{code_correct}/{n} =   N/A".rjust(18)
+    else:
+        if run_cot:
+            summary_line += f"{cot_correct}/{n} = {cot_correct/n:5.0%}".rjust(14)
+        if run_code:
+            summary_line += f"{code_correct}/{n} = {code_correct/n:5.0%}".rjust(18)
     print(summary_line)
     print("=" * 78)
-    if run_cot and run_code:
+    if n and run_cot and run_code:
         print(
             f"\n结论：纯 CoT 准确率 {cot_correct/n:.0%}，代码辅助准确率 {code_correct/n:.0%}，"
             f"提升 {(code_correct-cot_correct)/n:+.0%}。"

--- a/chapter5/code-for-math/demo.py
+++ b/chapter5/code-for-math/demo.py
@@ -446,17 +446,16 @@ def main(argv=None):
         )
     print("-" * 78)
     summary_line = f"{'准确率':<5}{'':<26}{'':>7}"
-    # Empty --problems JSON is valid; avoid ZeroDivisionError on the rate line.
-    if n == 0:
-        if run_cot:
-            summary_line += f"{cot_correct}/{n} =   N/A".rjust(14)
-        if run_code:
-            summary_line += f"{code_correct}/{n} =   N/A".rjust(18)
-    else:
-        if run_cot:
-            summary_line += f"{cot_correct}/{n} = {cot_correct/n:5.0%}".rjust(14)
-        if run_code:
-            summary_line += f"{code_correct}/{n} = {code_correct/n:5.0%}".rjust(18)
+
+    def _rate_cell(correct: int, width: int) -> str:
+        if n == 0:
+            return f"{correct}/{n} =   N/A".rjust(width)
+        return f"{correct}/{n} = {correct / n:5.0%}".rjust(width)
+
+    if run_cot:
+        summary_line += _rate_cell(cot_correct, 14)
+    if run_code:
+        summary_line += _rate_cell(code_correct, 18)
     print(summary_line)
     print("=" * 78)
     if n and run_cot and run_code:

--- a/chapter5/code-for-math/test_empty_problems.py
+++ b/chapter5/code-for-math/test_empty_problems.py
@@ -8,11 +8,12 @@ import demo as cfm
 
 
 class _Resp:
-    choices = [
-        SimpleNamespace(
-            message=SimpleNamespace(content="FINAL ANSWER: 1", tool_calls=None)
-        )
-    ]
+    def __init__(self):
+        self.choices = [
+            SimpleNamespace(
+                message=SimpleNamespace(content="FINAL ANSWER: 1", tool_calls=None)
+            )
+        ]
 
 
 class _Completions:

--- a/chapter5/code-for-math/test_empty_problems.py
+++ b/chapter5/code-for-math/test_empty_problems.py
@@ -1,0 +1,54 @@
+"""Empty problems JSON must not ZeroDivisionError in the accuracy summary."""
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import demo as cfm
+
+
+class _Resp:
+    choices = [
+        SimpleNamespace(
+            message=SimpleNamespace(content="FINAL ANSWER: 1", tool_calls=None)
+        )
+    ]
+
+
+class _Completions:
+    @staticmethod
+    def create(**kwargs):
+        return _Resp()
+
+
+class _Chat:
+    completions = _Completions()
+
+
+class _Client:
+    chat = _Chat()
+
+
+def test_empty_problems_summary_no_zerodiv(tmp_path, monkeypatch, capsys):
+    path = tmp_path / "empty.json"
+    path.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(cfm, "build_client_and_model", lambda model_override=None: (_Client(), "fake"))
+    rc = cfm.main(["--problems", str(path), "--mode", "cot"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "0/0" in out
+    assert "N/A" in out
+
+
+def test_nonempty_summary_still_shows_percent(tmp_path, monkeypatch, capsys):
+    path = tmp_path / "one.json"
+    path.write_text(
+        json.dumps([{"id": "1", "topic": "t", "question": "1+1?", "answer": 1}]),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cfm, "build_client_and_model", lambda model_override=None: (_Client(), "fake"))
+    rc = cfm.main(["--problems", str(path), "--mode", "cot"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "1/1" in out
+    assert "%" in out


### PR DESCRIPTION
`--problems []` is valid input but the accuracy summary divided by zero.

Print N/A rates when there are no problems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accuracy summaries now handle empty problem sets without errors.
  * Empty results display `0/0` and `N/A` instead of attempting an invalid percentage calculation.
  * Normal accuracy summaries continue to display percentage values correctly.

* **Tests**
  * Added coverage for both empty and non-empty problem sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->