### PR TITLE
fix(context): honor tail_lines=0 in truncate_and_persist

### DIFF
--- a/chapter4/execution-tools/execution_tools.py
+++ b/chapter4/execution-tools/execution_tools.py
@@ -50,13 +50,20 @@ def truncate_and_persist(
     with os.fdopen(fd, "w", encoding="utf-8") as f:
         f.write(text)
 
-    head_part = lines[:head_lines]
-    tail_part = lines[-tail_lines:]
-    omitted = max(len(lines) - head_lines - tail_lines, 0)
+    # lines[-0:] is the whole list in Python; treat 0 as "keep no tail".
+    head_n = max(0, head_lines)
+    tail_n = max(0, tail_lines)
+    head_part = lines[:head_n] if head_n else []
+    tail_part = lines[-tail_n:] if tail_n else []
+    omitted = max(len(lines) - head_n - tail_n, 0)
 
-    middle = f"... [省略 {omitted} 行，完整输出已保存至 {path}] ..."
     guide = f"[如需完整输出，请使用 read_file 工具读取 {path}]"
-    truncated = "\n".join(head_part + [middle] + tail_part + [guide])
+    if omitted == 0:
+        # Head+tail cover the file; do not concatenate overlapping slices.
+        truncated = "\n".join(lines + [guide])
+    else:
+        middle = f"... [省略 {omitted} 行，完整输出已保存至 {path}] ..."
+        truncated = "\n".join(head_part + [middle] + tail_part + [guide])
     return truncated, path
 
 

--- a/chapter4/execution-tools/test_truncate_tail_lines_zero.py
+++ b/chapter4/execution-tools/test_truncate_tail_lines_zero.py
@@ -1,0 +1,36 @@
+"""tail_lines=0 must keep no tail lines (Python lines[-0:] quirk)."""
+from execution_tools import truncate_and_persist
+
+
+def test_tail_lines_zero_keeps_only_head():
+    text = "\n".join(f"line{i}" for i in range(100))
+    out, path = truncate_and_persist(
+        text, head_lines=3, tail_lines=0, max_lines=10, max_chars=50
+    )
+    assert path is not None
+    assert "line0" in out and "line1" in out and "line2" in out
+    assert "line99" not in out
+    assert "line50" not in out
+    assert out.count("line0") == 1
+
+
+def test_tail_lines_positive_still_keeps_tail():
+    text = "\n".join(f"line{i}" for i in range(100))
+    out, path = truncate_and_persist(
+        text, head_lines=2, tail_lines=2, max_lines=10, max_chars=50
+    )
+    assert path is not None
+    assert "line0" in out and "line1" in out
+    assert "line98" in out and "line99" in out
+    assert "line50" not in out
+
+
+def test_short_file_char_overflow_does_not_duplicate_lines():
+    text = ("x" * 4000 + "\n") * 3
+    out, path = truncate_and_persist(
+        text, head_lines=50, tail_lines=50, max_lines=200, max_chars=100
+    )
+    assert path is not None
+    # Three content lines plus the guide line — no head/tail duplication.
+    content_lines = [ln for ln in out.split("\n") if ln.startswith("x")]
+    assert len(content_lines) == 3


### PR DESCRIPTION
`tail_lines=0` kept every line because `lines[-0:]` is the full list.

Treat 0 as keep-none.