### PR TITLE
fix(pdf): tolerate trailing commas in parse_page_range

### DIFF
--- a/chapter4/perception-tools/src/document_processing_tools.py
+++ b/chapter4/perception-tools/src/document_processing_tools.py
@@ -323,8 +323,15 @@ def parse_page_range(page_range: str, total_pages: int) -> list[int]:
     
     for part in page_range.split(","):
         part = part.strip()
+        if not part:
+            # Trailing/duplicate commas (e.g. "1,3," or "1,,3") are common in
+            # LLM tool args; skip empty segments instead of int("").
+            continue
         if "-" in part:
-            start, end = map(int, part.split("-"))
+            bounds = part.split("-")
+            if len(bounds) != 2 or not bounds[0] or not bounds[1]:
+                raise ValueError(f"Invalid page range segment: {part!r}")
+            start, end = int(bounds[0]), int(bounds[1])
             # Clamp both ends: the caller's guard is `page_num < total_pages`,
             # which a negative index passes, and reader.pages[-1] is the LAST
             # page -- so an unclamped start silently returns the wrong page.

--- a/chapter4/perception-tools/test_parse_page_range_trailing_comma.py
+++ b/chapter4/perception-tools/test_parse_page_range_trailing_comma.py
@@ -1,0 +1,33 @@
+"""Trailing commas in page_range must not crash parse_page_range."""
+import importlib.util
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent / "src" / "document_processing_tools.py"
+_spec = importlib.util.spec_from_file_location("document_processing_tools_page_range", _SRC)
+_mod = importlib.util.module_from_spec(_spec)
+# Load only parse_page_range without heavy optional deps (PyPDF2, etc.).
+source = _SRC.read_text(encoding="utf-8")
+start = source.index("def parse_page_range")
+ns = {}
+exec(compile(source[start:], str(_SRC), "exec"), ns)
+parse_page_range = ns["parse_page_range"]
+
+
+def test_trailing_comma_does_not_raise():
+    assert parse_page_range("1,3,", 10) == [0, 2]
+
+
+def test_duplicate_comma_does_not_raise():
+    assert parse_page_range("1,,3", 10) == [0, 2]
+
+
+def test_leading_comma_does_not_raise():
+    assert parse_page_range(",1,5", 10) == [0, 4]
+
+
+def test_normal_list_unchanged():
+    assert parse_page_range("1,3,5", 10) == [0, 2, 4]
+
+
+def test_range_with_trailing_comma():
+    assert parse_page_range("1-3,", 10) == [0, 1, 2]


### PR DESCRIPTION
`parse_page_range("1,3,")` raised `ValueError` on the empty trailing segment.

Skip empty comma-separated pieces.