### PR TITLE
fix(collaboration-tools): avoid eval when parsing MCP results

### DIFF
--- a/chapter4/collaboration-tools/client_example.py
+++ b/chapter4/collaboration-tools/client_example.py
@@ -10,6 +10,8 @@ from mcp.client.stdio import stdio_client
 from mcp.types import TextContent
 import sys
 
+from result_parsing import parse_mapping
+
 
 class CollaborationAgent:
     """An AI agent that uses collaboration tools."""
@@ -43,7 +45,7 @@ class CollaborationAgent:
         """Call a tool and return the result."""
         result = await self.session.call_tool(tool_name, arguments)
         text_content = [c.text for c in result.content if isinstance(c, TextContent)]
-        return eval(text_content[0]) if text_content else {}
+        return parse_mapping(text_content[0]) if text_content else {}
     
     async def monitor_website_workflow(self, url: str, check_interval: int = 300):
         """Monitor a website and notify on changes.

--- a/chapter4/collaboration-tools/quickstart.py
+++ b/chapter4/collaboration-tools/quickstart.py
@@ -10,6 +10,8 @@ from mcp.types import TextContent
 import sys
 import json
 
+from result_parsing import parse_mapping
+
 
 async def run_demo():
     """Run a demonstration of all collaboration tools."""
@@ -57,7 +59,7 @@ async def run_demo():
             
             if "timer_id" in str(timer_result):
                 # Parse timer_id from result
-                timer_data = eval(timer_result)
+                timer_data = parse_mapping(timer_result)
                 timer_id = timer_data.get("timer_id")
                 
                 print(f"\n📋 Checking timer status...")

--- a/chapter4/collaboration-tools/result_parsing.py
+++ b/chapter4/collaboration-tools/result_parsing.py
@@ -1,0 +1,17 @@
+"""Helpers for parsing text returned by collaboration tools."""
+
+import ast
+from typing import Any
+
+
+def parse_mapping(text: str) -> dict[str, Any]:
+    """Parse a Python dictionary literal without evaluating expressions."""
+    try:
+        parsed = ast.literal_eval(text)
+    except (SyntaxError, ValueError) as exc:
+        raise ValueError("MCP tool result must be a dictionary literal") from exc
+
+    if not isinstance(parsed, dict):
+        raise ValueError("MCP tool result must be a dictionary literal")
+
+    return parsed

--- a/chapter4/collaboration-tools/test_result_parsing.py
+++ b/chapter4/collaboration-tools/test_result_parsing.py
@@ -1,0 +1,42 @@
+"""Tests for MCP result parsing."""
+
+import unittest
+
+from result_parsing import parse_mapping
+
+
+class ParseMappingTests(unittest.TestCase):
+    def test_parses_python_mapping_literal(self):
+        text = (
+            "{'success': True, 'timer_id': 'abc', "
+            "'metadata': {'attempt': None, 'tags': ['demo']}}"
+        )
+
+        self.assertEqual(
+            parse_mapping(text),
+            {
+                "success": True,
+                "timer_id": "abc",
+                "metadata": {"attempt": None, "tags": ["demo"]},
+            },
+        )
+
+    def test_keeps_expression_like_text_as_data(self):
+        expression = "__import__('os').system('echo unexpected')"
+
+        self.assertEqual(
+            parse_mapping(repr({"message": expression})),
+            {"message": expression},
+        )
+
+    def test_rejects_expression(self):
+        with self.assertRaisesRegex(ValueError, "dictionary literal"):
+            parse_mapping("__import__('builtins').dict(executed=True)")
+
+    def test_rejects_non_mapping_literal(self):
+        with self.assertRaisesRegex(ValueError, "dictionary literal"):
+            parse_mapping("['not', 'a', 'mapping']")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace two `eval()` calls used for MCP text results with a shared
  `ast.literal_eval()` parser
- validate that decoded results are dictionaries before callers use mapping
  operations
- cover Python repr values, expression-like string data, executable
  expressions, and non-dictionary literals

The bundled MCP server returns `str(result)`, so responses use Python-literal
syntax (`'...'`, `True`, and `None`) rather than JSON. `json.loads()` would not
preserve compatibility. `ast.literal_eval()` accepts the existing format
without evaluating call expressions in response text.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_result_parsing.py`
  (`4 passed`)
- `python3 -m py_compile` for the two examples, parser, and test
- import smoke test in a temporary venv with `mcp==1.28.1`
- `python3 scripts/check_i18n_consistency.py`
- `git diff --check`

The full MCP demo was not run because browser, notification, and external
service integrations are not configured. This change removes arbitrary Python
expression evaluation from the local stdio examples; it does not change the
server serialization format or add a response-size limit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 改进协作工具结果的解析方式，提升示例客户端处理工具响应的安全性与可靠性。
  * 对无效或非字典格式的工具结果提供明确的错误提示。

* **测试**
  * 新增结果解析测试，覆盖嵌套数据、特殊值、无效表达式及非字典内容等场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->