### PR TITLE
fix(grep): honor head_limit=0 as zero results

### DIFF
--- a/chapter5/coding-agent/tests/test_grep_head_limit_zero.py
+++ b/chapter5/coding-agent/tests/test_grep_head_limit_zero.py
@@ -1,0 +1,43 @@
+"""head_limit=0 must return zero results (like `head -0`), not unlimited."""
+
+
+def test_head_limit_zero_files_with_matches(system_state, sample_files):
+    from tools.grep_tool import GrepTool
+
+    result = GrepTool(system_state).execute(
+        {
+            "pattern": "ERROR",
+            "path": str(sample_files["text_file1"].parent),
+            "head_limit": 0,
+            "output_mode": "files_with_matches",
+        }
+    )
+    assert result.data["matches"] == 0
+    assert result.data["output"] == "No matches found."
+
+
+def test_head_limit_one_still_caps(system_state, sample_files):
+    from tools.grep_tool import GrepTool
+
+    result = GrepTool(system_state).execute(
+        {
+            "pattern": "ERROR",
+            "path": str(sample_files["text_file1"].parent),
+            "head_limit": 1,
+            "output_mode": "files_with_matches",
+        }
+    )
+    assert result.data["matches"] == 1
+
+
+def test_omitted_head_limit_still_unlimited(system_state, sample_files):
+    from tools.grep_tool import GrepTool
+
+    result = GrepTool(system_state).execute(
+        {
+            "pattern": "test",
+            "path": str(sample_files["text_file1"].parent),
+            "output_mode": "files_with_matches",
+        }
+    )
+    assert result.data["matches"] >= 1

--- a/chapter5/coding-agent/tools/grep_tool.py
+++ b/chapter5/coding-agent/tools/grep_tool.py
@@ -54,6 +54,13 @@ class GrepTool(BaseTool):
         head_limit = params.get("head_limit")
         if head_limit is not None and head_limit < 0:
             head_limit = None
+        # head_limit=0 means zero results (like `head -0`), not unlimited.
+        if head_limit == 0:
+            return {
+                "pattern": pattern,
+                "output": "No matches found.",
+                "matches": 0,
+            }
         file_type = params.get("type")
         
         # Determine context
@@ -192,8 +199,8 @@ class GrepTool(BaseTool):
                 if regex.search(content):
                     matching_files.append(str(file_path))
                     
-                    # Check head limit
-                    if head_limit and len(matching_files) >= head_limit:
+                    # Check head limit (0 means zero results; do not treat as unlimited)
+                    if head_limit is not None and len(matching_files) >= head_limit:
                         break
                         
             except (IOError, OSError, UnicodeDecodeError):
@@ -228,7 +235,7 @@ class GrepTool(BaseTool):
                     results.append(f"{file_path}:{matches}")
                     total_matches += matches
                     
-                    if head_limit and len(results) >= head_limit:
+                    if head_limit is not None and len(results) >= head_limit:
                         break
                         
             except (IOError, OSError, UnicodeDecodeError):
@@ -309,11 +316,11 @@ class GrepTool(BaseTool):
                     
                     prev_line = line_num
                     
-                    # Check head limit
-                    if head_limit and lines_added >= head_limit:
+                    # Check head limit (0 means zero results; do not treat as unlimited)
+                    if head_limit is not None and lines_added >= head_limit:
                         break
                 
-                if head_limit and lines_added >= head_limit:
+                if head_limit is not None and lines_added >= head_limit:
                     break
                     
             except (IOError, OSError, UnicodeDecodeError):


### PR DESCRIPTION
Grep with head_limit=0 ignored the cap and returned matches.

Honor 0 as zero results.
