### PR TITLE
docs(ch9): add bilingual READMEs for Chapter 9 projects

### DIFF
--- a/chapter9/controllable-tts/README.md
+++ b/chapter9/controllable-tts/README.md
@@ -19,7 +19,7 @@ This environment lacks a usable Fish Audio key, so **OpenAI TTS** is used instea
 | Control markers select reference voice | Control markers parsed -> select `(emotion, speed, style)` profile |
 
 - Preferred model **`gpt-4o-mini-tts`**: Supports the `instructions` parameter, allowing precise control of emotion/speech rate/tone with a Chinese prompt, closest to the semantics of "control marker → stylized speech".
-- If the preferred model is unavailable, the code **automatically falls back to `tts-1`**: Does not support instructions, instead uses multiple voices + `speed` parameter + text-level pauses as an approximation.
+- If the preferred model is unavailable, the code **automatically falls back to `tts-1`**: Does not support instructions; keeps the same fixed `voice` (alloy) and approximates style with the `speed` parameter + text/silence pauses.
 
 **Must use a direct OpenAI Key**: This experiment only uses the TTS speech synthesis endpoint (`gpt-4o-mini-tts` / `tts-1`). These audio endpoints are only available through direct OpenAI connection—OpenRouter only handles chat completions and has no audio synthesis endpoint, so it cannot fall back to `OPENROUTER_API_KEY`. Offline viewing of the voice library/marker mapping (`--list-voices` / `--dump-mapping`) does not require any key.
 
@@ -31,9 +31,10 @@ This environment lacks a usable Fish Audio key, so **OpenAI TTS** is used instea
 
 | Marker | Chinese Form | Effect |
 | --- | --- | --- |
-| `[EMO:neutral\|happy\|frustrated\|thinking]` | `[EMO=neutral\|happy\|frustrated\|thinking]` | Switch emotion |
-| `[SPEED:normal\|fast\|slow]` / `[SPEED:0.8x]` | `[SPEED=normal\|fast\|slow]` | Switch speech rate |
-| `[STYLE:formal\|casual]` | `[STYLE=formal\|casual]` | Switch tone |
+| `[EMO:neutral\|happy\|frustrated\|thinking]` | `[情感=中性\|高兴\|沮丧\|思考]` | Switch emotion |
+| `[SPEED:normal\|fast\|slow]` / `[SPEED:0.8x]` | `[语速=正常\|快\|慢]` | Switch speech rate |
+| `[STYLE:formal\|casual]` | `[风格=正式\|轻松]` | Switch tone |
+
 The three dimensions combine to form a profile in the reference voice library (e.g., `happy_fast_formal`), which is then assembled into an `instructions` prompt for `gpt-4o-mini-tts`.
 
 ### Inline Markers (one-time events)
