### PR TITLE
fix(agent-cost): tolerate null usage on traced chat calls

### DIFF
--- a/chapter6/agent-cost-analysis/test_chat_null_usage.py
+++ b/chapter6/agent-cost-analysis/test_chat_null_usage.py
@@ -1,0 +1,44 @@
+"""Tracer.chat must tolerate response.usage == None (OpenAI-compatible providers)."""
+
+from types import SimpleNamespace
+
+import config
+from tracer import Tracer
+
+
+class _FakeClient:
+    def __init__(self, usage):
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(create=self._create)
+        )
+        self._usage = usage
+
+    def _create(self, **_kwargs):
+        return SimpleNamespace(usage=self._usage)
+
+
+def test_chat_tolerates_null_usage():
+    tr = Tracer(_FakeClient(None), pricing=config.default_pricing())
+    resp = tr.chat(step="turn-1", tool="query_order", model="m", messages=[])
+    assert resp.usage is None
+    assert len(tr.spans) == 1
+    s = tr.spans[0]
+    assert s.prompt_tokens == 0
+    assert s.completion_tokens == 0
+    assert s.cost_usd == 0.0
+    assert s.latency_s >= 0.0
+
+
+def test_chat_keeps_real_usage():
+    usage = SimpleNamespace(
+        prompt_tokens=100,
+        completion_tokens=20,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=10),
+    )
+    tr = Tracer(_FakeClient(usage), pricing=config.default_pricing())
+    tr.chat(step="turn-1", tool="query_order", model="m", messages=[])
+    s = tr.spans[0]
+    assert s.prompt_tokens == 100
+    assert s.completion_tokens == 20
+    assert s.cached_tokens == 10
+    assert s.cost_usd > 0

--- a/chapter6/agent-cost-analysis/tracer.py
+++ b/chapter6/agent-cost-analysis/tracer.py
@@ -86,23 +86,38 @@ class Tracer:
         latency = time.time() - t0
 
         usage = resp.usage
+        # Some OpenAI-compatible providers omit usage (null); match from_records coercion.
+        if usage is None:
+            span = Span(
+                step=step,
+                tool=tool,
+                kind="llm",
+                tool_ctx_tokens=tool_ctx_tokens,
+                latency_s=latency,
+                cost_usd=0.0,
+            )
+            self.spans.append(span)
+            return resp
+
         # cached_tokens 藏在 prompt_tokens_details 里，注意做防御式读取
         cached = 0
         details = getattr(usage, "prompt_tokens_details", None)
         if details is not None:
             cached = getattr(details, "cached_tokens", 0) or 0
 
+        prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
+        completion_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
         span = Span(
             step=step,
             tool=tool,
             kind="llm",
-            prompt_tokens=usage.prompt_tokens,
+            prompt_tokens=prompt_tokens,
             cached_tokens=cached,
-            completion_tokens=usage.completion_tokens,
+            completion_tokens=completion_tokens,
             tool_ctx_tokens=tool_ctx_tokens,
             latency_s=latency,
             cost_usd=self.pricing.cost_usd(
-                usage.prompt_tokens, cached, usage.completion_tokens),
+                prompt_tokens, cached, completion_tokens),
         )
         self.spans.append(span)
         return resp


### PR DESCRIPTION
Tracer.chat crashed with AttributeError when resp.usage was None.

Treat missing usage like from_records already does.
