### PR TITLE
test(self-evol-eval): drop tautological test, declare pytest dependency

### DIFF
--- a/chapter8/self-evolution-eval/requirements.txt
+++ b/chapter8/self-evolution-eval/requirements.txt
@@ -3,3 +3,4 @@
 # （youtube-transcript-api、yfinance 等）只是"参考方案"，被测 Agent 才会去安装，评估器不需要。
 openai>=1.30.0
 python-dotenv>=1.0.0
+pytest>=8.0.0

--- a/chapter8/self-evolution-eval/test_null_rubric_dimension.py
+++ b/chapter8/self-evolution-eval/test_null_rubric_dimension.py
@@ -22,10 +22,3 @@ def test_missing_dimension_still_zero():
 def test_empty_string_score_rejected():
     with pytest.raises(ValueError):
         _rubric_dimension_total({"error_handling": ""})
-
-
-def test_pristine_int_none_raises():
-    """Old pattern int(rubric.get(d, 0)) still blows up on explicit null."""
-    rubric = {"error_handling": None}
-    with pytest.raises(TypeError):
-        int(rubric.get("error_handling", 0))


### PR DESCRIPTION
Follow-up to #334 (merged), addressing two review nits in the added test file:

- Remove `test_pristine_int_none_raises`, which re-implemented the old inline one-liner and asserted Python's own `int(None)` behavior — it tested the language, not the codebase, and would keep passing even if the fix were reverted.
- Add `pytest>=8.0.0` to `requirements.txt` so readers following the README can actually run the test suite.

Verified: `python3 -m pytest test_null_rubric_dimension.py -q` → 3 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 更新错误处理维度的校验测试，现验证空字符串评分会被正确拒绝。
  * 移除针对 JSON 空值触发异常的旧测试场景。
* **开发环境**
  * 新增 pytest 8.0 或更高版本作为测试依赖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->