### PR TITLE
fix(ske): raise clear error when advise has zero archetypes

### DIFF
--- a/chapter3/structured-knowledge-extraction/advisor_agent.py
+++ b/chapter3/structured-knowledge-extraction/advisor_agent.py
@@ -57,7 +57,11 @@ class LegalAdvisorAgent:
 
     # --- 步骤 3+4：匹配最近原型并给出建议 ---
     def advise(self, known):
-        arch, dist = nearest_archetype(self.model, known)
+        matched = nearest_archetype(self.model, known)
+        # fit() can return n_archetypes=0 when every charge has too few samples to cluster.
+        if matched is None:
+            raise ValueError("模型中没有可用案件原型，无法给出量刑建议（样本过少无法聚类）")
+        arch, dist = matched
         m = arch["months"]
         defining = "；".join(
             f"{d['label']}（{d['direction']}，典型 {d['typical']}）"

--- a/chapter3/structured-knowledge-extraction/test_advise_zero_archetypes.py
+++ b/chapter3/structured-knowledge-extraction/test_advise_zero_archetypes.py
@@ -1,0 +1,35 @@
+"""advise() must not TypeError-unpack when the model has zero archetypes."""
+import sys
+import types
+
+import pytest
+
+# Stub openai/config client so LegalAdvisorAgent can be constructed offline.
+import config as cfg
+
+cfg.get_client = lambda: object()
+
+from advisor_agent import LegalAdvisorAgent  # noqa: E402
+from archetypes import fit, nearest_archetype  # noqa: E402
+
+
+def _small_model():
+    schema = {"core_factors": [], "extensions": {"盗窃罪": [], "诈骗罪": []}}
+    results = [
+        {"extracted": {"charge": "盗窃罪"}, "label_months": 12},
+        {"extracted": {"charge": "诈骗罪"}, "label_months": 24},
+    ]
+    return schema, fit(schema, results, save=False, verbose=False)
+
+
+def test_nearest_returns_none_when_no_archetypes():
+    _, model = _small_model()
+    assert model["n_archetypes"] == 0
+    assert nearest_archetype(model, {"charge": "盗窃罪"}) is None
+
+
+def test_advise_raises_clear_valueerror_not_typeerror():
+    schema, model = _small_model()
+    agent = LegalAdvisorAgent(schema, model)
+    with pytest.raises(ValueError, match="没有可用案件原型"):
+        agent.advise({"charge": "盗窃罪"})


### PR DESCRIPTION
`advise()` after a fit that yields zero archetypes unpacked `None` and raised `TypeError`.

Raise a clear `ValueError` instead.