### PR TITLE
fix(elo): reindex BT tie pivots before symmetrizing

### DIFF
--- a/chapter6/elo-leaderboard/bradley_terry.py
+++ b/chapter6/elo-leaderboard/bradley_terry.py
@@ -45,7 +45,9 @@ def compute_mle_elo(df: pd.DataFrame,
         observed=False
     )
     
-    # Handle ties (including "tie (bothbad)")
+    # Handle ties (including "tie (bothbad)"). Symmetrize only after aligning to
+    # the full model square; (pivot + pivot.T) on a one-sided A×B pivot zeroes
+    # every cell via pandas index/column alignment.
     if sum(df["winner"].isin(["tie", "tie (bothbad)"])) == 0:
         ptbl_tie = pd.DataFrame(0, index=ptbl_a_win.index, columns=ptbl_a_win.columns)
     else:
@@ -57,7 +59,6 @@ def compute_mle_elo(df: pd.DataFrame,
             fill_value=0,
             observed=False
         )
-        ptbl_tie = (ptbl_tie + ptbl_tie.T).fillna(0)
     
     ptbl_b_win = pd.pivot_table(
         df[df["winner"] == "model_b"],
@@ -73,6 +74,7 @@ def compute_mle_elo(df: pd.DataFrame,
     ptbl_a_win = ptbl_a_win.reindex(index=models, columns=models, fill_value=0)
     ptbl_b_win = ptbl_b_win.reindex(index=models, columns=models, fill_value=0)
     ptbl_tie = ptbl_tie.reindex(index=models, columns=models, fill_value=0)
+    ptbl_tie = ptbl_tie + ptbl_tie.T
 
     # Compute win matrix (A wins * 2 + B wins * 2 + ties)
     ptbl_win = (ptbl_a_win * 2 + ptbl_b_win.T * 2 + ptbl_tie).fillna(0)

--- a/chapter6/elo-leaderboard/test_bt_tie_pivot.py
+++ b/chapter6/elo-leaderboard/test_bt_tie_pivot.py
@@ -1,0 +1,41 @@
+"""Ties must contribute to Bradley-Terry weights (not be zeroed by pivot+T)."""
+import pandas as pd
+
+from bradley_terry import compute_mle_elo
+
+
+def test_all_ties_rates_models_instead_of_sample_weight_error():
+    df = pd.DataFrame(
+        [
+            {"model_a": "A", "model_b": "B", "winner": "tie"},
+            {"model_a": "A", "model_b": "C", "winner": "tie (bothbad)"},
+            {"model_a": "B", "model_b": "C", "winner": "tie"},
+        ]
+    )
+    ratings = compute_mle_elo(df)
+    assert set(ratings.index) == {"A", "B", "C"}
+    # Pure ties -> equal latent skills under BT.
+    assert abs(float(ratings["A"]) - float(ratings["B"])) < 1e-6
+    assert abs(float(ratings["A"]) - float(ratings["C"])) < 1e-6
+
+
+def test_ties_change_ratings_versus_wins_only():
+    wins_only = pd.DataFrame(
+        [
+            {"model_a": "A", "model_b": "B", "winner": "model_a"},
+            {"model_a": "B", "model_b": "C", "winner": "model_a"},
+        ]
+    )
+    with_ties = pd.concat(
+        [
+            wins_only,
+            pd.DataFrame(
+                [{"model_a": "A", "model_b": "C", "winner": "tie"}] * 8
+            ),
+        ],
+        ignore_index=True,
+    )
+    r1 = compute_mle_elo(wins_only)
+    r2 = compute_mle_elo(with_ties)
+    # Extra A–C ties pull A and C together relative to the wins-only fit.
+    assert abs(float(r2["A"]) - float(r2["C"])) < abs(float(r1["A"]) - float(r1["C"]))


### PR DESCRIPTION
All-tie Bradley-Terry battles wiped the weight matrix when symmetrizing before reindex.

Reindex tie pivots before symmetrizing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修正包含平局数据时的 Elo 评分计算，避免因数据对齐问题导致结果不准确。
  * 改善可选 Bootstrap 分布计算中的平局处理。

* **Tests**
  * 新增纯平局场景测试，确保各模型评分保持一致。
  * 新增测试，验证加入平局记录后，相关模型评分差异会合理缩小。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->