### PR TITLE
fix(video-edit): parse first JSON object when extras follow

### DIFF
--- a/chapter5/video-edit/agents.py
+++ b/chapter5/video-edit/agents.py
@@ -87,10 +87,16 @@ def _img_part(path: str) -> dict:
 
 def _extract_json(text: str) -> dict:
     """从 LLM 回复里稳健地抠出第一个 JSON 对象。"""
-    m = re.search(r"\{.*\}", text, re.DOTALL)
-    if not m:
+    start = text.find("{")
+    if start < 0:
         raise ValueError(f"未能从回复中解析 JSON：{text[:200]}")
-    return json.loads(m.group(0))
+    try:
+        obj, _ = json.JSONDecoder().raw_decode(text, start)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"未能从回复中解析 JSON：{text[:200]}") from e
+    if not isinstance(obj, dict):
+        raise ValueError(f"未能从回复中解析 JSON：{text[:200]}")
+    return obj
 
 
 def _num(value, default: float) -> float:

--- a/chapter5/video-edit/test_extract_json_adjacent.py
+++ b/chapter5/video-edit/test_extract_json_adjacent.py
@@ -1,0 +1,22 @@
+"""_extract_json must accept the first object when another object follows."""
+
+import pytest
+
+from agents import _extract_json
+
+
+def test_adjacent_json_objects_returns_first():
+    assert _extract_json('{"a":1}{"b":2}') == {"a": 1}
+
+
+def test_prose_with_two_objects_returns_first():
+    assert _extract_json('note {"a":1} mid {"b":2}') == {"a": 1}
+
+
+def test_single_object_unchanged():
+    assert _extract_json('prefix {"ok": true, "n": 3} suffix') == {"ok": True, "n": 3}
+
+
+def test_no_object_raises():
+    with pytest.raises(ValueError, match="未能从回复中解析 JSON"):
+        _extract_json("no braces here")


### PR DESCRIPTION
_extract_json used a greedy brace match, so adjacent JSON objects raised Extra data.

Parse the first complete object.
