### PR TITLE
fix(read): do not report nonempty file as empty when limit is 0

### DIFF
--- a/chapter5/coding-agent/tests/test_read_limit_zero.py
+++ b/chapter5/coding-agent/tests/test_read_limit_zero.py
@@ -1,0 +1,38 @@
+"""limit=0 on a nonempty file must not claim the file is empty."""
+
+
+def test_limit_zero_on_nonempty_file(system_state, temp_dir):
+    from tools.read_tool import ReadTool
+
+    path = temp_dir / "lines.txt"
+    path.write_text("a\nb\nc\n", encoding="utf-8")
+    result = ReadTool(system_state).execute(
+        {"file_path": str(path), "limit": 0}
+    )
+    data = result.data
+    assert data["total_lines"] == 3
+    assert data["content"] != "File is empty."
+    assert "No lines in selected range" in data["content"]
+    assert data["showing_lines"] == "1-0"
+
+
+def test_truly_empty_file_still_warns(system_state, temp_dir):
+    from tools.read_tool import ReadTool
+
+    path = temp_dir / "empty.txt"
+    path.write_text("", encoding="utf-8")
+    result = ReadTool(system_state).execute({"file_path": str(path)})
+    assert result.data["content"] == "File is empty."
+    assert result.data["total_lines"] == 0
+
+
+def test_positive_limit_still_returns_lines(system_state, temp_dir):
+    from tools.read_tool import ReadTool
+
+    path = temp_dir / "lines.txt"
+    path.write_text("a\nb\nc\n", encoding="utf-8")
+    result = ReadTool(system_state).execute(
+        {"file_path": str(path), "limit": 1}
+    )
+    assert "     1|a" in result.data["content"]
+    assert result.data["total_lines"] == 3

--- a/chapter5/coding-agent/tools/read_tool.py
+++ b/chapter5/coding-agent/tools/read_tool.py
@@ -86,10 +86,13 @@ class ReadTool(BaseTool):
                 formatted_lines.append(f"{i:6d}|{line_content}")
             
             content = "\n".join(formatted_lines)
-            
-            if not content:
+
+            # tools.json: empty-file warning only when the file has no contents.
+            if total_lines == 0:
                 content = "File is empty."
-            
+            elif not selected_lines:
+                content = "No lines in selected range."
+
             return {
                 "file_path": str(file_path),
                 "total_lines": total_lines,


### PR DESCRIPTION
Read with limit=0 on a nonempty file returned "File is empty."

Treat limit=0 as zero lines, not as an empty file.
