### PR TITLE
fix(cron): treat max_occurrences=0 as zero runs

### DIFF
--- a/chapter4/collaboration-tools/src/timer_tools.py
+++ b/chapter4/collaboration-tools/src/timer_tools.py
@@ -345,6 +345,12 @@ async def _run_recurring_timer(
             return
 
         occurrence = timer_data.get("occurrences", 0)
+
+        # max_occurrences=0 means "never fire" (None means infinite).
+        if max_occurrences is not None and occurrence >= max_occurrences:
+            timer_data["status"] = "completed"
+            await _save_timers()
+            return
         
         while True:
             await asyncio.sleep(interval_seconds)
@@ -362,7 +368,8 @@ async def _run_recurring_timer(
             await _trigger_timer_callback(timer_data)
 
             # Persist the terminal state, not an active record at the limit.
-            if max_occurrences and occurrence >= max_occurrences:
+            # Use `is not None`: max_occurrences=0 means "never fire", not infinite.
+            if max_occurrences is not None and occurrence >= max_occurrences:
                 timer_data["status"] = "completed"
                 logger.info(f"Recurring timer {timer_id} completed after {occurrence} occurrences")
 
@@ -421,7 +428,7 @@ async def _load_timers():
 
                     max_occurrences = timer_data.get("max_occurrences")
                     occurrences = timer_data.get("occurrences", 0)
-                    if max_occurrences and occurrences >= max_occurrences:
+                    if max_occurrences is not None and occurrences >= max_occurrences:
                         # Older versions persisted the final occurrence before
                         # changing the in-memory status to completed.
                         timer_data["status"] = "completed"

--- a/chapter4/collaboration-tools/test_recurring_max_occurrences_zero.py
+++ b/chapter4/collaboration-tools/test_recurring_max_occurrences_zero.py
@@ -1,0 +1,47 @@
+"""max_occurrences=0 must stop the recurring timer (not run forever)."""
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
+
+import timer_tools as tt
+
+
+async def _run():
+    # Clear any leftover timers from other tests in this process.
+    tt._active_timers.clear()
+    for task in list(tt._timer_tasks.values()):
+        task.cancel()
+    tt._timer_tasks.clear()
+
+    result = await tt.set_recurring_timer(
+        interval_seconds=0.02,
+        max_occurrences=0,
+        timer_name="zero-max",
+    )
+    assert result["success"] is True
+    timer_id = result["timer_id"]
+
+    await asyncio.sleep(0.12)
+
+    status = await tt.get_timer_status(timer_id)
+    assert status["success"] is True
+    timer = status["timer"]
+    assert timer["status"] == "completed"
+    assert timer["occurrences"] == 0
+
+    # Positive max_occurrences still stops at the limit.
+    result2 = await tt.set_recurring_timer(
+        interval_seconds=0.02,
+        max_occurrences=2,
+        timer_name="two-max",
+    )
+    await asyncio.sleep(0.15)
+    status2 = await tt.get_timer_status(result2["timer_id"])
+    assert status2["timer"]["status"] == "completed"
+    assert status2["timer"]["occurrences"] == 2
+
+
+def test_max_occurrences_zero_completes_without_spinning():
+    asyncio.run(_run())


### PR DESCRIPTION
`max_occurrences=0` was treated as unlimited because of a truthiness check.

Honor 0 as no runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 修正循环定时器对 `max_occurrences=0` 的处理，确保定时器不会触发或无限运行。
  * 定时器达到最大触发次数后会正确标记为“已完成”，包括重启恢复后的状态判断。

* **测试**
  * 新增验证用例，覆盖零次触发及达到指定次数后正常完成的场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->