### PR TITLE
fix(perception-tools): don't crash image metadata on ICC/EXIF bytes; release VideoCapture on error

### DIFF
--- a/chapter4/perception-tools/src/media_processing_tools.py
+++ b/chapter4/perception-tools/src/media_processing_tools.py
@@ -506,6 +506,7 @@ async def analyze_video_ai(
     Returns:
         TextContent with AI analysis
     """
+    video = None
     try:
         path = validate_file_path(video_path)
 
@@ -566,9 +567,7 @@ async def analyze_video_ai(
                 frames_analyzed += 1
             
             frame_num += 1
-        
-        video.release()
-        
+
         # Generate overall summary
         combined_analyses = "\n\n".join([f"Frame {i+1} (t={a['timestamp']}s): {a['analysis']}" 
                                           for i, a in enumerate(frame_analyses)])
@@ -602,11 +601,17 @@ async def analyze_video_ai(
             message=error_msg,
             metadata={"error_type": "video_analysis_error"}
         )
-        
+
         return TextContent(
             type="text",
             text=json.dumps(action_response.model_dump())
         )
+    finally:
+        # Release the native decoder/file handle even when a per-frame Vision
+        # API call raises mid-loop (the most likely failure point), otherwise
+        # the VideoCapture leaks until GC finalizes it.
+        if video is not None:
+            video.release()
 
 
 async def trim_audio(
@@ -737,7 +742,16 @@ async def get_image_metadata(
         
         # Image info
         if hasattr(img, 'info'):
-            metadata["info"] = dict(img.info)
+            # PIL's img.info routinely carries non-JSON-serializable values --
+            # most notably the raw ICC color profile / EXIF blob as `bytes`
+            # (present in almost every real photo, screenshot or design export).
+            # Copying them verbatim would make the final json.dumps() raise
+            # TypeError, turning a valid image into a failure response. Summarize
+            # bytes as a size marker so metadata extraction still succeeds.
+            metadata["info"] = {
+                k: (f"<{len(v)} bytes>" if isinstance(v, (bytes, bytearray)) else v)
+                for k, v in img.info.items()
+            }
         
         result = {
             "metadata": metadata,

--- a/chapter4/perception-tools/test_analyze_video_release_on_error.py
+++ b/chapter4/perception-tools/test_analyze_video_release_on_error.py
@@ -10,29 +10,41 @@ import json
 import os
 import sys
 import types
+from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+import cv2
+import numpy as np
+import pytest
 
-# Optional runtime deps for importing the chapter module in unit tests.
-sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
-mcp = types.ModuleType("mcp")
-mcp_types = types.ModuleType("mcp.types")
+SRC = os.path.join(os.path.dirname(__file__), "src")
 
 
-class TextContent:
+class _TextContent:
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
 
 
-mcp_types.TextContent = TextContent
-sys.modules["mcp"] = mcp
-sys.modules["mcp.types"] = mcp_types
+@pytest.fixture
+def media_processing_tools(monkeypatch):
+    """Import the chapter module with its optional runtime deps stubbed only for
+    the duration of the test. monkeypatch restores sys.modules / sys.path
+    afterwards, so we never permanently overwrite a real `mcp` / `dotenv` (or
+    leave a partial stub in the global cache for other tests to pick up)."""
+    monkeypatch.syspath_prepend(SRC)
+    monkeypatch.setitem(
+        sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda: None)
+    )
+    mcp = types.ModuleType("mcp")
+    mcp_types = types.ModuleType("mcp.types")
+    mcp_types.TextContent = _TextContent
+    monkeypatch.setitem(sys.modules, "mcp", mcp)
+    monkeypatch.setitem(sys.modules, "mcp.types", mcp_types)
+    # Force a fresh import under the stubs even if another test already imported
+    # the module; monkeypatch restores the original entry on teardown.
+    monkeypatch.delitem(sys.modules, "media_processing_tools", raising=False)
+    import media_processing_tools
 
-import cv2
-import numpy as np
-
-import media_processing_tools
-from media_processing_tools import analyze_video_ai
+    return media_processing_tools
 
 
 class _FakeCapture:
@@ -64,9 +76,12 @@ class _FakeCapture:
         self.released = True
 
 
-def test_analyze_video_ai_releases_capture_when_vision_call_raises(monkeypatch):
+def test_analyze_video_ai_releases_capture_when_vision_call_raises(
+    media_processing_tools, monkeypatch
+):
+    mpt = media_processing_tools
     fake = _FakeCapture()
-    monkeypatch.setattr(media_processing_tools.cv2, "VideoCapture", lambda _path: fake)
+    monkeypatch.setattr(mpt.cv2, "VideoCapture", lambda _path: fake)
 
     def _boom(**kwargs):
         raise RuntimeError("vision backend unavailable")
@@ -74,16 +89,12 @@ def test_analyze_video_ai_releases_capture_when_vision_call_raises(monkeypatch):
     client = types.SimpleNamespace(
         chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=_boom))
     )
-    monkeypatch.setattr(
-        media_processing_tools, "_make_vision_client", lambda: (client, "fake-model")
-    )
+    monkeypatch.setattr(mpt, "_make_vision_client", lambda: (client, "fake-model"))
     # validate_file_path would reject a non-existent path before we reach the
     # capture; stub it to pass the path through unchanged.
-    from pathlib import Path
+    monkeypatch.setattr(mpt, "validate_file_path", lambda p: Path(p))
 
-    monkeypatch.setattr(media_processing_tools, "validate_file_path", lambda p: Path(p))
-
-    result = asyncio.run(analyze_video_ai("some_clip.mp4", num_frames=2))
+    result = asyncio.run(mpt.analyze_video_ai("some_clip.mp4", num_frames=2))
     payload = json.loads(result.text)
 
     assert payload["success"] is False

--- a/chapter4/perception-tools/test_analyze_video_release_on_error.py
+++ b/chapter4/perception-tools/test_analyze_video_release_on_error.py
@@ -1,0 +1,90 @@
+"""Regression test: analyze_video_ai must release the VideoCapture even when a
+per-frame Vision API call raises mid-loop.
+
+The capture was previously released only on the success path, so a failing
+Vision call (network / rate-limit / auth) leaked the native decoder/file handle
+until GC. Release now happens in a finally.
+"""
+import asyncio
+import json
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
+# Optional runtime deps for importing the chapter module in unit tests.
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+mcp = types.ModuleType("mcp")
+mcp_types = types.ModuleType("mcp.types")
+
+
+class TextContent:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+mcp_types.TextContent = TextContent
+sys.modules["mcp"] = mcp
+sys.modules["mcp.types"] = mcp_types
+
+import cv2
+import numpy as np
+
+import media_processing_tools
+from media_processing_tools import analyze_video_ai
+
+
+class _FakeCapture:
+    """Minimal VideoCapture stand-in that yields a few frames and records
+    whether release() was called."""
+
+    def __init__(self):
+        self.released = False
+        self._frames = 3
+        self._i = 0
+
+    def get(self, prop):
+        if prop == cv2.CAP_PROP_FPS:
+            return 10.0
+        if prop == cv2.CAP_PROP_FRAME_COUNT:
+            return float(self._frames)
+        return 0.0
+
+    def isOpened(self):
+        return True
+
+    def read(self):
+        if self._i < self._frames:
+            self._i += 1
+            return True, np.zeros((48, 64, 3), dtype=np.uint8)
+        return False, None
+
+    def release(self):
+        self.released = True
+
+
+def test_analyze_video_ai_releases_capture_when_vision_call_raises(monkeypatch):
+    fake = _FakeCapture()
+    monkeypatch.setattr(media_processing_tools.cv2, "VideoCapture", lambda _path: fake)
+
+    def _boom(**kwargs):
+        raise RuntimeError("vision backend unavailable")
+
+    client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=_boom))
+    )
+    monkeypatch.setattr(
+        media_processing_tools, "_make_vision_client", lambda: (client, "fake-model")
+    )
+    # validate_file_path would reject a non-existent path before we reach the
+    # capture; stub it to pass the path through unchanged.
+    from pathlib import Path
+
+    monkeypatch.setattr(media_processing_tools, "validate_file_path", lambda p: Path(p))
+
+    result = asyncio.run(analyze_video_ai("some_clip.mp4", num_frames=2))
+    payload = json.loads(result.text)
+
+    assert payload["success"] is False
+    assert fake.released is True


### PR DESCRIPTION
Fixes #344.

Two fixes in `media_processing_tools.py`:

1. **`get_image_metadata`** — `img.info` bytes values (icc_profile / exif) made the final `json.dumps(model_dump())` raise `TypeError`, which the `except` turned into a **failure** response for any image carrying a color profile (nearly all real photos/screenshots). Bytes are now summarized as `"<N bytes>"` so extraction succeeds. Repro: a PNG saved with `icc_profile=b'...'` returned `success=false` before, `success=true` after (with `info.icc_profile = "<N bytes>"`).
2. **`analyze_video_ai`** — the `VideoCapture` was released only on success; a per-frame Vision API call raising mid-loop leaked the native handle. Release now happens in a `finally`.

**Verification:** `py_compile` clean; scripted repro confirms the old `dict(img.info)` path raises `TypeError` on an ICC-profile PNG while the new comprehension serializes and yields `success=true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **错误修复**
  - 修复视频分析在逐帧过程中途出错时底层视频资源未正确释放的问题，提升稳定性并降低资源泄漏风险。
  - 修复图片元数据在包含不可序列化的二进制内容时可能导致元数据提取失败的问题。
- **测试**
  - 新增回归测试：验证逐帧调用异常时也能正确释放视频句柄，并确保返回结果符合预期。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->