### PR TITLE
fix(elo): tolerate empty rating history in analyze/get_rating_history

### DIFF
--- a/chapter6/elo-leaderboard/leaderboard.py
+++ b/chapter6/elo-leaderboard/leaderboard.py
@@ -179,6 +179,9 @@ def get_rating_history(historical_leaderboards: List[Tuple]) -> pd.DataFrame:
                 'wins': row['wins']
             })
     
+    cols = ['date', 'model', 'rating', 'rank', 'matches', 'wins']
+    if not all_data:
+        return pd.DataFrame(columns=cols)
     history_df = pd.DataFrame(all_data)
     return history_df
 
@@ -194,6 +197,13 @@ def analyze_rating_changes(history_df: pd.DataFrame, top_n: int = 20) -> pd.Data
     Returns:
         DataFrame with change statistics
     """
+    stats_cols = [
+        'model', 'final_rating', 'initial_rating', 'rating_change',
+        'max_rating', 'min_rating', 'volatility', 'total_matches',
+    ]
+    if history_df is None or len(history_df) == 0:
+        return pd.DataFrame(columns=stats_cols)
+
     # Get final ratings
     final_date = history_df['date'].max()
     final_ratings = history_df[history_df['date'] == final_date].nlargest(top_n, 'rating')
@@ -223,6 +233,8 @@ def analyze_rating_changes(history_df: pd.DataFrame, top_n: int = 20) -> pd.Data
                 'total_matches': model_data.iloc[-1]['matches']
             })
     
+    if not stats:
+        return pd.DataFrame(columns=stats_cols)
     stats_df = pd.DataFrame(stats).sort_values('final_rating', ascending=False)
     return stats_df
 

--- a/chapter6/elo-leaderboard/test_analyze_empty_history.py
+++ b/chapter6/elo-leaderboard/test_analyze_empty_history.py
@@ -1,0 +1,39 @@
+"""Empty rating history must not crash analyze_rating_changes / get_rating_history."""
+import pandas as pd
+
+from animation import prepare_animation_data
+from leaderboard import (
+    analyze_rating_changes,
+    build_historical_leaderboards,
+    get_rating_history,
+)
+
+
+def test_get_rating_history_empty_keeps_columns():
+    hist = build_historical_leaderboards(
+        pd.DataFrame(columns=["model_a", "model_b", "winner"]),
+        [(pd.Timestamp("2020-01-01"), pd.DataFrame(columns=["model_a", "model_b", "winner"]))],
+    )
+    rh = get_rating_history(hist)
+    assert list(rh.columns) == ["date", "model", "rating", "rank", "matches", "wins"]
+    assert len(rh) == 0
+
+
+def test_analyze_empty_history_returns_empty_frame():
+    empty = pd.DataFrame(columns=["date", "model", "rating", "rank", "matches", "wins"])
+    stats = analyze_rating_changes(empty)
+    assert len(stats) == 0
+    assert "model" in stats.columns
+
+
+def test_analyze_after_empty_historical_leaderboards():
+    hist = build_historical_leaderboards(
+        pd.DataFrame(columns=["model_a", "model_b", "winner"]),
+        [(pd.Timestamp("2020-01-01"), pd.DataFrame(columns=["model_a", "model_b", "winner"]))],
+    )
+    rh = get_rating_history(hist)
+    stats = analyze_rating_changes(rh)
+    assert len(stats) == 0
+    anim = prepare_animation_data(rh)
+    assert anim["frames"] == []
+    assert anim["total_frames"] == 0


### PR DESCRIPTION
Empty rating history left no columns, so `analyze_rating_changes` crashed in `nlargest`.

Return an empty result for empty history.