### PR TITLE
feat(context): add Zhipu (GLM) as LLM provider for experiment 1-1

### DIFF
--- a/chapter1/context/agent.py
+++ b/chapter1/context/agent.py
@@ -345,12 +345,13 @@ class ContextAwareAgent:
             # V4 Flash: OpenAI-compatible; tool calling + thinking mode.
             # Legacy deepseek-chat / deepseek-reasoner aliases deprecated 2026-07-24.
             "deepseek": (deepseek_base, "deepseek-v4-flash"),
+            "zhipu": ("https://open.bigmodel.cn/api/paas/v4", "glm-5.2"),
             "openrouter": ("https://openrouter.ai/api/v1", "openai/gpt-5.6-luna"),
         }
         if self.provider not in provider_defaults:
             raise ValueError(
                 f"Unsupported provider: {provider}. Use 'siliconflow', 'doubao', "
-                "'kimi', 'moonshot', 'deepseek', or 'openrouter'"
+                "'kimi', 'moonshot', 'deepseek', 'zhipu', or 'openrouter'"
             )
         base_url, default_model = provider_defaults[self.provider]
         resolved_model = model or default_model

--- a/chapter1/context/config.py
+++ b/chapter1/context/config.py
@@ -70,7 +70,7 @@ def resolve_llm_backend(primary_key: str, primary_base_url: str, model: str):
         return openrouter_key, base_url, map_model_to_openrouter(model), True
     raise ValueError(
         "No API key found. Set a provider key "
-        "(SILICONFLOW_API_KEY/ARK_API_KEY/MOONSHOT_API_KEY/DEEPSEEK_API_KEY) or "
+        "(SILICONFLOW_API_KEY/ARK_API_KEY/MOONSHOT_API_KEY/DEEPSEEK_API_KEY/ZHIPU_API_KEY) or "
         "OPENROUTER_API_KEY (universal fallback)."
     )
 
@@ -95,6 +95,9 @@ class Config:
     DEEPSEEK_BASE_URL: str = os.getenv(
         "DEEPSEEK_BASE_URL", "https://api.deepseek.com"
     )
+
+    ZHIPU_API_KEY: str = os.getenv("ZHIPU_API_KEY", "")
+    ZHIPU_BASE_URL: str = "https://open.bigmodel.cn/api/paas/v4"
     
     # Model Configuration (defaults based on provider)
     MODEL_NAME: str = os.getenv("MODEL_NAME", "")  # Will be set based on provider if not specified
@@ -156,6 +159,8 @@ class Config:
             return cls.MOONSHOT_API_KEY
         elif provider == "deepseek":
             return cls.DEEPSEEK_API_KEY
+        elif provider == "zhipu":
+            return cls.ZHIPU_API_KEY
         else:
             return ""
     
@@ -186,6 +191,8 @@ class Config:
             # V4 Flash: tool calling + thinking mode (legacy deepseek-chat /
             # deepseek-reasoner aliases are deprecated 2026-07-24).
             return "deepseek-v4-flash"
+        elif provider == "zhipu":
+            return "glm-5.2"
         else:
             return ""
     
@@ -212,6 +219,8 @@ class Config:
                 print("ERROR: MOONSHOT_API_KEY is not set")
             elif provider == "deepseek":
                 print("ERROR: DEEPSEEK_API_KEY is not set")
+            elif provider == "zhipu":
+                print("ERROR: ZHIPU_API_KEY is not set")
             else:
                 print(f"ERROR: No API key configured for provider: {provider}")
             

--- a/chapter1/context/env.example
+++ b/chapter1/context/env.example
@@ -8,6 +8,7 @@ MOONSHOT_API_KEY=your_moonshot_api_key_here
 DEEPSEEK_API_KEY=your_deepseek_api_key_here
 # Optional: override DeepSeek base URL (default: https://api.deepseek.com)
 # DEEPSEEK_BASE_URL=https://api.deepseek.com
+ZHIPU_API_KEY=your_zhipu_api_key_here
 
 # Universal fallback: if the provider key above is missing/invalid but
 # OPENROUTER_API_KEY is set, requests are routed through OpenRouter and the

--- a/chapter1/context/env.example
+++ b/chapter1/context/env.example
@@ -1,4 +1,4 @@
-# LLM Provider Configuration (siliconflow, doubao, kimi, moonshot, or deepseek)
+# LLM Provider Configuration (siliconflow, doubao, kimi, moonshot, deepseek, or zhipu)
 LLM_PROVIDER=doubao
 
 # API Keys (set the appropriate one for your provider)

--- a/chapter1/context/main.py
+++ b/chapter1/context/main.py
@@ -795,7 +795,7 @@ def interactive_mode(api_key: str, provider: str = "siliconflow", model: str = N
     current_api_key = api_key
     
     # Available providers
-    available_providers = ["siliconflow", "doubao", "kimi", "moonshot", "deepseek"]
+    available_providers = ["siliconflow", "doubao", "kimi", "moonshot", "deepseek", "zhipu"]
     
     print("\n" + "="*60)
     print("INTERACTIVE MODE - Context-Aware Agent")
@@ -1087,7 +1087,7 @@ def main():
     )
     parser.add_argument(
         "--provider",
-        choices=["siliconflow", "doubao", "kimi", "moonshot", "deepseek", "openrouter"],
+        choices=["siliconflow", "doubao", "kimi", "moonshot", "deepseek", "zhipu", "openrouter"],
         default="doubao",
         help="LLM 提供商（默认：doubao；openrouter 或缺失主 key 时经 OpenRouter 兜底）"
     )
@@ -1122,6 +1122,8 @@ def main():
         api_key = os.getenv("MOONSHOT_API_KEY")
     elif args.provider == "deepseek":
         api_key = os.getenv("DEEPSEEK_API_KEY")
