### PR TITLE
fix(sanitize): redact Authorization Basic credentials

### DIFF
--- a/chapter2/log-sanitization/regex_sanitizer.py
+++ b/chapter2/log-sanitization/regex_sanitizer.py
@@ -9,7 +9,7 @@
   - 私钥 / 证书（PEM 块）
   - JWT
   - 云厂商与第三方密钥（AWS AKIA、GitHub、Slack、Google、OpenAI 风格 sk-）
-  - HTTP Authorization: Bearer 令牌
+  - HTTP Authorization: Bearer / Basic 令牌
   - 配置中的口令 / 密钥赋值（password=..., token: ... 等）
   - 邮箱地址
   - 信用卡号（Luhn 校验）
@@ -109,6 +109,11 @@ _RULES = [
         1, None,
     ),
     (
+        "basic_auth", "[REDACTED_BASIC_AUTH]",
+        re.compile(r"(?i)\bBasic\s+([A-Za-z0-9+/=]{4,})"),
+        1, None,
+    ),
+    (
         "secret_assignment", "[REDACTED_SECRET]",
         re.compile(
             r"(?i)(?:password|passwd|pwd|secret|token|api[_-]?key|"
@@ -165,6 +170,7 @@ CATEGORY_LABELS = {
     "google_api_key": "Google API Key",
     "api_key": "API Key (sk-)",
     "bearer_token": "Bearer 令牌",
+    "basic_auth": "Basic 认证",
     "secret_assignment": "口令 / 密钥赋值",
     "email": "邮箱地址",
     "credit_card": "信用卡号",

--- a/chapter2/log-sanitization/regex_sanitizer.py
+++ b/chapter2/log-sanitization/regex_sanitizer.py
@@ -110,7 +110,8 @@ _RULES = [
     ),
     (
         "basic_auth", "[REDACTED_BASIC_AUTH]",
-        re.compile(r"(?i)\bBasic\s+([A-Za-z0-9+/=]{4,})"),
+        # Require Authorization: so English "Basic knowledge …" is not redacted.
+        re.compile(r"(?i)\bAuthorization\s*:\s*Basic\s+([A-Za-z0-9+/=]{4,})"),
         1, None,
     ),
     (

--- a/chapter2/log-sanitization/test_authorization_basic.py
+++ b/chapter2/log-sanitization/test_authorization_basic.py
@@ -23,3 +23,18 @@ def test_bearer_still_redacted():
     assert token not in text
     assert "[REDACTED_BEARER_TOKEN]" in text
     assert any(h["category"] == "bearer_token" for h in hits)
+
+
+def test_english_basic_prose_not_redacted():
+    prose = "Basic knowledge of Python is required."
+    text, hits = sanitize(prose)
+    assert text == prose
+    assert not any(h["category"] == "basic_auth" for h in hits)
+
+
+def test_www_authenticate_basic_realm_not_treated_as_credential():
+    # Challenge header names the scheme; it does not carry the password blob.
+    line = 'WWW-Authenticate: Basic realm="api"'
+    text, hits = sanitize(line)
+    assert text == line
+    assert not any(h["category"] == "basic_auth" for h in hits)

--- a/chapter2/log-sanitization/test_authorization_basic.py
+++ b/chapter2/log-sanitization/test_authorization_basic.py
@@ -1,0 +1,25 @@
+"""Authorization: Basic credentials must be redacted like Bearer tokens."""
+from regex_sanitizer import sanitize
+
+
+def test_authorization_basic_redacted():
+    cred = "dXNlcjpwYXNzd29yZA=="
+    text, hits = sanitize(f"Authorization: Basic {cred}")
+    assert cred not in text
+    assert "[REDACTED_BASIC_AUTH]" in text
+    assert any(h["category"] == "basic_auth" for h in hits)
+
+
+def test_authorization_basic_case_insensitive():
+    cred = "YWRtaW46c2VjcmV0"
+    text, hits = sanitize(f"authorization: basic {cred}")
+    assert cred not in text
+    assert "[REDACTED_BASIC_AUTH]" in text
+
+
+def test_bearer_still_redacted():
+    token = "aaaaaaaaaaaaaaaaaaaa"
+    text, hits = sanitize(f"Authorization: Bearer {token}")
+    assert token not in text
+    assert "[REDACTED_BEARER_TOKEN]" in text
+    assert any(h["category"] == "bearer_token" for h in hits)


### PR DESCRIPTION
`Authorization: Basic …` was left in logs while Bearer was redacted.

Redact Basic credentials the same way.