### PR TITLE
fix(attention-viz): label heatmap rows with the output token, not an input token

### DIFF
--- a/chapter2/attention_visualization/frontend/components/AttentionModal.tsx
+++ b/chapter2/attention_visualization/frontend/components/AttentionModal.tsx
@@ -17,6 +17,14 @@ export default function AttentionModal({ isOpen, onClose, tokens, attentionWeigh
   const [zoomLevel, setZoomLevel] = useState(1);
   const [transformMethod, setTransformMethod] = useState<'none' | 'log' | 'log10' | 'sqrt' | 'power' | 'power-extreme' | 'exclude-sink'>('log10');
 
+  // The attention matrix has one row per OUTPUT token, while `tokens` is the
+  // full input+output sequence. So matrix row i corresponds to
+  // tokens[rowTokenOffset + i], where rowTokenOffset is the context (input)
+  // length. Labeling row i with tokens[i] would show an input token where the
+  // attending output token belongs. Degrades to 0 if tokens is already
+  // output-only.
+  const rowTokenOffset = Math.max(0, tokens.length - Math.min(tokens.length, attentionWeights.length));
+
   // Zoom controls
   const handleZoomIn = useCallback(() => {
     setZoomLevel(prev => Math.min(prev * 1.2, 10));
@@ -220,7 +228,8 @@ export default function AttentionModal({ isOpen, onClose, tokens, attentionWeigh
               if (i < numRows) {
                 ctx.save();
                 ctx.textAlign = 'right';
-                const rowLabel = tokens[i].length > 15 ? tokens[i].substring(0, 15) + '...' : tokens[i];
+                const rowTok = tokens[rowTokenOffset + i] ?? '';
+                const rowLabel = rowTok.length > 15 ? rowTok.substring(0, 15) + '...' : rowTok;
                 ctx.fillText(rowLabel, margin.left - 5, margin.top + i * cellSize + cellSize / 2);
                 ctx.restore();
               }
@@ -459,7 +468,7 @@ export default function AttentionModal({ isOpen, onClose, tokens, attentionWeigh
             }}
           >
             <div>Weight: {hoveredCell.value.toFixed(4)}</div>
-            <div>From [{hoveredCell.row}]: {tokens[hoveredCell.row]?.substring(0, 20)}</div>
+            <div>From [{hoveredCell.row}]: {tokens[rowTokenOffset + hoveredCell.row]?.substring(0, 20)}</div>
             <div>To [{hoveredCell.col}]: {tokens[hoveredCell.col]?.substring(0, 20)}</div>
           </div>
         )}

--- a/chapter2/attention_visualization/frontend/components/AttentionStats.tsx
+++ b/chapter2/attention_visualization/frontend/components/AttentionStats.tsx
@@ -43,8 +43,13 @@ export default function AttentionStats({ attentionData }: AttentionStatsProps) {
 
   const stats = calculateStats();
   
-  // Prepare data for chart
-  const chartData = attentionData.tokens.slice(0, stats.avgAttention.length).map((token, idx) => ({
+  // Prepare data for chart.
+  // avgAttention has one entry per matrix row (one per OUTPUT token), while
+  // attentionData.tokens is the full input+output sequence. Offset into the
+  // output-token slice so each stat lines up with the token it describes,
+  // instead of pairing output stats with the first (input) tokens.
+  const rowTokenOffset = Math.max(0, attentionData.tokens.length - stats.avgAttention.length);
+  const chartData = attentionData.tokens.slice(rowTokenOffset, rowTokenOffset + stats.avgAttention.length).map((token, idx) => ({
     position: idx,
     token: token.length > 10 ? token.substring(0, 10) + '...' : token,
     avgAttention: stats.avgAttention[idx]?.toFixed(4) || 0,
@@ -55,7 +60,7 @@ export default function AttentionStats({ attentionData }: AttentionStatsProps) {
   // Calculate global statistics
   const globalStats = {
     avgAttention: stats.avgAttention.reduce((a, b) => a + b, 0) / stats.avgAttention.length || 0,
-    maxAttention: Math.max(...stats.maxAttention) || 0,
+    maxAttention: stats.maxAttention.length ? Math.max(...stats.maxAttention) : 0,
     avgEntropy: stats.entropy.reduce((a, b) => a + b, 0) / stats.entropy.length || 0,
   };
 


### PR DESCRIPTION
Fixes #346.

The attention matrix has one row per OUTPUT token (`main.py` pairs row `i` with `output_tokens[i]`), but `attentionData.tokens` is the full input+output sequence, and the frontend labeled row `i` with `tokens[i]` (an input/context token). Every row label, hover "From:" value, and stats-chart token was off by the context length (560 in the sample trajectory).

Row `i` now maps to `tokens[rowTokenOffset + i]`, where `rowTokenOffset = tokens.length - numRows` (the context length; degrades to 0 if tokens is already output-only). Fixed in:
- `AttentionModal.tsx` — row axis labels and the hover "From" tooltip (the "To" column labels were already correct — columns ARE the attended context tokens).
- `AttentionStats.tsx` — the per-output-token line-chart data; also guarded "Max Attention" against `-Infinity` on an empty matrix.

Cell values, colors, and the column axis are unchanged. Verified the offset against the shipped sample dims (850 tokens, 290 rows → offset 560 = context length; row 0 → first output token, last row → last token).