### PR TITLE
fix(live-audio): stop the mic when the WebSocket closes unexpectedly (zombie recording)

### DIFF
--- a/chapter9/live-audio/frontend/pages/index.tsx
+++ b/chapter9/live-audio/frontend/pages/index.tsx
@@ -316,6 +316,14 @@ export default function Home() {
     websocketRef.current.onclose = () => {
       addLog('WebSocket closed');
       websocketRef.current = null;
+      // A server restart or network blip fires onclose mid-session. Without
+      // tearing down, the button stays "Stop Recording", the mic keeps
+      // capturing, the ping interval keeps firing, and the audio worklet
+      // silently discards every captured buffer (it checks
+      // websocketRef.current?.readyState, now null) -- a "zombie recording".
+      // websocketRef is already null here, so stopRecording won't re-close the
+      // socket or re-enter onclose.
+      stopRecording();
     };
 
     websocketRef.current.onerror = (error) => {
@@ -463,7 +471,12 @@ export default function Home() {
       streamRef.current.getTracks().forEach(track => track.stop());
     }
     if (audioContextRef.current) {
-      audioContextRef.current.close();
+      // Guard against closing an already-closed context (stopRecording is now
+      // idempotent because onclose also calls it).
+      if (audioContextRef.current.state !== 'closed') {
+        audioContextRef.current.close();
+      }
+      audioContextRef.current = null;
     }
     if (websocketRef.current) {
       websocketRef.current.close();
@@ -544,6 +557,15 @@ export default function Home() {
   useEffect(() => {
     scrollLogsToBottom();
   }, [logs]);
+
+  // Tear down the mic stream, AudioContext, WebSocket and ping interval if the
+  // component unmounts mid-recording (client-side nav / fast refresh), instead
+  // of leaving the microphone active and the ping interval firing.
+  useEffect(() => {
+    return () => {
+      stopRecording();
+    };
+  }, []);
 
 
 


### PR DESCRIPTION
Fixes #348.

WebSocket `onclose` only nulled the ref, so a server restart / network blip left the mic capturing, the ping interval firing, the button stuck on "Stop Recording", and captured audio silently dropped (the worklet gates on `websocketRef.current?.readyState`, now null).

`onclose` now calls `stopRecording()` to return to a clean state. To make that safe:
- `stopRecording()` is idempotent — it guards `AudioContext.close()` with a `state !== 'closed'` check and nulls the ref, so the double invocation from a normal Stop (which closes the socket → fires onclose → stopRecording again) is a no-op.
- Added an unmount effect calling `stopRecording()` so navigating away mid-recording no longer leaks the mic stream and ping interval.

`websocketRef` is already null inside `onclose` when `stopRecording` runs, so it won't re-close the socket or re-enter onclose.