### PR TITLE
fix(web-search-agent): handle truncation, apply timeout, correct fact-check parsing

### DIFF
--- a/chapter1/web-search-agent/agent.py
+++ b/chapter1/web-search-agent/agent.py
@@ -87,7 +87,7 @@ class WebSearchAgent:
         """
         # 优先使用传入的 api_key，否则从环境变量获取
         # Moonshot 为主，OpenRouter 为通用兜底（当 MOONSHOT_API_KEY 缺失时启用）
-        from config import resolve_llm_backend
+        from config import resolve_llm_backend, Config
         primary_key = api_key or os.environ.get("MOONSHOT_API_KEY") or os.environ.get("KIMI_API_KEY")
         resolved_key, resolved_base_url, model, self.using_openrouter = \
             resolve_llm_backend(primary_key, base_url, model)
@@ -100,7 +100,9 @@ class WebSearchAgent:
 
         self.client = OpenAI(
             api_key=resolved_key,
-            base_url=resolved_base_url
+            base_url=resolved_base_url,
+            # 应用配置的搜索超时，避免后端挂起时请求默认阻塞约 10 分钟
+            timeout=Config.SEARCH_TIMEOUT,
         )
         self.model = model
         self.verbose = verbose
@@ -269,6 +271,20 @@ class WebSearchAgent:
                             "name": tool_call_name,
                             "content": tool_content
                         })
+                elif finish_reason == "length":
+                    # 输出预算（max_tokens）耗尽导致截断：返回已生成内容并明确标注，
+                    # 而不是把半截答案当作完整答案，也不误报“无法获取足够信息”
+                    # （content 为空时，思考过程已耗尽整个预算）。
+                    partial = (choice.message.content or "").strip()
+                    logger.warning("回答因达到 max_tokens 上限被截断 (finish_reason=length)")
+                    note = "（注意：回答因达到 max_tokens 上限被截断，请增大 max_tokens 后重试。）"
+                    final = f"{partial}\n\n{note}" if partial else note
+                    self._emit({"iteration": iteration, "type": "answer", "content": final})
+                    self.conversation_history.append({
+                        "role": "assistant",
+                        "content": partial or final
+                    })
+                    return final
                 else:
                     # 获得最终答案
                     if choice.message.content:

--- a/chapter1/web-search-agent/agent.py
+++ b/chapter1/web-search-agent/agent.py
@@ -66,6 +66,23 @@ def search_impl(arguments: Dict[str, Any]) -> Any:
     return arguments
 
 
+# search_and_answer 不抛异常，而是以字符串形式返回失败兜底文案。
+# 下列前缀 / 文案是判断“一次搜索是否失败”的唯一来源，供调用方（如
+# examples.batch_search）复用，避免把失败响应误判为 success。
+SEARCH_ERROR_PREFIX = "搜索过程中出现错误"
+MAX_ITERATIONS_MESSAGE = "抱歉，搜索过程超过了最大迭代次数，请稍后重试。"
+NO_INFO_MESSAGE = "抱歉，我无法获取足够的信息来回答您的问题。"
+
+
+def is_failure_answer(answer: str) -> bool:
+    """判断 search_and_answer 的返回是否为失败兜底（未能正常作答）。"""
+    return (
+        answer.startswith(SEARCH_ERROR_PREFIX)
+        or answer == MAX_ITERATIONS_MESSAGE
+        or answer == NO_INFO_MESSAGE
+    )
+
+
 class WebSearchAgent:
     """
     Web Search Agent - 使用 Kimi API 的内置搜索工具
@@ -280,9 +297,11 @@ class WebSearchAgent:
                     note = "（注意：回答因达到 max_tokens 上限被截断，请增大 max_tokens 后重试。）"
                     final = f"{partial}\n\n{note}" if partial else note
                     self._emit({"iteration": iteration, "type": "answer", "content": final})
+                    # 存入历史时保留截断提示（final），否则 get_conversation_history()
+                    # 会丢失截断语义，后续复用历史时可能把不完整回答当作普通回答。
                     self.conversation_history.append({
                         "role": "assistant",
-                        "content": partial or final
+                        "content": final
                     })
                     return final
                 else:
@@ -303,13 +322,13 @@ class WebSearchAgent:
             # 如果达到最大迭代次数仍未完成
             if iteration >= max_iterations:
                 logger.warning(f"达到最大迭代次数 {max_iterations}")
-                return "抱歉，搜索过程超过了最大迭代次数，请稍后重试。"
-            
-            return "抱歉，我无法获取足够的信息来回答您的问题。"
+                return MAX_ITERATIONS_MESSAGE
+
+            return NO_INFO_MESSAGE
                 
         except Exception as e:
