### PR TITLE
test(self-evol-eval): drop tautological int(None) test, declare pytest dep

### DIFF
--- a/chapter8/self-evolution-eval/requirements.txt
+++ b/chapter8/self-evolution-eval/requirements.txt
@@ -3,3 +3,4 @@
 # （youtube-transcript-api、yfinance 等）只是"参考方案"，被测 Agent 才会去安装，评估器不需要。
 openai>=1.30.0
 python-dotenv>=1.0.0
+pytest>=8.0.0

--- a/chapter8/self-evolution-eval/test_null_rubric_dimension.py
+++ b/chapter8/self-evolution-eval/test_null_rubric_dimension.py
@@ -22,10 +22,3 @@ def test_missing_dimension_still_zero():
 def test_empty_string_score_rejected():
     with pytest.raises(ValueError):
         _rubric_dimension_total({"error_handling": ""})
-
-
-def test_pristine_int_none_raises():
-    """Old pattern int(rubric.get(d, 0)) still blows up on explicit null."""
-    rubric = {"error_handling": None}
-    with pytest.raises(TypeError):
-        int(rubric.get("error_handling", 0))


### PR DESCRIPTION
清理 self-evolution-eval 中重言式的 int(None) 测试，并声明 pytest 依赖。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 评分时，明确设置为 `None` 或缺失的评估维度将按 0 分处理。
  - 空字符串维度值仍会被识别为无效输入并提示错误。

- **测试**
  - 补充并更新相关边界场景验证，确保评分结果和输入校验行为保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->