### PR TITLE
fix(elo): tolerate empty battle frames in Bradley-Terry MLE

### DIFF
--- a/chapter6/elo-leaderboard/bradley_terry.py
+++ b/chapter6/elo-leaderboard/bradley_terry.py
@@ -32,6 +32,9 @@ def compute_mle_elo(df: pd.DataFrame,
     Returns:
         Series of Elo ratings indexed by model name
     """
+    # Empty battle frame (e.g. --num-battles 0 or fully filtered input) is valid.
+    if df is None or len(df) == 0:
+        return pd.Series(dtype=float)
     # Create pivot tables for wins
     ptbl_a_win = pd.pivot_table(
         df[df["winner"] == "model_a"],

--- a/chapter6/elo-leaderboard/test_zero_battles_bt.py
+++ b/chapter6/elo-leaderboard/test_zero_battles_bt.py
@@ -1,0 +1,32 @@
+"""Empty battle DataFrame must not crash Bradley-Terry LogisticRegression."""
+import pandas as pd
+
+from bradley_terry import compute_bradley_terry_leaderboard, compute_mle_elo
+
+
+def test_compute_mle_elo_empty_battles():
+    df = pd.DataFrame(columns=["model_a", "model_b", "winner"])
+    ratings = compute_mle_elo(df)
+    assert isinstance(ratings, pd.Series)
+    assert len(ratings) == 0
+
+
+def test_compute_bradley_terry_leaderboard_empty():
+    df = pd.DataFrame(columns=["model_a", "model_b", "winner"])
+    board = compute_bradley_terry_leaderboard(df)
+    assert isinstance(board, pd.DataFrame)
+    assert len(board) == 0
+
+
+def test_nonempty_still_rates():
+    df = pd.DataFrame(
+        [
+            {"model_a": "A", "model_b": "B", "winner": "model_a"},
+            {"model_a": "A", "model_b": "B", "winner": "model_a"},
+            {"model_a": "B", "model_b": "C", "winner": "model_b"},
+            {"model_a": "A", "model_b": "C", "winner": "model_a"},
+        ]
+    )
+    ratings = compute_mle_elo(df)
+    assert set(ratings.index) >= {"A", "B", "C"}
+    assert ratings["A"] > ratings["C"]


### PR DESCRIPTION
An empty battles frame crashed Bradley-Terry MLE inside `LogisticRegression`.

Return an empty ratings frame when there are no battles.