@@ -42,10 +43,12 @@ The three dimensions combine to form a profile in the reference voice library (e
 | --- | --- |
 | `[THINKING]` | Switch to "thinking/slow/formal" reference voice + insert 0.5s pause |
 | `[SEARCHING]` | Same as above, 0.4s pause (searching hesitation) |
-| `[PAUSE]` / `<pause>` / `[停顿]` | Insert 0.5s silence || `[BREATH]` / `<breath>` | Insert 0.4s breathing pause |
+| `[PAUSE]` / `<pause>` / `[停顿]` | Insert 0.5s silence |
+| `[BREATH]` / `<breath>` | Insert 0.4s breathing pause |
 | `[SIGH]` / `<sigh>` | Sigh onomatopoeia "Ahh—" + 0.3s pause |
 | `[LAUGH:small]` / `<laugh>` | Light laugh onomatopoeia "Haha," (cheerful tone) |
 | `<emphasis>…</emphasis>` / `[强调]…[/强调]` | Append "emphasize" prompt for the wrapped text |
+
 ### Reference Voice Library
 
 `voice_library.py` generates **24 profiles** from the Cartesian product of emotion(4) × speech rate(3) × style(2), all with a fixed `voice=alloy` (consistent timbre), differing only in `instructions`. Can be viewed by running it standalone:
@@ -77,14 +80,15 @@ Common parameters (`python demo.py --help`):
 | Parameter | Effect |
 | --- | --- |
 | `--quick` | Only run the three-configuration comparison (A/B/C), skip the 5 style variants, reducing TTS calls and time |
-| `--text text` | Only synthesize this custom text (can embed control markers, e.g., `[emotion=happy][THINKING]…`) || `--emotion / --speed / --style` | Specify emotion/speech rate/tone for `--text` (equivalent to adding corresponding state markers before the text) |
+| `--text text` | Only synthesize this custom text (can embed control markers, e.g., `[EMO:happy][THINKING]…`) |
+| `--emotion / --speed / --style` | Specify emotion/speech rate/tone for `--text` (equivalent to adding corresponding state markers before the text) |
 | `-o / --output path` | Output mp3 path for `--text` mode (default `output/custom.mp3`) |
 | `--list-voices` | **Offline** (no API key needed): Print the complete reference voice library (24 profiles and their instructions) |
 | `--dump-mapping` | **Offline** (no API key needed): Print the control marker → action mapping table, and demonstrate the parsing process on example text |
 
 ## Example Expected Output (Real Excerpt)
 
-```
+```text
 Preferred model: gpt-4o-mini-tts (automatically falls back to tts-1 if unavailable)
 
 Comparison experiment: Same text with control markers, three configurations
@@ -141,8 +145,8 @@ Comparing the ffprobe durations of the three configurations reveals the differen
 
 - 首选模型 **`gpt-4o-mini-tts`**：支持 `instructions` 参数，可用一段中文提示词精确
   控制情感/语速/口吻，最贴近「控制标记 → 风格化语音」的语义。
-- 若首选模型不可用，代码**自动兜底到 `tts-1`**：不支持 instructions，改用多 voice +
-  `speed` 参数 + 文本级停顿近似。
+- 若首选模型不可用，代码**自动兜底到 `tts-1`**：不支持 instructions，仍用固定 `voice`（alloy），
+  改用 `speed` 参数 + 文本/静音停顿近似。
 
 **必须用 OpenAI 直连 Key**：本实验只用 TTS 语音合成端点（`gpt-4o-mini-tts` / `tts-1`），
 这类音频端点只有 OpenAI 直连才有——OpenRouter 只做聊天补全、无音频合成端点，故无法回退到
@@ -217,7 +221,7 @@ python demo.py                            # 生成 output/*.mp3
 
 ## 预期输出示例（真实节选）
 
-```
+```text
 首选模型: gpt-4o-mini-tts（不可用时自动兜底 tts-1）
 
 对比实验：同一段带控制标记的文本，三种配置

--- a/chapter9/controllable-tts/README.md
+++ b/chapter9/controllable-tts/README.md
@@ -1,3 +1,121 @@
+## English
+
+# Experiment 9-5: Control-Marker-Driven Controllable TTS
+
+A runnable companion project for Experiment 9-5 of "Deep Understanding of AI Agents".
+
+Core idea: The main LLM's output is not just text, but also includes **control markers** (emotion/speech rate/style/pause/laughter, etc.); the execution layer parses these markers, maps them to corresponding timbre/style profiles in a **reference voice library**, and then synthesizes speech. This way, decisions about "where to pause and what tone to use" are delegated to the LLM. The same text, with different control markers, can synthesize speech with different styles, emotions, and rhythms.
+
+## Provider Adaptation (Important)
+
+Experiment 9-5 in the book uses **Fish Audio S1** for voice cloning: uses 3-10 seconds of reference audio for zero-shot cloning of the same timbre, builds a reference voice library covering emotion × speech rate × style, selects reference voices via control markers, and Fish Audio ensures **consistent timbre** across different reference voices with only changes in prosody and emotion.
+
+This environment lacks a usable Fish Audio key, so **OpenAI TTS** is used instead to demonstrate the **exact same concept**:
+
+| Book (Fish Audio) | This Project (OpenAI TTS) |
+| --- | --- |
+| Voice cloning ensures consistent timbre | Entire library uses a fixed `voice` (alloy), timbre unchanged |
+| Prosody/emotion of each reference voice | Each profile corresponds to a set of `instructions` style prompts |
+| Control markers select reference voice | Control markers parsed -> select `(emotion, speed, style)` profile |
+
+- Preferred model **`gpt-4o-mini-tts`**: Supports the `instructions` parameter, allowing precise control of emotion/speech rate/tone with a Chinese prompt, closest to the semantics of "control marker → stylized speech".
+- If the preferred model is unavailable, the code **automatically falls back to `tts-1`**: Does not support instructions, instead uses multiple voices + `speed` parameter + text-level pauses as an approximation.
+
+**Must use a direct OpenAI Key**: This experiment only uses the TTS speech synthesis endpoint (`gpt-4o-mini-tts` / `tts-1`). These audio endpoints are only available through direct OpenAI connection—OpenRouter only handles chat completions and has no audio synthesis endpoint, so it cannot fall back to `OPENROUTER_API_KEY`. Offline viewing of the voice library/marker mapping (`--list-voices` / `--dump-mapping`) does not require any key.
+
+> Limitation: OpenAI TTS cannot **natively generate** non-verbal sounds like laughter or sighs like Fish Audio can. This project approximates `<laugh>` / `[SIGH]` with emotion-matching onomatopoeia (e.g., "Haha," "Ahh—"), while `[PAUSE]`/`[THINKING]` and other pauses use ffmpeg to generate **real silence** that can be verified for duration by ffprobe.
+
+## Control Marker → TTS Parameter Mapping
+
+### State Markers (persist until changed by a similar marker)
+
+| Marker | Chinese Form | Effect |
+| --- | --- | --- |
+| `[EMO:neutral\|happy\|frustrated\|thinking]` | `[EMO=neutral\|happy\|frustrated\|thinking]` | Switch emotion |
+| `[SPEED:normal\|fast\|slow]` / `[SPEED:0.8x]` | `[SPEED=normal\|fast\|slow]` | Switch speech rate |
+| `[STYLE:formal\|casual]` | `[STYLE=formal\|casual]` | Switch tone |
+The three dimensions combine to form a profile in the reference voice library (e.g., `happy_fast_formal`), which is then assembled into an `instructions` prompt for `gpt-4o-mini-tts`.
+
+### Inline Markers (one-time events)
+
+| Marker | Effect |
+| --- | --- |
+| `[THINKING]` | Switch to "thinking/slow/formal" reference voice + insert 0.5s pause |
+| `[SEARCHING]` | Same as above, 0.4s pause (searching hesitation) |
+| `[PAUSE]` / `<pause>` / `[停顿]` | Insert 0.5s silence || `[BREATH]` / `<breath>` | Insert 0.4s breathing pause |
+| `[SIGH]` / `<sigh>` | Sigh onomatopoeia "Ahh—" + 0.3s pause |
+| `[LAUGH:small]` / `<laugh>` | Light laugh onomatopoeia "Haha," (cheerful tone) |
+| `<emphasis>…</emphasis>` / `[强调]…[/强调]` | Append "emphasize" prompt for the wrapped text |
+### Reference Voice Library
+
+`voice_library.py` generates **24 profiles** from the Cartesian product of emotion(4) × speech rate(3) × style(2), all with a fixed `voice=alloy` (consistent timbre), differing only in `instructions`. Can be viewed by running it standalone:
+
+```bash
+python voice_library.py
+```
+
+## Installation and Execution
+
+```bash
+pip install -r requirements.txt          # Requires ffmpeg/ffprobe installed on the system
+cp env.example .env                       # Fill in a valid OPENAI_API_KEY
+python demo.py                            # Generates output/*.mp3
+```
+
+`demo.py` does two things:
+
+1. **Comparison of three configurations** (as required by the book), using the same text with markers:
+   - `A_no_markers.mp3` No control markers (fluent but mechanical)
+   - `B_single_voice.mp3` Single reference voice (natural but emotionally monotone)
+   - `C_voice_library.mp3` Multiple reference voice library (switches emotion/speech rate/pause based on markers)
+2. **Same text / different control markers** → multiple different style audio files: `variant_*.mp3`.
+
+During execution, it prints the "control marker → parameter" parsing process for each audio file, along with ffprobe duration information.
+
+Common parameters (`python demo.py --help`):
+
+| Parameter | Effect |
+| --- | --- |
+| `--quick` | Only run the three-configuration comparison (A/B/C), skip the 5 style variants, reducing TTS calls and time |
+| `--text text` | Only synthesize this custom text (can embed control markers, e.g., `[emotion=happy][THINKING]…`) || `--emotion / --speed / --style` | Specify emotion/speech rate/tone for `--text` (equivalent to adding corresponding state markers before the text) |
+| `-o / --output path` | Output mp3 path for `--text` mode (default `output/custom.mp3`) |
+| `--list-voices` | **Offline** (no API key needed): Print the complete reference voice library (24 profiles and their instructions) |
+| `--dump-mapping` | **Offline** (no API key needed): Print the control marker → action mapping table, and demonstrate the parsing process on example text |
+
+## Example Expected Output (Real Excerpt)
+
+```
+Preferred model: gpt-4o-mini-tts (automatically falls back to tts-1 if unavailable)
+
+Comparison experiment: Same text with control markers, three configurations
+[EMO:happy][SPEED:fast]Great! Your order has been confirmed.[THINKING]Hmm, let me check the delivery time...[EMO:neutral][SPEED:normal]It is expected to arrive tomorrow afternoon.
+[C] Multiple reference voice library (parse control markers -> switch reference voice per segment + pauses)
+    -- Control marker parsing process --
+  [EMO:happy]            -> emotion = happy
+  [SPEED:fast]           -> speech rate = fast
+  [THINKING]             -> Switch to thinking/slow/formal reference voice
+  [THINKING] pause          -> Insert silence 500ms
+    -- Synthesis segments --
+    · [happy_fast_formal         ] gpt-4o-mini-tts  voice=alloy text='Great! Your order has been confirmed.'    · [Silence 500ms]
+    · [thinking_slow_formal      ] gpt-4o-mini-tts  voice=alloy text='Hmm, let me check the delivery time...'
+    · [neutral_normal_formal     ] gpt-4o-mini-tts  voice=alloy text='It is expected to arrive tomorrow afternoon.'  => output/C_voice_library.mp3  |  format_name=mp3  duration=11.324000  ...
+```
+
+Comparing the ffprobe durations of the three configurations reveals the difference: C (multiple reference voice library) is longer (approximately 11.3s) than A/B (approximately 8.5s) due to the inserted real silence pauses, and each segment uses a different `(emotion, speech rate, style)` profile. (Each run will actually call OpenAI TTS, so duration/byte count will have slight fluctuations.)
+
+## File Descriptions
+
+| File | Description |
+| --- | --- |
+| `voice_library.py` | Reference voice library + control dimension → instructions mapping |
+| `markup.py` | Control marker parser: text with markers → list of segments (speech/silence) |
+| `tts.py` | OpenAI TTS synthesis + ffmpeg silence generation/concatenation |
+| `demo.py` | Demo entry point, three-configuration comparison + style variants |
+
+---
+
+## 中文
+
 # 实验 9-5：控制标记驱动的可控 TTS
 
 《深入理解 AI Agent》实验 9-5 的可运行配套项目。

--- a/chapter9/end-to-end-speech/README.md
+++ b/chapter9/end-to-end-speech/README.md
@@ -71,15 +71,15 @@ Requires `ffprobe`/`ffplay` (for validation, listening to audio): `brew install 
 
 ## Example Expected Output (Real Excerpt)
 
-```
-Paradigm 1: End-to-End Speech Reasoning (backend=gpt-audio, model=gpt-audio)
+```text
+Paradigm 2: End-to-End Speech Reasoning (backend=gpt-audio, model=gpt-audio)
 Form: Audio in → Single model "listens→thinks→speaks" → Audio out (single call, no separate ASR/LLM/TTS stages)
 [Single Stage] End-to-End (listens→thinks→speaks, single model call)  |  Latency=7.21s
     Speech answer transcription (produced incidentally by the model, not an intermediate text stage): Let's calculate: Xiao Ming has 12 yuan, buys 3 pencils... finally has no money left.
     ffprobe validation: {'format': 'wav', 'duration(seconds)': 20.75, ...}
 End-to-End Total Latency (single model forward pass): 7.21s
 
-Paradigm 2 (Comparison Baseline): Cascaded Pipeline ASR → LLM → TTS
+Paradigm 1 (Comparison Baseline): Cascaded Pipeline ASR → LLM → TTS
 [Stage 1] ASR Speech Recognition  |  Model=whisper-1  |  Latency=1.35s
 [Stage 2] LLM Reasoning          |  Model=gpt-5.6-luna  |  Latency=1.92s
 [Stage 3] TTS Speech Synthesis   |  Model=tts-1  |  Latency=3.66s
@@ -95,7 +95,7 @@ End-to-End vs Cascaded: Real Latency Comparison
 
 For the same sentence "Alright, that's it then. I have no objections." (TTS synthesized, relatively flat emotion), the responses from the two paths:
 
-```
+```text
 [Stage 1] ASR Speech Recognition  |  whisper-1  → 「Alright, that's it then. I have no objections.」   ← The cascaded LLM only receives this plain text
 
 Responses from both paths to the same audio segment (allowing direct comparison of whether "how it was said" was heard):
@@ -202,15 +202,15 @@ CLI 全部参数见 `python demo.py --help`：`--task`、`--question`、`--audio
 
 ## 预期输出示例（真实节选）
 
-```
-范式一：端到端语音思考（后端=gpt-audio，模型=gpt-audio）
+```text
+范式二：端到端语音思考（后端=gpt-audio，模型=gpt-audio）
 形态：音频进 → 单模型「听→想→说」→ 音频出（一次调用，无独立 ASR/LLM/TTS 段）
 [单阶段] 端到端（听→想→说，单模型一次调用）  |  延迟=7.21s
     语音答案转写（模型顺带产出，非中间文本阶段）：咱们先算一下：小明有12块钱，买了3支铅笔……最后不剩钱了。
     ffprobe 校验：{'格式': 'wav', '时长(秒)': 20.75, ...}
 端到端总延迟（单模型一次前向）：7.21s
 
-范式二（对照基线）：级联流水线 ASR → LLM → TTS
+范式一（对照基线）：级联流水线 ASR → LLM → TTS
 [阶段 1] ASR 语音识别  |  模型=whisper-1  |  延迟=1.35s
 [阶段 2] LLM 思考      |  模型=gpt-5.6-luna  |  延迟=1.92s
 [阶段 3] TTS 语音合成  |  模型=tts-1  |  延迟=3.66s
@@ -226,7 +226,7 @@ CLI 全部参数见 `python demo.py --help`：`--task`、`--question`、`--audio
 
 同一句「行吧，那就这样吧，我没什么意见。」（TTS 合成，情感偏平），两条路的回答：
 
-```
+```text
 [阶段 1] ASR 语音识别  |  whisper-1  → 「行吧,那就这样吧,我没什么意见」   ← 级联 LLM 只拿得到这行纯文本
 
 两条路对同一段音频的回答（可直观对比是否「听到了怎么说」）：

--- a/chapter9/end-to-end-speech/README.md
+++ b/chapter9/end-to-end-speech/README.md
@@ -1,3 +1,136 @@
+## English
+
+# Experiment 9-4 Companion: End-to-End Speech Reasoning vs. Cascaded Pipeline
+
+Corresponds to Chapter 9 of *Deep Understanding of AI Agents*, **Experiment 9-4 ★★★: Using Step-Audio R1 for End-to-End Speech Reasoning**.
+
+## Purpose
+
+The core of Experiment 9-4 in the book is the **end-to-end speech reasoning model Step-Audio R1**: a single model that directly "listens → thinks → speaks", combining ASR, LLM, and TTS into one. It transmits paralinguistic information (emotion, tone, speech rate, ambient sound) directly in the latent space, resulting in lower latency and more natural prosody.
+
+Since Step-Audio R1 has no public endpoint and requires multi-GPU deployment, it is difficult for readers to run directly. Therefore, this demo uses OpenAI's speech-to-speech model `gpt-audio` as a **real, runnable end-to-end representative**: it also takes "audio in → single model → audio out", returning a spoken answer and its transcription in a single call, with **no** separate ASR/LLM/TTS stages in between. The demo lets you **compare the same problem** across real end-to-end and cascaded pipelines, allowing you to directly observe the differences in **latency** and **information loss (tone, paralinguistics)**—the latencies for both paths are measured in real-time during this run, and both output audio files are validated with `ffprobe`.
+
+The demo provides two task types (`--task`), corresponding to the two comparison axes in the book:
+
+- **`math` (default)**: Verbally presented math problems (Spoken-MQA style). The answer depends only on "what was said," so the accuracy of cascaded and end-to-end approaches is comparable (corresponding to the "Self-Cascading" section in 9.3). Therefore, this task primarily compares **latency**.
+- **`paralinguistic`**: A phrase where "the answer depends on how it is said." In the cascaded pipeline, ASR compresses speech into plain text, so the LLM only receives the literal words. Any emotional judgment is **Textual Surrogate Reasoning** (Section 9.3, "The Problem of Textual Surrogate Reasoning")—guessing emotion from vocabulary. The end-to-end model, however, directly hears acoustic features (speech rate, pitch) and responds accordingly. This task compares the **information loss** dimension, which is the core problem that **MGRD (Modality-Grounded Reasoning Distillation)** in the book aims to solve.
+
+## Principle: Three Speech Paradigms
+
+The book categorizes speech architectures into three paradigms (chapter9.md "Three Paradigms of Speech Architecture"):
+
+| Paradigm | Structure | Characteristics |
+|----------|-----------|-----------------|
+| **Cascaded** | ASR → LLM → TTS (three independent models in series) | Clear modules, independently tunable, good interpretability; but latency accumulates serially, models connect via plain text interfaces, and emotion/speech rate/tone/ambient sound are almost entirely lost at the interface |
+| **End-to-End Omni** | Single model "listens→thinks→speaks" (Step-Audio R1, gpt-audio, etc.) | Lower latency, preserves paralinguistic information, natural prosody, can "think while speaking"; cost is large training data requirements and poor interpretability. **Still assumes "turn-taking," using VAD to segment turns** |
+| **Full-Duplex** | Single model listens and speaks simultaneously, removing the "turn-taking" assumption (Moshi, GPT-Live) | Continuously processes input and output simultaneously, making decisions multiple times per second about whether to speak/listen/stop/interrupt; this demo does not cover this |
+
+This demo focuses on the **comparison** between the first two paradigms: End-to-End (Paradigm 2) vs. Cascaded (Paradigm 1).
+
+**Step-Audio R1 is a representative of Paradigm 2 that internalizes "reasoning" within a single model**: it truly reasons based on acoustic features through MGRD (Modality-Grounded Reasoning Distillation) and achieves "thinking while speaking" through the MPS dual-brain architecture. `gpt-audio` is a representative of the same paradigm (audio in, single model, audio out) that readers can directly call.
+
+## Running
+
+```bash
+# 1. Install dependencies
+pip install -r requirements.txt
+
+# 2. Configure Key
+cp env.example .env
+# Edit .env, fill in a valid OPENAI_API_KEY (requires access to gpt-audio / whisper-1 / tts-1).
+# Audio endpoints (end-to-end gpt-audio, cascaded ASR/TTS) are only available via direct OpenAI connection—OpenRouter has no audio endpoints.
+# Therefore, this experiment requires a direct OpenAI API Key. Optional: additionally configure OPENROUTER_API_KEY, then the plain-text
+# LLM reasoning in the cascaded pipeline will automatically switch to OpenRouter's gpt-5.6-luna (bypassing organizational identity verification for direct gpt-5.6* connections).
+
+# 3. Run (default: math task, runs both end-to-end + cascaded on the same problem, prints real latency comparison)
+python demo.py
+
+# Paralinguistic task: highlights the advantage of end-to-end over cascaded (end-to-end hears tone, cascaded only sees text)
+python demo.py --task paralinguistic
+
+# Use a real emotional recording as input (better demonstrates tonal differences than TTS synthesis; mutually exclusive with --question)
+python demo.py --task paralinguistic --audio-input my_voice.wav
+
+# Run only end-to-end / custom question / change voice / change output directory
+python demo.py --skip-cascade
+python demo.py --question "The high-speed train from Beijing to Shanghai takes 4 hours. If I depart at 9:00, what time will I arrive?"
+python demo.py --voice nova --output-dir out
+python demo.py --help
+
+# Switch to a self-deployed real Step-Audio R1 (overrides environment variables)
+python demo.py --step-audio-endpoint http://localhost:8000/v1/audio/chat
+
+# 4. (Optional) Listen to the generated speech answers
+ffplay audio/answer_end_to_end.wav   # End-to-end
+ffplay audio/answer_cascade.mp3      # Cascaded
+```
+
+See all CLI parameters with `python demo.py --help`: `--task`, `--question`, `--audio-input`, `--e2e-model`, `--step-audio-endpoint`, `--voice`, `--output-dir`, `--skip-cascade`. The default behavior (`python demo.py` runs the math task, end-to-end + cascaded comparison) remains consistent with the previous version.
+
+Requires `ffprobe`/`ffplay` (for validation, listening to audio): `brew install ffmpeg` (macOS).
+
+## Example Expected Output (Real Excerpt)
+
+```
+Paradigm 1: End-to-End Speech Reasoning (backend=gpt-audio, model=gpt-audio)
+Form: Audio in → Single model "listens→thinks→speaks" → Audio out (single call, no separate ASR/LLM/TTS stages)
+[Single Stage] End-to-End (listens→thinks→speaks, single model call)  |  Latency=7.21s
+    Speech answer transcription (produced incidentally by the model, not an intermediate text stage): Let's calculate: Xiao Ming has 12 yuan, buys 3 pencils... finally has no money left.
+    ffprobe validation: {'format': 'wav', 'duration(seconds)': 20.75, ...}
+End-to-End Total Latency (single model forward pass): 7.21s
+
+Paradigm 2 (Comparison Baseline): Cascaded Pipeline ASR → LLM → TTS
+[Stage 1] ASR Speech Recognition  |  Model=whisper-1  |  Latency=1.35s
+[Stage 2] LLM Reasoning          |  Model=gpt-5.6-luna  |  Latency=1.92s
+[Stage 3] TTS Speech Synthesis   |  Model=tts-1  |  Latency=3.66s
+Cascaded Total Latency (serial sum of stages): 6.94s
+
+End-to-End vs Cascaded: Real Latency Comparison
+【1】Measured Total Latency  End-to-End 7.21s; Cascaded ASR(1.35)+LLM(1.92)+TTS(3.66)=6.94s
+【3】Table 9-1 from the book (cited from Step-Audio R1 paper, not produced by this demo)
+    MPS Speak-First 92.8% / Full TBS 93.0% ……
+```
+
+### Real Excerpt from Paralinguistic Task (`--task paralinguistic`, one real run)
+
+For the same sentence "Alright, that's it then. I have no objections." (TTS synthesized, relatively flat emotion), the responses from the two paths:
+
+```
+[Stage 1] ASR Speech Recognition  |  whisper-1  → 「Alright, that's it then. I have no objections.」   ← The cascaded LLM only receives this plain text
+
+Responses from both paths to the same audio segment (allowing direct comparison of whether "how it was said" was heard):
+    Cascaded (relying only on ASR text, Textual Surrogate Reasoning) → "It sounds like you're a bit resigned, maybe not entirely satisfied with this decision. ..."
+    End-to-End (directly hearing acoustic features)        → "It sounds like you're a bit resigned, your speech rate isn't fast, and your pitch is quite steady. ..."
+```
+
+The difference is clear: **Cascaded** can only guess resignation from the literal words "no objections" and cannot cite any acoustic basis (the "Textual Surrogate Reasoning" from the book); **End-to-End** directly references acoustic features like "speech rate isn't fast, pitch is quite steady"—this is precisely what MGRD in the book aims to teach models: "thinking with your ears." Note that the default input is TTS synthesized, with relatively flat emotion, which weakens the difference; using `--audio-input` to feed a real emotional recording will make the contrast more apparent.
+
+**Regarding Table 9-1**: The Spoken-MQA / URO-Bench scores printed in the demo are **cited from the Step-Audio R1 paper** (reproduced as Table 9-1 in the book), not generated by this demo—the only real outputs from this demo are the measured latencies and the two real audio files. Latency numbers fluctuate with network conditions and OpenAI load; `gpt-audio` produces the entire audio segment in a single forward pass. A truly streaming end-to-end model (like Step-Audio R1's MPS) can further reduce **time-to-first-token** by "thinking while speaking," a benefit not captured by this demo's total segment latency.
+
+## How to Adapt for Real Step-Audio R1
+
+The backend for the end-to-end path is switchable:
+
+- **Default**: `STEP_AUDIO_ENDPOINT` not configured → uses `gpt-audio` (model name can be overridden with `E2E_MODEL`).
+- **Real Step-Audio R1**: After deploying on multi-GPU, write the service address into `STEP_AUDIO_ENDPOINT`, and the demo's end-to-end path will switch to it. `speech_model.py`'s `EndToEndSpeechModel._run_step_audio` provides the call skeleton for "upload audio, retrieve audio"; request bodies vary by deployment scheme (vLLM / custom HTTP service), so adapt as needed.
+
+## Limitations
+
+- `gpt-audio` is a **representative** of the end-to-end paradigm, not Step-Audio R1 itself: it does not expose MPS's streaming time-to-first-token, nor does it have the paralinguistic benchmark scores reported in the Step-Audio R1 paper. Table 9-1 is therefore a **citation**, not a reproduction.
+- The demo constructs input using "text TTS → input speech" solely for a demonstration loop; in real scenarios, input comes from the user's microphone, carrying richer paralinguistic information, and the loss in the cascaded pipeline is more pronounced.
+- The relative latency of end-to-end vs. cascaded will fluctuate with network conditions, model load, and answer length; a single run does not represent a stable conclusion. The paradigm difference (whether paralinguistic information is preserved) is a more robust dimension for comparison.
+
+## Files
+
+- `demo.py`: Runnable main program (`python demo.py`), runs both end-to-end + cascaded on the same problem and prints a real comparison.
+- `speech_model.py`: `EndToEndSpeechModel` (gpt-audio / switchable to Step-Audio R1) and `CascadedSpeechModel` (whisper-1 → gpt-5.6-luna → tts-1).
+- `requirements.txt` / `env.example`: Dependencies and environment variable template.
+- `audio/`: Input/output audio generated at runtime (ignored in `.gitignore`).
+
+---
+
+## 中文
+
 # 实验 9-4 配套：端到端语音思考 vs 级联流水线
 
 对应《深入理解 AI Agent》第 9 章 **实验 9-4 ★★★：使用 Step-Audio R1 实现端到端语音思考**。

--- a/chapter9/end-to-end-speech/demo.py
+++ b/chapter9/end-to-end-speech/demo.py
@@ -123,7 +123,7 @@ def ffprobe_info(audio_path: str) -> dict:
 def print_e2e_result(result: PipelineResult, backend: str) -> None:
     s = result.stages[0]
     print(hr("="))
-    print(f"范式一：端到端语音思考（后端={backend}，模型={s.model}）")
+    print(f"范式二：端到端语音思考（后端={backend}，模型={s.model}）")
     print(hr("="))
     print("形态：音频进 → 单模型「听→想→说」→ 音频出（一次调用，无独立 ASR/LLM/TTS 段）")
     print(f"\n[单阶段] {s.name}  |  延迟={s.latency_s:.2f}s")
@@ -136,7 +136,7 @@ def print_e2e_result(result: PipelineResult, backend: str) -> None:
 
 def print_cascade_result(result: PipelineResult) -> None:
     print("\n" + hr("="))
-    print(f"范式二（对照基线）：级联流水线 ASR → LLM → TTS")
+    print(f"范式一（对照基线）：级联流水线 ASR → LLM → TTS")
     print(hr("="))
     for i, s in enumerate(result.stages, 1):
         print(f"\n[阶段 {i}] {s.name}  |  模型={s.model}  |  延迟={s.latency_s:.2f}s")

--- a/chapter9/live-audio/README.md
+++ b/chapter9/live-audio/README.md
@@ -385,7 +385,7 @@ MIT
 - **提供商工厂**：支持动态创建和切换提供商
 
 ### 数据流
-```
+```text
 用户语音 → WebSocket → 后端 VAD → 多提供商 STT → 多提供商 LLM → TTS → 音频响应
 ```
 
@@ -427,7 +427,7 @@ sudo apt install ffmpeg
 
 ## 项目结构
 
-```
+```text
 /backend
 - server.js: 集成提供商的主 WebSocket 服务器
 - config.js: 多提供商配置设置
@@ -445,7 +445,7 @@ sudo apt install ffmpeg
 - package.json: 后端依赖和脚本
 ```
 
-```
+```text
 /frontend
 - pages/: Next.js 页面
   - index.tsx: 主应用界面

--- a/chapter9/live-audio/README.md
+++ b/chapter9/live-audio/README.md
@@ -1,3 +1,5 @@
+## English
+
 # Live Voice Chat Demo
 
 A real-time voice chat demo featuring speech-to-text, AI conversation, and text-to-speech capabilities. The application supports multiple AI service providers and provides a seamless conversational experience with minimal latency.
@@ -331,3 +333,340 @@ For provider configuration, see [`backend/config.js.example`](backend/config.js.
 
 MIT
 
+---
+
+## 中文
+
+# 实时语音聊天演示
+
+一个具备语音转文本、AI 对话和文本转语音能力的实时语音聊天演示。该应用支持多家 AI 服务提供商，以极低延迟提供流畅的对话体验。
+
+> 这是《深入理解 AI Agent》第 9 章 **实验 9-1「构建传统语音 Agent」**的配套代码。它实现了书中讨论的**级联式**语音流水线（VAD → ASR → LLM → TTS）：前端采集麦克风音频并通过 WebSocket 以流的形式传输；后端运行 Silero VAD，通过约 500 ms 的静音检测语音结束，随后将话语依次交给可插拔的 ASR、LLM 和 TTS 提供商，并将合成音频流式返回播放。
+
+## 功能特性
+
+- 🎤 采用语音活动检测（VAD）的实时语音输入
+- 🤖 支持**多家提供商**的 AI 对话
+- 🔊 文本转语音合成
+- ⚡ 低延迟音频流
+- 📊 实时延迟监控与日志记录
+- 🎯 基于 WebSocket 的通信
+- 🔧 可灵活选择 ASR、LLM 和 TTS 服务提供商
+
+## 支持的 AI 提供商
+
+### ASR（自动语音识别）
+- **OpenAI Whisper**：准确率高，语言支持出色
+- **SenseVoice**（通过 Siliconflow）：低延迟、经济实惠、自动检测语言
+
+### LLM（大语言模型）
+- **OpenAI GPT-4o**：推理能力出色、性能均衡
+- **OpenRouter GPT-4o**：无地域限制、统一接口
+- **OpenRouter Gemini**：响应迅速，针对实时聊天优化
+- **ARK Doubao**：在中国低延迟，针对中文优化
+
+### TTS（文本转语音）
+- **CosyVoice2**（通过 Siliconflow）：自然语音合成，提供多种系统音色
+
+## 架构概览
+
+系统采用前后端架构，具备实时音频处理和**可插拔的提供商架构**：
+
+### 前端（Next.js）
+- **音频采集**：使用 Web Audio API 采集麦克风输入
+- **音频处理**：在客户端处理音频并将其流式传输至后端
+- **WebSocket 通信**：向后端发送音频流并接收响应
+- **音频播放**：播放后端返回的 TTS 音频响应
+
+### 后端（Node.js）
+- **WebSocket 服务器**：处理实时音频流和客户端连接
+- **语音活动检测**：在服务端运行 Silero VAD，以高准确率检测语音边界
+- **多提供商支持**：灵活集成 ASR、LLM 和 TTS 提供商
+- **提供商工厂**：支持动态创建和切换提供商
+
+### 数据流
+```
+用户语音 → WebSocket → 后端 VAD → 多提供商 STT → 多提供商 LLM → TTS → 音频响应
+```
+
+### 端口
+
+| 组件 | 端口 | 说明 |
+|-----------|------|-------|
+| 后端（WebSocket 服务器） | **8848** | 由 `backend/config.js` 中的 `LISTEN_PORT` 设置。前端连接到 `ws://localhost:8848`。 |
+| 前端（Next.js 开发服务器） | **3000** | 在浏览器中打开 http://localhost:3000。 |
+
+前端从 `WEBSOCKET_PORT` 环境变量获取后端端口（参见 `frontend/.env.example`）。它必须与后端的 `LISTEN_PORT` 一致。
+
+## 前置条件
+
+- Node.js（v16 或更高版本）
+- npm 或 yarn
+- **FFmpeg**——音频处理和格式转换所必需
+- **Google Chrome**（推荐）——实时音频的性能和兼容性最佳
+  - 不推荐：Safari、Edge 或其他浏览器，因为 WebAudio API 存在限制
+- 支持的提供商所需的 **API key**（参见“配置”一节）
+
+### 安装 FFmpeg
+
+#### macOS（使用 Homebrew）
+```bash
+brew install ffmpeg
+```
+
+#### Ubuntu/Debian
+```bash
+sudo apt update
+sudo apt install ffmpeg
+```
+
+#### Windows
+- 从 https://ffmpeg.org/download.html 下载
+- 或使用 Chocolatey：`choco install ffmpeg`
+- 确保 `ffmpeg` 位于 PATH 中
+
+## 项目结构
+
+```
+/backend
+- server.js: 集成提供商的主 WebSocket 服务器
+- config.js: 多提供商配置设置
+- utils/
+  - providers/
+    - asrProviders.js: ASR 提供商实现（OpenAI、Siliconflow）
+    - llmProviders.js: LLM 提供商实现（OpenAI、OpenRouter、ARK）
+  - vad.js: 语音活动检测实现
+  - speechToText.js: 感知提供商的 STT 服务
+  - textProcessor.js: 文本预处理工具
+- tests/
+  - provider-tests.js: 完整的提供商测试
+- run-tests.js: 带环境校验的测试运行器
+- utils/providers/: 提供商配置（ASR / LLM / TTS）
+- package.json: 后端依赖和脚本
+```
+
+```
+/frontend
+- pages/: Next.js 页面
+  - index.tsx: 主应用界面
+- components/: 可复用 UI 组件
+- public/: 静态资源
+  - audioWorklet.js: 音频处理与 VAD 实现
+- next.config.js: Next.js 配置
+- tailwind.config.js: Tailwind CSS 设置
+- package.json: 前端依赖和脚本
+```
+
+## 安装
+
+1. 克隆仓库
+2. 安装后端依赖：
+   ```bash
+   cd backend && npm install
+   ```
+3. 安装前端依赖：
+   ```bash
+   cd frontend && npm install
+   ```
+4. 下载 Silero VAD 模型（本仓库已在 `backend/models/silero_vad.onnx` 包含该文件；仅在文件缺失时需要）：
+   ```bash
+   cd backend/models
+   wget https://huggingface.co/deepghs/silero-vad-onnx/resolve/main/silero_vad.onnx
+   ```
+5. 配置前端的 WebSocket 端口（省略时默认为 8848）：
+   ```bash
+   cd frontend && cp .env.example .env   # 将 WEBSOCKET_PORT=8848 设为与后端一致
+   ```
+
+安装完成后，无需麦克风或浏览器即可检查环境（Node 版本、FFmpeg、VAD 模型和提供商 key）：
+
+```bash
+cd backend && npm run check    # 或：node check-setup.js
+```
+
+该命令会打印哪些前置条件已经满足，以及所选提供商是否已设置 API key。只有在缺少硬性前置条件（Node < 16、缺少 FFmpeg 或缺少 VAD 模型）时才会以非零状态退出。
+
+## 配置
+
+### 基于提供商的配置
+
+系统现在支持**多家 AI 服务提供商**，以获得最大的灵活性。ASR、LLM 和 TTS 服务可以自由混合搭配不同提供商。
+
+### 1. 设置环境变量
+
+将 API key 设置为环境变量：
+
+```bash
+# OpenAI 服务所必需
+export OPENAI_API_KEY="your-openai-api-key"
+
+# OpenRouter 服务所必需
+export OPENROUTER_API_KEY="your-openrouter-api-key"
+
+# ARK（Doubao）服务所必需
+export ARK_API_KEY="your-ark-api-key"
+
+# Siliconflow 服务（ASR 和 TTS）所必需
+export SILICONFLOW_API_KEY="your-siliconflow-api-key"
+
+# 留作将来使用
+export ANTHROPIC_API_KEY="your-anthropic-api-key"
+```
+
+### 2. 选择提供商
+
+1. 本仓库已经提供可直接编辑的 `backend/config.js`。如果该文件缺失（例如全新检出时被忽略），请先复制示例：
+   ```bash
+   cp backend/config.js.example backend/config.js
+   ```
+
+2. 编辑 `backend/config.js`，选择偏好的提供商：
+   ```javascript
+   const config = {
+     // 提供商选择——选择偏好的提供商
+     ASR_PROVIDER: 'siliconflow',      // 'openai'（whisper-1）或 'siliconflow'（SenseVoice）
+     LLM_PROVIDER: 'openrouter',       // 'openrouter'（gpt-5.6-luna，默认）、'openai'、'openrouter-gemini'、'ark'
+     TTS_PROVIDER: 'siliconflow',      // 'siliconflow'（CosyVoice2）
+
+     // API Key（从环境变量加载）
+     OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+     OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+     ARK_API_KEY: process.env.ARK_API_KEY,
+     SILICONFLOW_API_KEY: process.env.SILICONFLOW_API_KEY,
+
+     // ……其他配置选项
+   };
+   ```
+
+### 3. 推荐的提供商组合
+
+#### 默认 / 推荐（只要有 OpenRouter key 即可在任何地方使用）
+```javascript
+ASR_PROVIDER: 'siliconflow',      // SenseVoice
+LLM_PROVIDER: 'openrouter',       // 通过 OpenRouter 使用 openai/gpt-5.6-luna（避免 gpt-5.6* 组织验证）
+TTS_PROVIDER: 'siliconflow',      // CosyVoice2
+```
+
+#### 实时性能优先（在中国低延迟）
+```javascript
+ASR_PROVIDER: 'siliconflow',      // SenseVoice
+LLM_PROVIDER: 'ark',              // Doubao（在中国速度快）；也可用 'openrouter' 运行 gpt-5.6-luna
+TTS_PROVIDER: 'siliconflow',      // CosyVoice2
+```
+
+#### 准确率优先
+```javascript
+ASR_PROVIDER: 'openai',           // 高准确率的 Whisper
+LLM_PROVIDER: 'openrouter',       // 通过 OpenRouter 使用 openai/gpt-5.6-luna
+TTS_PROVIDER: 'siliconflow'       // CosyVoice2
+```
+
+### 4. API Key 要求
+
+只需配置计划使用的提供商所需的 API key：
+
+| 提供商 | ASR | LLM | TTS | 所需 API Key |
+|----------|-----|-----|-----|------------------|
+| OpenAI | ✅ Whisper | ✅ gpt-5.6-luna | ❌ | `OPENAI_API_KEY` |
+| OpenRouter | ❌ | ✅ gpt-5.6-luna、Gemini | ❌ | `OPENROUTER_API_KEY` |
+| ARK（Doubao） | ❌ | ✅ Doubao | ❌ | `ARK_API_KEY` |
+| Siliconflow | ✅ SenseVoice | ❌ | ✅ CosyVoice2 | `SILICONFLOW_API_KEY` |
+
+### 5. 配置校验
+
+系统包含完整的校验与测试工具：
+
+```bash
+# 测试所有已配置的提供商
+npm run test:providers
+
+# 运行带环境校验的完整测试套件
+node run-tests.js
+```
+
+### 旧版配置支持
+
+系统继续向后兼容先前的硬编码配置格式，但强烈建议使用新的提供商选择机制，以获得更好的灵活性。
+
+## 使用方法
+
+1. **设置 API key**（参见“配置”一节）
+
+2. 在 `backend/config.js` 中**配置偏好的提供商**
+
+3. （可选）**验证配置**：`cd backend && npm run check`
+
+4. 启动后端服务器（WebSocket 服务器使用端口 **8848**）：
+   ```bash
+   cd backend && npm start
+   ```
+   此时应看到 `Server is running on 0.0.0.0:8848`。
+
+5. 启动前端开发服务器（使用端口 **3000**）：
+   ```bash
+   cd frontend && npm run dev
+   ```
+   此时应看到 `Server is running on 0.0.0.0:3000`。
+
+6. 在浏览器中打开 http://localhost:3000（推荐 Chrome）
+
+7. 点击“Start Recording”并授予麦克风权限，开始对话
+
+**预期行为**：说话结束后，后端检测约 500 ms 的静音（VAD），转录语音（ASR），以流的形式生成 LLM 回复，再将其合成为自动播放的音频（TTS）。屏幕日志面板会显示各阶段延迟（WebSocket RTT、转录、LLM、TTS）。如果在助手说话时再次开口，播放会被打断。
+
+## 测试
+
+### 提供商测试
+
+测试各个提供商和所有组合：
+
+```bash
+cd backend
+
+# 使用 API key 测试所有提供商
+node run-tests.js
+
+# 仅测试指定提供商
+npm run test:providers
+
+# 如有需要，安装测试依赖
+npm install
+```
+
+测试套件会自动跳过未配置 API key 的提供商。
+
+### 测试覆盖范围
+
+- ✅ ASR 提供商功能（OpenAI Whisper、SenseVoice）
+- ✅ LLM 提供商功能（OpenAI、OpenRouter GPT-4o、OpenRouter Gemini、ARK Doubao）
+- ✅ TTS 提供商功能（通过 Siliconflow 使用 CosyVoice2）
+- ✅ 所有提供商组合（8 种 ASR+LLM 组合）
+- ✅ 动态切换提供商
+- ✅ 错误处理和回退机制
+
+## 故障排查
+
+### 常见问题
+
+1. **缺少 API Key**：确保已经设置所需的环境变量
+2. **找不到 FFmpeg**：确保 FFmpeg 已安装且位于系统 PATH 中
+   - 使用 `ffmpeg -version` 测试
+   - 如果找不到，请参阅上面的 FFmpeg 安装说明
+3. **网络问题**：检查与 API 端点的连通性
+4. **速率限制**：考虑切换提供商或实现重试逻辑
+5. **地域限制**：使用 OpenRouter 获得全球访问能力
+6. **ONNX Runtime 问题**：后端使用 ONNX Runtime 进行语音活动检测
+   - 通常会由 `onnxruntime-node` 包自动解决
+   - 在某些系统上，可能需要额外的系统库
+
+### 性能优化
+
+- **低延迟**：使用 Siliconflow ASR + OpenRouter Gemini
+- **高准确率**：使用 OpenAI ASR + OpenAI LLM
+- **中国部署**：使用 Siliconflow ASR + ARK LLM
+
+提供商配置请参见 [`backend/config.js.example`](backend/config.js.example)，实现代码位于 [`backend/utils/providers/`](backend/utils/providers)。
+
+## 许可证
+
+MIT

--- a/chapter9/phone-agent/README.md
+++ b/chapter9/phone-agent/README.md
@@ -14,7 +14,7 @@ The top layer is a standard **ReAct Agent**: given a natural language task (e.g.
 
 A production-grade phone voice API (such as the [PineClaw Voice API](https://pineclaw.com/), developed by the author's team) encapsulates an entire phone call as **a single tool call**:
 
-```
+```python
 record = make_phone_call(phone_number, goal, context)
 ```
 
@@ -111,7 +111,7 @@ There are two independent layers of simulation in this experiment; do not confus
 
 ## Expected Output Example (Real Excerpt)
 
-```
+```text
 [Agent calls tool make_phone_call] Parameters:
     phone_number = 10010
     goal         = Inquire about the reason for the extra 50 yuan on this month's broadband bill and request a refund for the erroneous charge.
@@ -171,7 +171,7 @@ Note: The IVR menu, employee ID, confirmation number, etc., are **simulated scen
 生产级电话语音 API（如 [PineClaw Voice API](https://pineclaw.com/)，作者团队开发）
 把一整通电话封装成**一次工具调用**：
 
-```
+```python
 record = make_phone_call(phone_number, goal, context)
 ```
 
@@ -279,7 +279,7 @@ python demo.py --help                                          # 查看全部参
 
 ## 预期输出示例（真实节选）
 
-```
+```text
 [Agent 调用工具 make_phone_call] 入参:
     phone_number = 10010
     goal         = 查询本月宽带账单多扣的50元原因，并要求处理误扣。

--- a/chapter9/phone-agent/README.md
+++ b/chapter9/phone-agent/README.md
@@ -1,3 +1,156 @@
+## English
+
+# Experiment 9-2: Building a Phone Agent with the PineClaw Voice API
+
+Accompanying Chapter 9, Experiment 9-2 of "Deep Understanding of AI Agents".
+
+## Objective
+
+Many real-world agent tasks require **making actual phone calls**—contacting customer service to negotiate a bill, booking a restaurant, or confirming an order. This experiment demonstrates an important application direction for voice agents: **The agent can not only engage in voice conversations with users but also interact with the outside world via phone calls on the user's behalf**.
+
+The top layer is a standard **ReAct Agent**: given a natural language task (e.g., "Call the broadband customer service, ask why my bill was overcharged by 50 yuan this month, and request an explanation"), it figures out the number to dial, the call goal, and the context, invokes the `make_phone_call` tool to complete the entire call, reads the returned **structured call record**, asks follow-up questions or redials if necessary, and finally reports the result to the user.
+
+## Abstraction of the Phone Voice API
+
+A production-grade phone voice API (such as the [PineClaw Voice API](https://pineclaw.com/), developed by the author's team) encapsulates an entire phone call as **a single tool call**:
+
+```
+record = make_phone_call(phone_number, goal, context)
+```
+
+You only provide three things—**number, goal, context**—and its voice agent automatically handles:
+
+- **Dialing**: Connecting to the callee;
+- **IVR Navigation**: Handling menu prompts like "Press 1 for billing, press 0 for an operator";
+- **Multi-turn Conversation**: Negotiating, asking follow-ups, and confirming key information around the goal once connected to a human;
+- **Transcription**: Converting the entire call into text.
+
+Finally, it returns a **structured call record**, not a raw audio recording. This is precisely why it can fit into a ReAct loop: the agent receives structured fields (whether the goal was achieved, extracted key information, turn-by-turn transcript) and can make decisions and report based on them directly. The shape of the return body in this experiment (see `CallRecord` in `pine_voice.py`):
+
+| Field | Description |
+| --- | --- |
+| `call_id` | Unique call ID |
+| `phone_number` / `goal` | Phone number and goal of this call |
+| `status` / `goal_achieved` | Call status / whether the goal was achieved |
+| `duration_seconds` | Call duration |
+| `summary` | One-sentence call summary |
+| `key_fields` | Extracted key information (deduction reason / amount / confirmation number / time…) |
+| `transcript` | Turn-by-turn conversation `[{speaker, text}, ...]` |
+| `follow_up_needed` / `follow_up_reason` | Whether a follow-up is needed and the reason |
+
+## About the Mock (Important)
+
+The real PineClaw Voice API requires a `PINECLAW_API_KEY` and will dial real phone numbers. To facilitate offline execution, this experiment **uses a local mock client instead of the real API** (`pine_voice.py`):
+
+- It **does not touch the real phone network** and **does not require a PineClaw key**;
+- Internally, `make_phone_call` uses **OpenAI to play the role of the callee**—first acting as an automated IVR voice menu, then as a human customer service agent after being "transferred"—engaging in a **multi-turn conversation** (simulating IVR navigation + customer service response) with the outgoing voice agent, then summarizing the transcript into the structured record shown in the table above;
+- The key point: **The mock client has exactly the same input/output contract as the real API**, so the code of the upper-layer ReAct Agent requires almost no changes when switching to the real PineClaw SDK.
+
+Therefore, the "deduction reason," "confirmation number," etc., appearing in this experiment are **simulated scenarios fabricated on the fly by the model**, used only to demonstrate the data flow and do not represent any real calls.
+
+### Real Integration with PineClaw
+
+Simply replace the call to the mock `make_phone_call` in `agent.py` with the real SDK; the rest of the logic remains unchanged:
+
+```python
+# pip install pine-voice
+from pine_voice import PineVoiceClient   # Real SDK (illustrative)
+
+client = PineVoiceClient(api_key=os.environ["PINECLAW_API_KEY"])
+
+def make_phone_call(phone_number, goal, context=""):
+    call = client.calls.create(to=phone_number, goal=goal, context=context)
+    result = call.wait()          # Blocks until the call ends (could be minutes to hours)
+    return result.to_dict()       # Returns a structured call record of the same shape
+```
+
+For real usage, please refer to the official PineClaw documentation; it is recommended to first dial **your own phone** to verify connectivity.
+
+## Running
+
+```bash
+cd chapter9/phone-agent
+pip install -r requirements.txt
+
+cp env.example .env
+# Edit .env, fill in OPENROUTER_API_KEY or OPENAI_API_KEY (at least one)
+
+python demo.py
+python demo.py --task "Call the restaurant to book a table for 4 at 7 PM tonight"   # Custom phone task
+python demo.py --dry-run                                       # Run offline, no API Key required
+python demo.py --help                                          # View all parameters
+```
+
+Command-line arguments (`python demo.py --help` has Chinese descriptions):
+
+| Argument | Description |
+| --- | --- |
+| `--task` | Custom phone task (natural language). Defaults to the broadband bill example from the book |
+| `--phone` | Optional: The callee's phone number. Provided as known info to the agent (used directly as the callee number in dry-run mode) |
+| `--goal` | Optional: A clear call goal. Provided as known info to the agent (used directly as the call goal in dry-run mode) |
+| `--model` | Optional: Override the model (defaults to `OPENAI_MODEL`, i.e., `gpt-5.6-luna`) |
+| `--dry-run` | **Offline script mode**: No internet connection, no API Key required, only demonstrates the shape of the ReAct loop and data contract |
+
+`demo.py` will actually call OpenAI (unless `--dry-run` is added) and print three sections:
+(a) The ReAct Agent's trace (thinking + initiating `make_phone_call`);
+(b) The returned structured call record (multi-turn transcript + whether the goal was achieved + key fields);
+(c) The agent's final report to the user based on the call result.
+
+> **Model and Fallback**: The default chat model is `gpt-5.6-luna`. The resolution priority is
+> `OPENAI_API_KEY` (optionally `OPENAI_BASE_URL` pointing to a compatible gateway, such as Moonshot `kimi-k3` / Volcano Ark)
+> \> `OPENROUTER_API_KEY` (automatically maps the model to `openai/gpt-5.6-luna` etc. in `provider/model` format).
+> Since `gpt-5.6*` requires organizational real-name authentication for direct connection to OpenAI, **OpenRouter is recommended**; just fill in
+> `OPENROUTER_API_KEY` in `.env` (do not set `OPENAI_API_KEY` in this case, otherwise direct connection will take priority).
+
+### Difference Between the Two Levels of "Mock"
+
+There are two independent layers of simulation in this experiment; do not confuse them:
+
+- **Default (mock)**: `pine_voice.py` replaces the real **phone network**, but the conversation between the ReAct Agent and the callee is still **generated in real-time by OpenAI**—so an `OPENAI_API_KEY` is required, and each conversation/field will be different.
+- **`--dry-run` (offline script)**: The LLM is not called at all; `make_phone_call` directly returns a **fixed script** of a structured call record. Used to run through the entire ReAct loop (think → call tool → read structured record → report) and see its shape **without any API Key, completely offline**. The confirmation number in the script is derived from the hash of the goal, is reproducible, and **does not represent any real call**.
+
+## Expected Output Example (Real Excerpt)
+
+```
+[Agent calls tool make_phone_call] Parameters:
+    phone_number = 10010
+    goal         = Inquire about the reason for the extra 50 yuan on this month's broadband bill and request a refund for the erroneous charge.
+    context      = Broadband account hz-88231
+
+[PineClaw returns structured call record]
+  Status           : completed  |  Goal Achieved: True
+  Summary          : The user successfully inquired about the reason for the extra 50 yuan on the broadband bill and applied for a refund.
+  Key Fields (key_fields):
+      - Deduction Reason: System automatically adjusted the plan fee
+      - Amount Involved: 50 yuan
+      - Confirmation Number: RW20231015
+      - Processing Result: Refund application successfully submitted
+  Call Transcript (transcript):
+      << [Callee] Welcome to customer service hotline! For billing inquiries, press 1; for business processing, press 2; for a human operator, press 0.
+      >> [Voice Agent] I'll press 0 to be transferred to a human.
+      << [Callee] Hello, I am a customer service representative, employee ID 12345. How can I help you?
+      >> [Voice Agent] Hi, I noticed an extra 50 yuan on my broadband bill. Can you help me check the reason? My account is hz-88231.
+      ...(Multiple rounds of negotiation, verification, confirmation number provided)...
+
+Agent's final report to the user:
+  Successfully called customer service and inquired about the reason: Deduction reason = System automatically adjusted the plan fee; refund submitted, confirmation number RW20231015.
+```
+
+Note: The IVR menu, employee ID, confirmation number, etc., are **simulated scenarios fabricated on the fly by the model** (see "About the Mock"), used only to demonstrate the data flow; the conversation and fields will differ with each run, but the shape of "IVR navigation → transfer to human for multi-turn negotiation → structured record → agent report" is stably reproduced.
+
+## File Descriptions
+
+| File | Description |
+| --- | --- |
+| `pine_voice.py` | Local **mock** client for the PineClaw Voice API, providing the `make_phone_call` tool |
+| `agent.py` | **ReAct Agent** (OpenAI function calling) that uses `make_phone_call` as a tool |
+| `demo.py` | End-to-end demonstration: from task assignment to reporting for a phone call |
+| `requirements.txt` / `env.example` | Dependencies and environment variable template |
+
+---
+
+## 中文
+
 # 实验 9-2：使用 PineClaw Voice API 构建电话 Agent
 
 配套《深入理解 AI Agent》第 9 章实验 9-2。

--- a/chapter9/streaming-speech/README.md
+++ b/chapter9/streaming-speech/README.md
@@ -16,7 +16,8 @@ The phenomenon from the original experiment in the book: in a sentence with a pa
   **OpenAI Whisper (`whisper-1`)**, reading the `OPENAI_API_KEY`.
 - Choosing Whisper is appropriate: like Qwen2-Audio, it is a **non-streaming model that takes the entire segment as input** – the encoder needs the full audio segment to start working and is **non-incremental** (each longer prefix requires re-encoding from scratch).
   Therefore, "slicing by increasing prefixes and recognizing each slice" perfectly reproduces the mechanism and cost of "simulated streaming" described in the book.
-- The test audio is synthesized on the fly using **OpenAI TTS (`tts-1`)**. The sentence contains time information "两点半" (two thirty). When the first half is truncated, it is prone to incomplete/erroneous recognition.- **Must use a direct OpenAI Key**: This experiment only uses audio endpoints (ASR `whisper-1` / TTS `tts-1`). These endpoints are only available via direct OpenAI connection – OpenRouter only handles chat completions and has no audio endpoints, so it cannot fall back to `OPENROUTER_API_KEY`. If you only want to verify the chunking/timing logic, use `python demo.py --offline`, which requires no Key.
+- The test audio is synthesized on the fly using **OpenAI TTS (`tts-1`)**. The sentence contains time information "两点半" (two thirty). When the first half is truncated, it is prone to incomplete/erroneous recognition.
+- **Must use a direct OpenAI Key**: This experiment only uses audio endpoints (ASR `whisper-1` / TTS `tts-1`). These endpoints are only available via direct OpenAI connection – OpenRouter only handles chat completions and has no audio endpoints, so it cannot fall back to `OPENROUTER_API_KEY`. If you only want to verify the chunking/timing logic, use `python demo.py --offline`, which requires no Key.
 
 Compared to true streaming models (e.g., Qwen3-Omni using chunked/causal encoders), the latency numbers in this demo only reflect the overhead of "chunk granularity + re-encoding each chunk from scratch" and do not equal the first-packet latency of true streaming; this is also explained in the book.
 
@@ -35,7 +36,7 @@ Compared to true streaming models (e.g., Qwen3-Omni using chunked/causal encoder
 cd chapter9/streaming-speech
 pip install -r requirements.txt          # Also requires ffmpeg on the machine: brew install ffmpeg
 cp env.example .env                       # Fill in OPENAI_API_KEY (or directly export)
-python demo.py                             # Default: TTS synthesis + 0.5s granularity real Whisper streaming recognition
+python demo.py                             # Default: TTS synthesis + 0.5s granularity simulated-streaming (growing-prefix) recognition via real Whisper calls
 python demo.py --quick                     # Increase chunk granularity to 1.5s, reducing Whisper calls to ~1/3
 python demo.py --sentence "..." --chunk-step 0.5   # Custom test sentence and chunk granularity
 python demo.py --audio my.wav              # Use an existing audio file as input, skip TTS synthesis
@@ -61,7 +62,7 @@ Common parameters (`python demo.py --help`):
 ## Real Run Output (Excerpt, for Reference)
 
 A real run (sentence: "Please help me reschedule tomorrow afternoon's meeting to 2:30, the location is still Conference Room 3, and don't forget to notify everyone.", total duration 7.75s) per-chunk recognition:
-```
+```text
 Chunk#01  Audio Prefix  0.5s | Recognition: Could you please                         ← Premature truncation: misrecognition + incomplete
 Chunk#03  Audio Prefix  1.5s | Recognition: Could you please reschedule tomorrow afternoon's
 Chunk#05  Audio Prefix  2.5s | Recognition: ...to two o'clock                       ← Time only half heard
@@ -71,7 +72,7 @@ Chunk#12  Audio Prefix  6.0s | Recognition: ...the location is still in Conferen
 Chunk#14  Audio Prefix  7.0s | Recognition: ...don't forget to notify me                   ← Another premature misjudgment (should be "notify everyone")
 Chunk#16  Audio Prefix  7.8s | Recognition: ...don't forget to notify everyone (Complete and correct)
 Full Segment Recognition (wait for complete audio): Could you please reschedule tomorrow afternoon's meeting to 2:30 PM? The location is still Conference Room 3. Don't forget to notify everyone.  Wait time: 7.75s (recording) + 2.25s (inference)
-First available streaming recognition: Only ~0.5s of audio needed to produce a partial result, obtaining the first version 7.2s earlier than the full segment.
+First available streaming recognition: Only ~0.5s of audio needed to produce a partial result, obtaining the first version 7.25s earlier than the full segment.
 ```
 
 It can be seen: streaming chunking advances the latency of the "first partial result" from "after recording the full sentence (7.75s)" to "after receiving 0.5s of audio", but the cost is **premature decision misrecognitions** in early chunks like "你帮我→你们" (you help me → you all), "三号会议室→四川" (Conference Room 3 → Sichuan), "通知大家→通知我" (notify everyone → notify me), which gradually converge as audio accumulates. Full segment recognition is the most accurate but has the highest latency. This is the **latency vs. accuracy trade-off** of streaming speech perception.
@@ -136,7 +137,7 @@ It can be seen: streaming chunking advances the latency of the "first partial re
 cd chapter9/streaming-speech
 pip install -r requirements.txt          # 另需本机 ffmpeg：brew install ffmpeg
 cp env.example .env                       # 填入 OPENAI_API_KEY（或直接 export）
-python demo.py                             # 默认：TTS 合成 + 0.5s 粒度真实 Whisper 流式识别
+python demo.py                             # 默认：TTS 合成 + 0.5s 粒度、真实调用 Whisper 的模拟流式（递增前缀）识别
 python demo.py --quick                     # 分块粒度放大到 1.5s，Whisper 调用减到约 1/3
 python demo.py --sentence "..." --chunk-step 0.5   # 自定义测试句与分块粒度
 python demo.py --audio my.wav              # 用现成音频作输入，跳过 TTS 合成
@@ -164,7 +165,7 @@ python demo.py --help                      # 查看全部参数
 一次真实运行（句子：「麻烦你帮我把明天下午的会议改到两点半，地点还是在三号会议室，
 别忘了通知大家。」，整段 7.75s）的逐块识别：
 
-```
+```text
 块#01  音频前缀  0.5s | 识别：麻烦你们                         ← 过早截断：误识别 + 不完整
 块#03  音频前缀  1.5s | 识别：麻烦你帮我把明天下午的
 块#05  音频前缀  2.5s | 识别：...改到两点                       ← 时间只听到一半
@@ -176,7 +177,7 @@ python demo.py --help                      # 查看全部参数
 
 整段识别（等完整音频）：麻烦你帮我把明天下午的会议改到两点半 地点还是在三号会议室 别忘了通知大家
   需等待：7.75s（录完）+ 2.25s（推理）
-流式首个可用识别：仅需约 0.5s 音频即产出部分结果，比整段提前 7.2s 拿到第一版
+流式首个可用识别：仅需约 0.5s 音频即产出部分结果，比整段提前 7.25s 拿到第一版
 ```
 
 可见：流式分块把「首个部分结果」的延迟从「录完整句（7.75s）之后」提前到「收到 0.5s 音频」，

--- a/chapter9/streaming-speech/README.md
+++ b/chapter9/streaming-speech/README.md
@@ -1,3 +1,94 @@
+## English
+
+# Experiment 9-3: Streaming Speech Perception
+
+Companion to Chapter 9 of "Understanding AI Agents" – Experiment 9-3: Using Qwen2-Audio to Simulate Streaming Speech Perception.
+
+## Objective
+
+Demonstrate the core trade-off of **streaming speech perception**: feed continuous audio to ASR in **incrementally growing chunks**, producing a "current partial recognition result" after each small segment. This achieves extremely low **first-packet latency** for obtaining text; the cost is that early chunks, **lacking the latter half of the sentence context** and with speech cut off mid-stream, may produce **incomplete or erroneous** recognition, which gradually **converges** to the correct text as more audio accumulates. As a baseline, "wait for the complete audio and then recognize once" is the most accurate, but requires waiting for the entire sentence plus inference, resulting in the **highest latency for the first character**.
+
+The phenomenon from the original experiment in the book: in a sentence with a pause, "大概两点左右" (around two o'clock) was misrecognized as "大概零点左右" (around midnight) in an overly early chunk. This demo replicates this "cost of premature decision" with a similar phenomenon.
+## Model Adaptation Notes (Important)
+
+- The original experiment in the book used **Qwen2-Audio** (a native audio model capable of outputting acoustic event tokens like `<|noise|>`).
+  However, it currently **has no directly callable key/endpoint**, so this demo uses an **available ASR alternative**:
+  **OpenAI Whisper (`whisper-1`)**, reading the `OPENAI_API_KEY`.
+- Choosing Whisper is appropriate: like Qwen2-Audio, it is a **non-streaming model that takes the entire segment as input** – the encoder needs the full audio segment to start working and is **non-incremental** (each longer prefix requires re-encoding from scratch).
+  Therefore, "slicing by increasing prefixes and recognizing each slice" perfectly reproduces the mechanism and cost of "simulated streaming" described in the book.
+- The test audio is synthesized on the fly using **OpenAI TTS (`tts-1`)**. The sentence contains time information "两点半" (two thirty). When the first half is truncated, it is prone to incomplete/erroneous recognition.- **Must use a direct OpenAI Key**: This experiment only uses audio endpoints (ASR `whisper-1` / TTS `tts-1`). These endpoints are only available via direct OpenAI connection – OpenRouter only handles chat completions and has no audio endpoints, so it cannot fall back to `OPENROUTER_API_KEY`. If you only want to verify the chunking/timing logic, use `python demo.py --offline`, which requires no Key.
+
+Compared to true streaming models (e.g., Qwen3-Omni using chunked/causal encoders), the latency numbers in this demo only reflect the overhead of "chunk granularity + re-encoding each chunk from scratch" and do not equal the first-packet latency of true streaming; this is also explained in the book.
+
+## Streaming Chunking Mechanism
+
+1. Synthesize the entire Chinese test audio using TTS (approx. 7–8 seconds), saved as `audio/sentence.wav`.
+2. Use `ffmpeg` to slice out "all audio received so far" at increasing lengths: `t = 0.5s, 1.0s, 1.5s ...`,
+   simulating the continuous arrival of an audio stream.
+3. For each prefix chunk, call Whisper to obtain the "current partial recognition result", recording the **single-chunk recognition latency** and **cumulative arrival latency**.
+4. Baseline: At the end, recognize the **entire** audio segment once, recording its result and latency.
+5. Print a per-chunk recognition table + full-segment baseline, quantifying the latency/accuracy trade-off between "first available recognition" and "full-segment recognition".
+
+## Running
+
+```bash
+cd chapter9/streaming-speech
+pip install -r requirements.txt          # Also requires ffmpeg on the machine: brew install ffmpeg
+cp env.example .env                       # Fill in OPENAI_API_KEY (or directly export)
+python demo.py                             # Default: TTS synthesis + 0.5s granularity real Whisper streaming recognition
+python demo.py --quick                     # Increase chunk granularity to 1.5s, reducing Whisper calls to ~1/3
+python demo.py --sentence "..." --chunk-step 0.5   # Custom test sentence and chunk granularity
+python demo.py --audio my.wav              # Use an existing audio file as input, skip TTS synthesis
+python demo.py --compare-chunks            # Cross-granularity (0.5/1.0/2.0s) latency comparison table
+python demo.py --offline                   # Offline self-test: no network, no ffmpeg, no Key, uses a synthetic recognizer
+python demo.py --offline --compare-chunks  # Offline synthetic cross-granularity latency comparison table
+python demo.py --output result.json        # Save results (per-chunk table/comparison table) as JSON
+python demo.py --help                      # View all parameters
+```
+
+Common parameters (`python demo.py --help`):
+
+- `--sentence`: Test sentence (default is a sentence with time information similar to the one in the book).
+- `--chunk-step`: Chunk granularity (seconds), default 0.5. Smaller values mean more chunks and slower processing.
+- `--quick`: Increase granularity to 1.5s for a quick demo (Whisper calls reduced to ~1/3).
+- `--audio PATH`: Use an existing audio file as input, skip TTS synthesis (ignored in offline mode).
+- `--compare-chunks [S1,S2,...]`: Run once for each specified chunk granularity, output a cross-granularity latency comparison table; if no value is given, defaults to `0.5,1.0,2.0` (seconds).
+- `--offline`: **Offline self-test**, no network, no ffmpeg, no Key needed. Uses a **synthetic recognizer** (SYNTHETIC) to drive the same chunking/timing logic – text is revealed proportionally to the prefix, latency values are synthetic, **only validates the process, does not represent any real model performance**.
+- `--duration SEC`: Total duration of the segment in offline mode (default is estimated based on sentence length).
+- `--tts-model` / `--voice` / `--asr-model` / `--language`: Override TTS/ASR models and language (defaults are `tts-1` / `alloy` / `whisper-1` / `zh`).
+- `--output PATH`: Save results as JSON.
+
+## Real Run Output (Excerpt, for Reference)
+
+A real run (sentence: "Please help me reschedule tomorrow afternoon's meeting to 2:30, the location is still Conference Room 3, and don't forget to notify everyone.", total duration 7.75s) per-chunk recognition:
+```
+Chunk#01  Audio Prefix  0.5s | Recognition: Could you please                         ← Premature truncation: misrecognition + incomplete
+Chunk#03  Audio Prefix  1.5s | Recognition: Could you please reschedule tomorrow afternoon's
+Chunk#05  Audio Prefix  2.5s | Recognition: ...to two o'clock                       ← Time only half heard
+Chunk#06  Audio Prefix  3.0s | Recognition: ...to two thirty                     ← Converges after context is supplemented
+Chunk#10  Audio Prefix  5.0s | Recognition: ...the location is still in Sichuan                 ← Truncation misrecognition (should be "Conference Room 3")
+Chunk#12  Audio Prefix  6.0s | Recognition: ...the location is still in Conference Room 3           ← Converges with more audio
+Chunk#14  Audio Prefix  7.0s | Recognition: ...don't forget to notify me                   ← Another premature misjudgment (should be "notify everyone")
+Chunk#16  Audio Prefix  7.8s | Recognition: ...don't forget to notify everyone (Complete and correct)
+Full Segment Recognition (wait for complete audio): Could you please reschedule tomorrow afternoon's meeting to 2:30 PM? The location is still Conference Room 3. Don't forget to notify everyone.  Wait time: 7.75s (recording) + 2.25s (inference)
+First available streaming recognition: Only ~0.5s of audio needed to produce a partial result, obtaining the first version 7.2s earlier than the full segment.
+```
+
+It can be seen: streaming chunking advances the latency of the "first partial result" from "after recording the full sentence (7.75s)" to "after receiving 0.5s of audio", but the cost is **premature decision misrecognitions** in early chunks like "你帮我→你们" (you help me → you all), "三号会议室→四川" (Conference Room 3 → Sichuan), "通知大家→通知我" (notify everyone → notify me), which gradually converge as audio accumulates. Full segment recognition is the most accurate but has the highest latency. This is the **latency vs. accuracy trade-off** of streaming speech perception.
+> Note: Each run makes real calls to TTS + Whisper, so the specific recognized text and latency numbers will fluctuate slightly;
+> the table above is the result of one particular real run. The positions of misrecognitions in early chunks may vary between runs, but the pattern of "early inaccuracy, convergence with more audio" is stably reproduced.
+
+## File Description
+
+- `demo.py`: Main program (synthesize audio → incremental chunk streaming recognition → full segment baseline).
+- `requirements.txt`: Python dependencies (also requires ffmpeg/ffprobe on the machine).
+- `env.example`: Environment variable example, copy to `.env` and fill in `OPENAI_API_KEY`.
+- `audio/`: Audio generated at runtime (gitignored).
+
+---
+
+## 中文
+
 # 实验 9-3：模拟流式语音感知（Streaming Speech Perception）
 
 配套《深入理解 AI Agent》第 9 章「实验 9-3：使用 Qwen2-Audio 模拟流式语音感知」。


### PR DESCRIPTION
## Summary

Add complete English and Chinese translations to the Chapter 9 project READMEs using a single-file bilingual layout.

## Scope

- Add `## English` and `## 中文` sections to five `chapter9/*/README.md` files.
- Preserve all original content verbatim.
- Preserve commands, code blocks, tables, links, parameters, filenames, examples, and technical terminology.
- Leave Chapter 9 root README and localized index files unchanged.
- No source code, configuration, dependency, or data changes.

## Test plan

- Verified each target README contains exactly one English section and one Chinese section.
- Compared each original-language section byte-for-byte with its version in `HEAD`.
- Confirmed the diff contains additions only and no original-content deletions.
- Confirmed only the five target project READMEs changed.
- Confirmed Chapter 9 root and localized index READMEs are unchanged.
- Ran `git diff --check` successfully.

Refs https://github.com/bojieli/ai-agent-book/issues/89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 为多项语音实验补充完整的中英文说明，涵盖实验概览、架构流程、运行步骤、配置要求及示例输出。
  * 新增语音服务商适配、模型选择、密钥配置与离线模式说明。
  * 补充流式语音、电话 Agent、端到端语音及可控 TTS 的参数、命令行用法、故障排查和性能提示。
  * 增加项目结构、文件职责、测试方式与常见限制说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->