### PR TITLE
fix(multiedit): reject empty old_string on existing files

### DIFF
--- a/chapter5/coding-agent/tests/test_multi_edit_empty_old_on_existing.py
+++ b/chapter5/coding-agent/tests/test_multi_edit_empty_old_on_existing.py
@@ -1,0 +1,63 @@
+"""Empty old_string on an existing file must not wipe contents (match Edit)."""
+
+from tools.edit_tool import EditTool
+from tools.multi_edit_tool import MultiEditTool
+
+
+def test_empty_old_string_on_existing_file_rejected(system_state, temp_dir):
+    path = temp_dir / "keep.txt"
+    path.write_text("hello world", encoding="utf-8")
+
+    result = MultiEditTool(system_state).execute(
+        {
+            "file_path": str(path),
+            "edits": [{"old_string": "", "new_string": "Y"}],
+        }
+    )
+    assert result.data.get("error") == "old_string cannot be empty"
+    assert path.read_text(encoding="utf-8") == "hello world"
+
+
+def test_empty_old_string_matches_edit_rejection(system_state, temp_dir):
+    path = temp_dir / "keep.txt"
+    path.write_text("hello world", encoding="utf-8")
+    edit = EditTool(system_state).execute(
+        {"file_path": str(path), "old_string": "", "new_string": "Y"}
+    )
+    multi = MultiEditTool(system_state).execute(
+        {
+            "file_path": str(path),
+            "edits": [{"old_string": "", "new_string": "Y"}],
+        }
+    )
+    assert edit.data.get("error") == multi.data.get("error") == "old_string cannot be empty"
+    assert path.read_text(encoding="utf-8") == "hello world"
+
+
+def test_create_new_file_with_empty_old_string_still_works(system_state, temp_dir):
+    path = temp_dir / "brand_new.txt"
+    assert not path.exists()
+    result = MultiEditTool(system_state).execute(
+        {
+            "file_path": str(path),
+            "edits": [{"old_string": "", "new_string": "created"}],
+        }
+    )
+    assert "error" not in result.data
+    assert path.read_text(encoding="utf-8") == "created"
+
+
+def test_empty_old_string_later_edit_rejected(system_state, temp_dir):
+    path = temp_dir / "keep.txt"
+    path.write_text("hello", encoding="utf-8")
+    result = MultiEditTool(system_state).execute(
+        {
+            "file_path": str(path),
+            "edits": [
+                {"old_string": "hello", "new_string": "hello"},
+                {"old_string": "", "new_string": "X", "replace_all": True},
+            ],
+        }
+    )
+    assert result.data.get("error") == "old_string cannot be empty"
+    assert path.read_text(encoding="utf-8") == "hello"

--- a/chapter5/coding-agent/tools/multi_edit_tool.py
+++ b/chapter5/coding-agent/tools/multi_edit_tool.py
@@ -58,12 +58,15 @@ class MultiEditTool(BaseTool):
                 new_string = edit["new_string"]
                 replace_all = edit.get("replace_all", False)
                 
-                if old_string == "" and i == 0:
-                    # File creation case
-                    content = new_string
-                    results.append({"edit": i + 1, "action": "created", "success": True})
-                    continue
-                
+                # Empty old_string is only for creating a new file (tools.json);
+                # on an existing file it would wipe contents (Edit rejects this).
+                if old_string == "":
+                    if creating_new and i == 0:
+                        content = new_string
+                        results.append({"edit": i + 1, "action": "created", "success": True})
+                        continue
+                    return {"error": "old_string cannot be empty"}
+
                 if old_string not in content:
                     return {
                         "error": f"Edit #{i + 1} failed: String not found",

--- a/chapter5/coding-agent/tools/multi_edit_tool.py
+++ b/chapter5/coding-agent/tools/multi_edit_tool.py
@@ -58,8 +58,7 @@ class MultiEditTool(BaseTool):
                 new_string = edit["new_string"]
                 replace_all = edit.get("replace_all", False)
                 
-                # Empty old_string is only for creating a new file (tools.json);
-                # on an existing file it would wipe contents (Edit rejects this).
+                # Empty old_string only valid when creating a new file (tools.json / Edit parity).
                 if old_string == "":
                     if creating_new and i == 0:
                         content = new_string


### PR DESCRIPTION
An empty old_string on an existing file wiped the file contents with new_string.

Reject empty old_string when the target file already exists.
