### PR TITLE
fix(web-search): tolerate malformed tool-arg JSON

### DIFF
--- a/chapter1/web-search-agent/agent.py
+++ b/chapter1/web-search-agent/agent.py
@@ -264,7 +264,18 @@ class WebSearchAgent:
                     # 执行每个工具调用
                     for tool_call in choice.message.tool_calls:
                         tool_call_name = tool_call.function.name
-                        tool_call_arguments = json.loads(tool_call.function.arguments)
+                        try:
+                            tool_call_arguments = json.loads(
+                                tool_call.function.arguments or "{}"
+                            )
+                        except json.JSONDecodeError:
+                            # Models sometimes emit slightly invalid JSON; match
+                            # chapter4 async-agent and keep the ReAct loop alive.
+                            tool_call_arguments = {}
+                            logger.warning(
+                                "工具参数不是合法 JSON，已按空对象继续: %r",
+                                tool_call.function.arguments,
+                            )
 
                         logger.info(f"执行工具: {tool_call_name}, 参数: {tool_call_arguments}")
                         # 行动：记录一次工具调用

--- a/chapter1/web-search-agent/tests/test_agent.py
+++ b/chapter1/web-search-agent/tests/test_agent.py
@@ -191,3 +191,29 @@ def test_agent_loop_marks_truncated_partial_answer(make_choice):
     # bare partial), so get_conversation_history() doesn't lose the semantics.
     assert instance.conversation_history[-1]["role"] == "assistant"
     assert "截断" in instance.conversation_history[-1]["content"]
+
+
+def test_agent_loop_survives_malformed_tool_arguments_json(
+    monkeypatch, make_choice
+):
+    """Slightly invalid tool JSON must not abort the ReAct loop."""
+    from types import SimpleNamespace
+
+    bad_call = SimpleNamespace(
+        id="call-bad",
+        function=SimpleNamespace(
+            name="$web_search",
+            arguments='{"query": "moonshot",}',  # trailing comma
+        ),
+    )
+    tool_choice = make_choice(finish_reason="tool_calls", tool_calls=[bad_call])
+    answer_choice = make_choice(content="recovered answer")
+    instance = build_agent(tool_choice, answer_choice)
+    search = Mock(return_value={"ok": True})
+    monkeypatch.setattr(agent_module, "search_impl", search)
+
+    answer = instance.search_and_answer("what is caching?")
+
+    assert answer == "recovered answer"
+    search.assert_called_once_with({})
+    assert any(step["type"] == "action" for step in instance.get_trace())

--- a/chapter1/web-search-agent/tests/test_agent.py
+++ b/chapter1/web-search-agent/tests/test_agent.py
@@ -193,9 +193,7 @@ def test_agent_loop_marks_truncated_partial_answer(make_choice):
     assert "截断" in instance.conversation_history[-1]["content"]
 
 
-def test_agent_loop_survives_malformed_tool_arguments_json(
-    monkeypatch, make_choice
-):
+def test_agent_loop_survives_malformed_tool_arguments_json(monkeypatch, make_choice):
     """Slightly invalid tool JSON must not abort the ReAct loop."""
     from types import SimpleNamespace
 


### PR DESCRIPTION
Malformed tool-argument JSON aborted the ReAct loop.

Catch parse errors and continue like the async-agent sibling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化工具调用参数处理：遇到格式错误的 JSON 时，搜索流程不再中断，可继续执行并返回结果。
  * 提升网络搜索问答流程在异常参数场景下的稳定性。

* **Tests**
  * 新增异常 JSON 参数场景的测试，验证流程能够恢复并完成搜索调用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->