### PR TITLE
fix(book-translation): treat non-dict proofread JSON as empty report

### DIFF
--- a/chapter10/book-translation/agents.py
+++ b/chapter10/book-translation/agents.py
@@ -28,7 +28,9 @@ BASE_URL = os.environ.get("OPENAI_BASE_URL")  # 可选，兼容自建/代理端�
 
 
 def _report_issues(report: dict) -> list:
-    """JSON null issues must behave like omit ([])."""
+    """JSON null issues must behave like omit ([]). Non-dict reports → []."""
+    if not isinstance(report, dict):
+        return []
     issues = report.get("issues")
     return issues if issues is not None else []
 
@@ -86,14 +88,19 @@ def _slug(name: str) -> str:
 
 
 def _loads_lenient(content: str):
-    """容错解析 JSON：兼容个别模型把 JSON 包在 ```json ... ``` 代码围栏里的情况。"""
+    """容错解析 JSON：兼容代码围栏；非法/空内容返回 None（不抛）。"""
     s = (content or "").strip()
     if s.startswith("```"):
         s = s.split("\n", 1)[-1] if "\n" in s else s
         s = s.rsplit("```", 1)[0].strip()
         if s.lower().startswith("json"):
             s = s[4:].strip()
-    return json.loads(s)
+    if not s:
+        return None
+    try:
+        return json.loads(s)
+    except json.JSONDecodeError:
+        return None
 
 
 def count_tokens(text: str) -> int:
@@ -310,7 +317,8 @@ def proofreading_agent(client, tracker, translations, glossary, target_lang="中
     content = llm_chat(
         client, tracker, "Proofreading", messages, json_mode=True, note="一致性审校"
     )
-    return _loads_lenient(content)
+    data = _loads_lenient(content)
+    return data if isinstance(data, dict) else {}
 
 
 def manager_decision(client, tracker, task, file_index, report):

--- a/chapter10/book-translation/test_proofread_non_dict.py
+++ b/chapter10/book-translation/test_proofread_non_dict.py
@@ -1,0 +1,54 @@
+"""Proofreading must return a dict when the model emits a JSON array or junk."""
+from agents import _loads_lenient, _report_issues, proofreading_agent
+
+
+def test_loads_lenient_empty_and_junk_return_none():
+    assert _loads_lenient("") is None
+    assert _loads_lenient("not json") is None
+    assert _loads_lenient('{"a": 1}') == {"a": 1}
+
+
+def test_report_issues_non_dict():
+    assert _report_issues([]) == []
+    assert _report_issues(None) == []
+
+
+def test_proofreading_agent_json_array_returns_empty_dict(monkeypatch):
+    calls = []
+
+    def fake_llm_chat(client, tracker, agent, messages, json_mode=False, note=""):
+        calls.append(note)
+        return "[]"
+
+    monkeypatch.setattr("agents.llm_chat", fake_llm_chat)
+    report = proofreading_agent(
+        client=object(),
+        tracker=type("T", (), {"record": lambda *a, **k: None})(),
+        translations={"ch1": "hello"},
+        glossary=[],
+    )
+    assert report == {}
+    assert _report_issues(report) == []
+    assert report.get("chapters_need_revision", []) == []
+    assert calls == ["一致性审校"]
+
+
+def test_proofreading_agent_valid_object(monkeypatch):
+    payload = {
+        "issues": [{"chapter": "ch1", "detail": "x"}],
+        "chapters_need_revision": ["ch1"],
+        "summary": "ok",
+    }
+
+    def fake_llm_chat(client, tracker, agent, messages, json_mode=False, note=""):
+        import json
+        return json.dumps(payload)
+
+    monkeypatch.setattr("agents.llm_chat", fake_llm_chat)
+    report = proofreading_agent(
+        client=object(),
+        tracker=type("T", (), {"record": lambda *a, **k: None})(),
+        translations={"ch1": "hello"},
+        glossary=[],
+    )
+    assert report == payload


### PR DESCRIPTION
A proofread JSON array made `report.get` raise `AttributeError`.

Treat non-dict proofread payloads as an empty report.