-            logger.error(f"搜索过程中出现错误: {str(e)}")
-            return f"搜索过程中出现错误: {str(e)}"
+            logger.error(f"{SEARCH_ERROR_PREFIX}: {str(e)}")
+            return f"{SEARCH_ERROR_PREFIX}: {str(e)}"
     
     def clear_history(self):
         """清空对话历史"""

--- a/chapter1/web-search-agent/examples.py
+++ b/chapter1/web-search-agent/examples.py
@@ -33,10 +33,14 @@ class AdvancedWebSearchAgent(WebSearchAgent):
             logger.info(f"处理问题 {i}/{len(questions)}: {question}")
             try:
                 answer = self.search_and_answer(question)
+                # search_and_answer 内部已捕获异常并返回错误字符串（见 agent.py），
+                # 因此下面的 except 通常不会触发；据错误前缀判定状态，
+                # 避免把失败的搜索错误地标记为 success。
+                status = "error" if answer.startswith("搜索过程中出现错误") else "success"
                 results.append({
                     "question": question,
                     "answer": answer,
-                    "status": "success"
+                    "status": status
                 })
             except Exception as e:
                 results.append({
@@ -99,15 +103,22 @@ class AdvancedWebSearchAgent(WebSearchAgent):
 请验证以下陈述的真实性：
 "{statement}"
 
-请提供：
-1. 这个陈述是否准确（真/假/部分真实）
-2. 相关的事实和证据
-3. 信息来源
+请严格按以下格式作答：
+- 第一行只输出判定结论，三选一：真 / 假 / 部分真实
+- 之后另起一行给出相关事实、证据与信息来源
 """
         answer = self.search_and_answer(question)
-        
-        # 简单解析结果
-        is_true = "真" in answer[:100]
+
+        # 解析判定：模型被要求首行只输出“真/假/部分真实”。
+        # 按“部分真实 -> 假 -> 真”的优先级匹配，避免“真”字出现在
+        # “部分真实/不真实”里而被误判为真（原实现 `"真" in answer[:100]` 的缺陷）。
+        first_line = next((ln.strip() for ln in answer.splitlines() if ln.strip()), "")
+        if "部分真实" in first_line or "部分正确" in first_line:
+            is_true = False
+        elif any(neg in first_line for neg in ("假", "不真实", "不属实", "不准确", "不正确", "错误")):
+            is_true = False
+        else:
+            is_true = "真" in first_line or "属实" in first_line or "正确" in first_line
         return {
             "statement": statement,
             "is_true": is_true,

--- a/chapter1/web-search-agent/examples.py
+++ b/chapter1/web-search-agent/examples.py
@@ -5,7 +5,7 @@
 import asyncio
 import json
 from typing import List, Dict, Any
-from agent import WebSearchAgent
+from agent import WebSearchAgent, is_failure_answer
 from config import Config
 import logging
 
@@ -34,9 +34,10 @@ class AdvancedWebSearchAgent(WebSearchAgent):
             try:
                 answer = self.search_and_answer(question)
                 # search_and_answer 内部已捕获异常并返回错误字符串（见 agent.py），
-                # 因此下面的 except 通常不会触发；据错误前缀判定状态，
+                # 因此下面的 except 通常不会触发。用统一的 is_failure_answer 判定状态，
+                # 覆盖“出现错误 / 超过最大迭代次数 / 无法获取足够信息”所有失败兜底，
                 # 避免把失败的搜索错误地标记为 success。
-                status = "error" if answer.startswith("搜索过程中出现错误") else "success"
+                status = "error" if is_failure_answer(answer) else "success"
                 results.append({
                     "question": question,
                     "answer": answer,

--- a/chapter1/web-search-agent/tests/test_agent.py
+++ b/chapter1/web-search-agent/tests/test_agent.py
@@ -162,3 +162,28 @@ def test_agent_loop_returns_a_readable_error():
 
     assert answer == "搜索过程中出现错误: provider unavailable"
     assert instance.get_trace() == []
+
+
+def test_agent_loop_marks_truncated_empty_answer(make_choice):
+    """finish_reason=length with empty content must not masquerade as
+    the misleading 'couldn't get enough info' response."""
+    instance = build_agent(make_choice(finish_reason="length", content=""))
+
+    answer = instance.search_and_answer("question")
+
+    assert "无法获取足够" not in answer
+    assert "截断" in answer
+    assert instance.get_trace()[-1]["type"] == "answer"
+
+
+def test_agent_loop_marks_truncated_partial_answer(make_choice):
+    """A partial answer cut off by max_tokens is returned WITH a truncation
+    marker, never presented as a complete answer."""
+    instance = build_agent(
+        make_choice(finish_reason="length", content="部分答案，被截")
+    )
+
+    answer = instance.search_and_answer("question")
+
+    assert answer.startswith("部分答案，被截")
+    assert "截断" in answer

--- a/chapter1/web-search-agent/tests/test_agent.py
+++ b/chapter1/web-search-agent/tests/test_agent.py
@@ -187,3 +187,7 @@ def test_agent_loop_marks_truncated_partial_answer(make_choice):
 
     assert answer.startswith("部分答案，被截")
     assert "截断" in answer
+    # conversation_history retains the truncation marker (stores final, not the
+    # bare partial), so get_conversation_history() doesn't lose the semantics.
+    assert instance.conversation_history[-1]["role"] == "assistant"
+    assert "截断" in instance.conversation_history[-1]["content"]

--- a/chapter1/web-search-agent/tests/test_examples.py
+++ b/chapter1/web-search-agent/tests/test_examples.py
@@ -1,0 +1,43 @@
+"""Unit tests for AdvancedWebSearchAgent helpers and failure classification."""
+
+from unittest.mock import Mock
+
+from agent import (
+    MAX_ITERATIONS_MESSAGE,
+    NO_INFO_MESSAGE,
+    SEARCH_ERROR_PREFIX,
+    is_failure_answer,
+)
+from examples import AdvancedWebSearchAgent
+
+
+def build_advanced(answers):
+    """AdvancedWebSearchAgent without a real OpenAI client; search_and_answer mocked."""
+    instance = AdvancedWebSearchAgent.__new__(AdvancedWebSearchAgent)
+    instance.search_and_answer = Mock(side_effect=answers)
+    instance.clear_history = Mock()
+    return instance
+
+
+def test_is_failure_answer_covers_every_failure_fallback():
+    assert is_failure_answer(f"{SEARCH_ERROR_PREFIX}: boom") is True
+    assert is_failure_answer(MAX_ITERATIONS_MESSAGE) is True
+    assert is_failure_answer(NO_INFO_MESSAGE) is True
+    assert is_failure_answer("北京今天多云。") is False
+
+
+def test_batch_search_marks_all_failure_fallbacks_as_error():
+    """search_and_answer never raises; every failure fallback prefix must map to
+    status='error', not just the '搜索过程中出现错误' one."""
+    answers = [
+        "正常答案",
+        f"{SEARCH_ERROR_PREFIX}: network down",
+        MAX_ITERATIONS_MESSAGE,
+        NO_INFO_MESSAGE,
+    ]
+    instance = build_advanced(answers)
+
+    results = instance.batch_search(["q1", "q2", "q3", "q4"])
+
+    assert [r["status"] for r in results] == ["success", "error", "error", "error"]
+    assert instance.clear_history.call_count == 4


### PR DESCRIPTION
Fixes #341.

Four correctness fixes in `chapter1/web-search-agent/`:

1. **`agent.py` — handle `finish_reason == "length"`.** On max_tokens truncation the loop previously fell through: empty content returned the misleading "无法获取足够的信息" message, and partial content was returned as if complete. Now the partial text (if any) is returned with an explicit truncation notice; the empty case returns the notice instead of a false "no info".
2. **`agent.py` — apply `Config.SEARCH_TIMEOUT`** to the `OpenAI` client (was defined but unused, so a hung backend blocked ~10 min instead of 30 s).
3. **`examples.py` `fact_check()`** — the prompt now asks the model to put the verdict on the first line, and the parser matches `部分真实 → 假 → 真` by priority so 真 inside 不真实/部分真实 no longer flips a false statement to true.
4. **`examples.py` `batch_search()`** — status now reflects the error prefix (`search_and_answer` returns an error string rather than raising, so the old `try/except` was dead).

**Verification**
- `python -m pytest` → 29 passed (added 2 regression tests for the truncation paths; they fail on the unfixed loop).
- `python -m black --check tests` → clean (module files left in their existing style; CI only formats `tests/`).
- Scripted repros confirm: length+empty → truncation notice (not "无法获取"); length+partial → partial + marker; `fact_check` correct for 真/假/部分真实/不真实; `batch_search` error→`status="error"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 搜索回答被截断时，现在会保留已生成的内容并明确提示用户增加回答长度后重试。
  * 批量搜索结果可准确区分成功与错误状态。
  * 优化事实核查判断，减少“部分真实”等结果被误判为完全真实的情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->