### PR TITLE
fix(multimodal-agent): repair interactive tools toggle

### DIFF
--- a/chapter3/multimodal-agent/agent.py
+++ b/chapter3/multimodal-agent/agent.py
@@ -312,7 +312,7 @@ class MultimodalAgent:
         self.config = Config()
         self.current_model = model or self.config.default_model
         self.extraction_mode = mode or self.config.default_mode
-        self.enable_multimodal_tools = enable_tools
+        self.enable_multimodal_tools = False
         
         # Conversation history
         self.conversation_history: List[Message] = []
@@ -321,11 +321,23 @@ class MultimodalAgent:
         self.current_content_path: Optional[str] = None
         
         # Multimodal tools
-        self.tools = MultimodalTools(self) if enable_tools else None
+        self.tools: Optional[MultimodalTools] = None
         
         # Tool definitions for OpenAI-style function calling
-        self.tool_definitions = []
-        if enable_tools:
+        self.tool_definitions: List[Dict[str, Any]] = []
+        self.set_multimodal_tools_enabled(enable_tools)
+
+    def set_multimodal_tools_enabled(self, enabled: bool) -> None:
+        """Keep the multimodal tool state in sync."""
+        self.enable_multimodal_tools = enabled
+        if not enabled:
+            self.tools = None
+            return
+
+        if self.tools is None:
+            self.tools = MultimodalTools(self)
+
+        if not self.tool_definitions:
             self.tool_definitions = [
                 {
                     "type": "function",

--- a/chapter3/multimodal-agent/main.py
+++ b/chapter3/multimodal-agent/main.py
@@ -184,12 +184,10 @@ async def interactive_chat(agent: MultimodalAgent) -> None:
                         
                 elif command == "/tools":
                     if args == "on":
-                        agent.enable_multimodal_tools = True
-                        agent.tools = MultimodalTools(agent) if not agent.tools else agent.tools
+                        agent.set_multimodal_tools_enabled(True)
                         print("Multimodal tools enabled")
                     elif args == "off":
-                        agent.enable_multimodal_tools = False
-                        agent.tools = None
+                        agent.set_multimodal_tools_enabled(False)
                         print("Multimodal tools disabled")
                     else:
                         print("Usage: /tools <on|off>")

--- a/chapter3/multimodal-agent/test_interactive_tools_toggle.py
+++ b/chapter3/multimodal-agent/test_interactive_tools_toggle.py
@@ -1,0 +1,37 @@
+"""Regression tests for the interactive multimodal tools toggle."""
+
+import asyncio
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from agent import MultimodalAgent, MultimodalTools
+from main import interactive_chat
+
+
+def _run_commands(agent, *commands):
+    with patch("builtins.input", side_effect=commands):
+        asyncio.run(interactive_chat(agent))
+
+
+def test_tools_on_configures_complete_tool_state():
+    agent = MultimodalAgent(enable_tools=False)
+
+    _run_commands(agent, "/tools on", "/quit")
+
+    assert agent.enable_multimodal_tools is True
+    assert isinstance(agent.tools, MultimodalTools)
+    assert {
+        definition["function"]["name"] for definition in agent.tool_definitions
+    } == {"analyze_image", "analyze_audio", "analyze_pdf"}
+
+
+def test_tools_off_disables_tool_execution():
+    agent = MultimodalAgent(enable_tools=True)
+
+    _run_commands(agent, "/tools off", "/quit")
+
+    assert agent.enable_multimodal_tools is False
+    assert agent.tools is None


### PR DESCRIPTION
## Summary

- centralize multimodal tool state changes in `MultimodalAgent`
- make the documented `/tools on` command initialize both tool execution and
  the OpenAI-compatible function definitions
- add offline regression tests for enabling and disabling tools interactively

The default interactive agent starts with tools disabled. `/tools on` currently
references `MultimodalTools` without importing it, so the command raises
`NameError`. Adding only that import would still leave `tool_definitions` empty,
and the OpenAI-compatible request path would omit tools after reporting that
they were enabled.

The new agent-owned transition keeps the enabled flag, execution object, and
tool definitions consistent. Disabling retains the existing schema cache while
the enabled flag prevents it from being sent.

## Validation

- focused Python 3.12 offline suite: 9 passed
- real credential-cleared stdin smoke for `/tools on` and `/quit`
- `python3 -m py_compile` for the changed source and test
- `git diff --check`

The complete component run is 15 passed and 4 failed. An exact-base run is 13
passed and the same 4 failed: two tests patch a Google SDK API that is no longer
present, and two do not mock the credential guards needed to reach their
provider clients.

No live provider request was run because credentials are not configured. The
direct Gemini streaming path already does not consume function tools even when
enabled at construction; adding Gemini tool calling is outside this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * `/tools on` 和 `/tools off` 现在可统一切换多模态工具。
  * 启用时自动加载图像、音频和 PDF 分析工具；禁用时会清理工具状态。
* **Bug 修复**
  * 优化工具开关状态同步，避免工具配置与实际启用状态不一致。
* **测试**
  * 新增交互式开关回归测试，覆盖启用、禁用及工具定义验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->