+    elif args.provider == "zhipu":
+        api_key = os.getenv("ZHIPU_API_KEY")
     else:
         logger.error(f"Unknown provider: {args.provider}")
         sys.exit(1)

--- a/chapter1/context/main.py
+++ b/chapter1/context/main.py
@@ -922,6 +922,8 @@ def interactive_mode(api_key: str, provider: str = "siliconflow", model: str = N
                         print(f"  - {p}: Moonshot Kimi K3 model{status}")
                     elif p == "deepseek":
                         print(f"  - deepseek: DeepSeek V4 model{status}")
+                    elif p == "zhipu":
+                        print(f"  - zhipu: Zhipu GLM model{status}")
             
             elif user_input.lower().startswith('provider '):
                 new_provider = user_input[9:].strip().lower()
@@ -946,6 +948,11 @@ def interactive_mode(api_key: str, provider: str = "siliconflow", model: str = N
                         new_api_key = os.getenv("DEEPSEEK_API_KEY")
                         if not new_api_key:
                             print("❌ DEEPSEEK_API_KEY not set in environment")
+                            continue
+                    elif new_provider == "zhipu":
+                        new_api_key = os.getenv("ZHIPU_API_KEY")
+                        if not new_api_key:
+                            print("❌ ZHIPU_API_KEY not set in environment")
                             continue
                     
                     # Update current settings
@@ -1008,6 +1015,9 @@ def interactive_mode(api_key: str, provider: str = "siliconflow", model: str = N
                 elif current_provider == "deepseek":
                     key_status = "✅ Set" if os.getenv("DEEPSEEK_API_KEY") else "❌ Not set"
                     print(f"  API Key (DEEPSEEK_API_KEY): {key_status}")
+                elif current_provider == "zhipu":
+                    key_status = "✅ Set" if os.getenv("ZHIPU_API_KEY") else "❌  Not set"
+                    print(f"  API Key (ZHIPU_API_KEY): {key_status}")
             
             elif user_input:
                 # Execute task
@@ -1099,7 +1109,7 @@ def main():
     parser.add_argument(
         "--api-key",
         type=str,
-        help="LLM 提供商的 API Key（也可通过环境变量 SILICONFLOW_API_KEY/ARK_API_KEY/MOONSHOT_API_KEY/DEEPSEEK_API_KEY 设置）"
+        help="LLM 提供商的 API Key（也可通过环境变量 SILICONFLOW_API_KEY/ARK_API_KEY/MOONSHOT_API_KEY/DEEPSEEK_API_KEY/ZHIPU_API_KEY 设置）"
     )
     parser.add_argument(
         "--output",
@@ -1140,7 +1150,7 @@ def main():
         else:
             logger.error(
                 "No API key found. Set the provider key "
-                "(ARK_API_KEY/SILICONFLOW_API_KEY/MOONSHOT_API_KEY/DEEPSEEK_API_KEY) or "
+                "(ARK_API_KEY/SILICONFLOW_API_KEY/MOONSHOT_API_KEY/DEEPSEEK_API_KEY/ZHIPU_API_KEY) or "
                 "OPENROUTER_API_KEY (universal fallback)."
             )
             sys.exit(1)

--- a/chapter1/context/main.py
+++ b/chapter1/context/main.py
@@ -1109,7 +1109,7 @@ def main():
     parser.add_argument(
         "--api-key",
         type=str,
-        help="LLM 提供商的 API Key（也可通过环境变量 SILICONFLOW_API_KEY/ARK_API_KEY/MOONSHOT_API_KEY/DEEPSEEK_API_KEY/ZHIPU_API_KEY 设置）"
+        help="LLM 提供商的 API Key（也可通过环境变量 SILICONFLOW_API_KEY/ARK_API_KEY/MOONSHOT_API_KEY/DEEPSEEK_API_KEY/ZHIPU_API_KEY 设置；缺失主 key 时可用 OPENROUTER_API_KEY 兜底）"
     )
     parser.add_argument(
         "--output",


### PR DESCRIPTION
## 背景

README 推荐了智谱 GLM 作为 API 平台之一，但 experiment 1-1（`chapter1/context/`）没有原生支持 Zhipu provider，只能通过 OpenRouter 兜底。

## 改动

在 `chapter1/context/` 的消融实验中添加 Zhipu (GLM) 作为一等 provider，与其他 provider（SiliconFlow、Doubao、Kimi、DeepSeek）保持一致的接入方式：

- `config.py` — 添加 `ZHIPU_API_KEY` / `ZHIPU_BASE_URL`，以及 `get_api_key` / `get_default_model` / `validate` 的 zhipu 分支
- `agent.py` — `provider_defaults` 添加 zhipu 条目，更新不支持 provider 的报错信息
- `main.py` — argparse `--provider` choices 和 provider key 获取逻辑添加 zhipu
- `env.example` — 添加 `ZHIPU_API_KEY` 占位

## 使用方式

```bash
export ZHIPU_API_KEY=your_key
python main.py --provider zhipu --mode interactive
python main.py --provider zhipu --model glm-4.7-flash --mode ablation
```

默认模型为 `glm-5.2`，可通过 `--model` 覆盖。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增智谱（Zhipu）LLM 提供商支持，可通过 `ZHIPU_API_KEY` 启用，并可选择 `zhipu` 作为交互式与命令行的提供商。
  * 智谱默认模型切换为 `glm-5.2`，支持通过 `ZHIPU_BASE_URL` 指定服务地址。
* **配置**
  * 更新环境变量示例，新增 `ZHIPU_API_KEY=your_zhipu_api_key_here`。
  * 在未设置 `ZHIPU_API_KEY` 时给出明确错误提示；主配置缺失时仍保留原有 OpenRouter 兜底逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->