### PR TITLE
test(self-evol-eval): drop tautological int(None) test, declare pytest dep

### DIFF
--- a/chapter8/self-evolution-eval/requirements.txt
+++ b/chapter8/self-evolution-eval/requirements.txt
@@ -3,3 +3,4 @@
 # （youtube-transcript-api、yfinance 等）只是"参考方案"，被测 Agent 才会去安装，评估器不需要。
 openai>=1.30.0
 python-dotenv>=1.0.0
+pytest>=8.0.0

--- a/chapter8/self-evolution-eval/test_null_rubric_dimension.py
+++ b/chapter8/self-evolution-eval/test_null_rubric_dimension.py
@@ -22,10 +22,3 @@ def test_missing_dimension_still_zero():
 def test_empty_string_score_rejected():
     with pytest.raises(ValueError):
         _rubric_dimension_total({"error_handling": ""})
-
-
-def test_pristine_int_none_raises():
-    """Old pattern int(rubric.get(d, 0)) still blows up on explicit null."""
-    rubric = {"error_handling": None}
-    with pytest.raises(TypeError):
-        int(rubric.get("error_handling", 0))


### PR DESCRIPTION
## Summary

- Drop the tautological `int(None)` test in `test_null_rubric_dimension.py` (7 lines removed)
- Declare `pytest` in `chapter8/self-evolution-eval/requirements.txt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 更新了评分维度异常值的校验覆盖。
  * 明确空字符串评分会被拒绝并触发错误。
  * 继续覆盖空值按 0 计分及缺失维度的处理场景。

* **依赖**
  * 新增 pytest 测试框架依赖，支持运行自动化测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->