### PR TITLE
fix(prompt-auto-optimization): skip non-dict edit list entries

### DIFF
--- a/chapter8/prompt-auto-optimization/coding_agent.py
+++ b/chapter8/prompt-auto-optimization/coding_agent.py
@@ -60,21 +60,24 @@ def _apply_one(content: str, old_str: str, new_str: str) -> tuple[str, str | Non
     return content.replace(old_str, new_str, 1), None
 
 
-def _apply_edits_from_args(working: str, args: dict) -> tuple[str, int, list, list]:
-    """Apply apply_edits tool args to working text. JSON null edits like omit ([])."""
+def _apply_edits_from_args(working: str, args: dict) -> tuple[str, int, list, list, list]:
+    """Apply edits; null edits → []; skip non-dict entries with a warning."""
     edits = args.get("edits")
     if edits is None:
         edits = []
     errors = []
+    warnings = []
     applied = 0
     for e in edits:
+        if not isinstance(e, dict):
+            warnings.append(f"跳过非对象编辑项 ({type(e).__name__}): {e!r}")
+            continue
         working, err = _apply_one(working, e.get("old_str", ""), e.get("new_str", ""))
         if err:
             errors.append(err)
         else:
             applied += 1
-    return working, applied, errors, edits
-
+    return working, applied, errors, warnings, edits
 
 def optimize_prompt(prompt_path: str, feedback, max_rounds: int = 3, verbose: bool = True) -> dict:
     """
@@ -138,26 +141,30 @@ def optimize_prompt(prompt_path: str, feedback, max_rounds: int = 3, verbose: bo
         except json.JSONDecodeError:
             args = {}
         rationale = args.get("rationale", rationale)
-        working, applied, errors, edits = _apply_edits_from_args(working, args)
+        working, applied, errors, warnings, edits = _apply_edits_from_args(working, args)
 
         if verbose:
-            print(f"  [round {round_idx + 1}] 提交 {len(edits)} 条编辑，成功 {applied}，失败 {len(errors)}")
+            print(f"  [round {round_idx + 1}] 提交 {len(edits)} 条编辑，成功 {applied}，失败 {len(errors)}，跳过 {len(warnings)}")
 
         if not errors:
-            # 全部编辑成功，落盘
+            # 有效编辑已全部成功应用，落盘
+            msg_content = "所有有效编辑已成功应用。"
+            if warnings:
+                msg_content += "\n以下非对象编辑项已被跳过：\n" + "\n".join(f"- {w}" for w in warnings)
             messages.append(
-                {"role": "tool", "tool_call_id": tc.id, "content": "所有编辑已成功应用。"}
+                {"role": "tool", "tool_call_id": tc.id, "content": msg_content}
             )
             break
         else:
-            # 有失败：回滚到原文，把错误反馈给模型重试（保持编辑的原子性）
+            # 有实际应用失败：回滚到原文，把错误反馈给模型重试（保持编辑的原子性）
             working = original
             feedback_msg = (
                 "以下编辑未能应用，请修正后重新提交完整的编辑列表（注意 old_str 必须与文件逐字符一致）：\n"
                 + "\n".join(f"- {er}" for er in errors)
             )
+            if warnings:
+                feedback_msg += "\n另有以下非对象编辑项已被跳过：\n" + "\n".join(f"- {w}" for w in warnings)
             messages.append({"role": "tool", "tool_call_id": tc.id, "content": feedback_msg})
-
     # 落盘（原地覆盖 prompt 文件）
     with open(prompt_path, "w", encoding="utf-8") as f:
         f.write(working)

--- a/chapter8/prompt-auto-optimization/test_non_dict_edit.py
+++ b/chapter8/prompt-auto-optimization/test_non_dict_edit.py
@@ -1,0 +1,68 @@
+"""Non-dict items in edits must not cause AttributeError or roll back valid edits in optimize_prompt."""
+import tempfile
+from unittest.mock import MagicMock, patch
+from coding_agent import _apply_edits_from_args, optimize_prompt
+
+
+def test_string_edit_item_skipped_with_warning():
+    working, applied, errors, warnings, edits = _apply_edits_from_args(
+        "hello world",
+        {"edits": ["bad", {"old_str": "hello", "new_str": "hi"}]},
+    )
+    assert working == "hi world"
+    assert applied == 1
+    assert errors == []
+    assert any("跳过非对象" in w for w in warnings)
+    assert len(edits) == 2
+
+
+def test_null_edit_item_skipped_with_warning():
+    working, applied, errors, warnings, _ = _apply_edits_from_args(
+        "hello world",
+        {"edits": [None]},
+    )
+    assert working == "hello world"
+    assert applied == 0
+    assert errors == []
+    assert any("跳过非对象" in w for w in warnings)
+
+
+def test_null_edits_list_still_empty():
+    working, applied, errors, warnings, edits = _apply_edits_from_args(
+        "hello world", {"edits": None}
+    )
+    assert working == "hello world"
+    assert applied == 0
+    assert errors == []
+    assert warnings == []
+    assert edits == []
+
+
+def test_optimize_prompt_applies_valid_edits_when_non_dict_items_present():
+    """optimize_prompt must write valid edits to disk even if non-dict items are in the edits array."""
+    with tempfile.NamedTemporaryFile("w+", delete=False, encoding="utf-8") as f:
+        f.write("hello world")
+        prompt_file = f.name
+
+    mock_tool_call = MagicMock()
+    mock_tool_call.id = "tc_1"
+    mock_tool_call.function.arguments = '{"edits": ["invalid_string_item", {"old_str": "hello", "new_str": "greetings"}]}'
+
+    mock_msg = MagicMock()
+    mock_msg.tool_calls = [mock_tool_call]
+    mock_msg.content = None
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=mock_msg)]
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_response
+
+    with patch("coding_agent.get_client", return_value=mock_client), \
+         patch("coding_agent.get_model", return_value="gpt-4o"):
+        res = optimize_prompt(prompt_file, feedback="test feedback", verbose=False)
+
+    assert res["after"] == "greetings world"
+    with open(prompt_file, "r", encoding="utf-8") as f:
+        content = f.read()
+    assert content == "greetings world"


### PR DESCRIPTION
An edits list with a non-dict entry made _apply_edits_from_args crash on .get.

Skip non-dict edit items and apply the rest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 改善编辑输入的容错能力，避免非法格式导致运行时错误。
  * 自动跳过非对象类型的编辑项并记录错误，同时继续处理其他有效编辑。
  * 当编辑列表为空或缺失时，统一按空列表处理。

* **测试**
  * 新增对字符串、空值及空编辑列表等异常输入场景的覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->