### PR TITLE
fix(elo): load empty battles JSON array as empty frame

### DIFF
--- a/chapter6/elo-leaderboard/cli.py
+++ b/chapter6/elo-leaderboard/cli.py
@@ -48,6 +48,9 @@ def _load_battles(path: str) -> pd.DataFrame:
     with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
     df = pd.DataFrame(data)
+    # `[]` from --num-battles 0 has no columns; treat as empty battle frame.
+    if len(df) == 0:
+        return pd.DataFrame(columns=["model_a", "model_b", "winner"])
     required = {"model_a", "model_b", "winner"}
     if not required.issubset(df.columns):
         raise ValueError(

--- a/chapter6/elo-leaderboard/test_load_battles_empty.py
+++ b/chapter6/elo-leaderboard/test_load_battles_empty.py
@@ -1,0 +1,34 @@
+"""Empty battles JSON array [] must load as an empty battle frame."""
+import json
+from pathlib import Path
+
+import cli
+
+
+def test_load_battles_empty_json_array(tmp_path):
+    path = tmp_path / "battles.json"
+    path.write_text("[]", encoding="utf-8")
+    df = cli._load_battles(str(path))
+    assert list(df.columns) == ["model_a", "model_b", "winner"]
+    assert len(df) == 0
+
+
+def test_load_battles_nonempty_still_requires_columns(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps([{"x": 1}]), encoding="utf-8")
+    try:
+        cli._load_battles(str(path))
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "model_a" in str(e)
+
+
+def test_load_battles_normal(tmp_path):
+    path = tmp_path / "ok.json"
+    path.write_text(
+        json.dumps([{"model_a": "A", "model_b": "B", "winner": "model_a"}]),
+        encoding="utf-8",
+    )
+    df = cli._load_battles(str(path))
+    assert len(df) == 1
+    assert df.iloc[0]["winner"] == "model_a"


### PR DESCRIPTION
A battles file of `[]` (for example `--num-battles 0`) raised a false missing-columns error.

Load an empty array as an empty frame.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复空对战数据导致排行榜加载失败的问题。
  * 空数据现在可正常加载，并保留必要字段结构。
  * 非空数据仍会校验必需字段，缺失时提供明确错误提示。

* **Tests**
  * 增加空数据、字段缺失及正常数据加载场景的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->