### PR TITLE
fix(self-evolution-eval): treat judge JSON arrays as unparseable

### DIFF
--- a/chapter8/self-evolution-eval/harness.py
+++ b/chapter8/self-evolution-eval/harness.py
@@ -121,13 +121,17 @@ _JUDGE_SYSTEM = (
 
 
 def _parse_judge_json(text: str) -> Optional[dict]:
+    """Parse judge output as a rubric object. Arrays/scalars → None (not crash)."""
+    def _as_dict(obj):
+        return obj if isinstance(obj, dict) else None
+
     try:
-        return json.loads(text)
+        return _as_dict(json.loads(text))
     except Exception:
         m = re.search(r"\{.*\}", text, re.DOTALL)
         if m:
             try:
-                return json.loads(m.group(0))
+                return _as_dict(json.loads(m.group(0)))
             except Exception:
                 return None
     return None

--- a/chapter8/self-evolution-eval/test_judge_json_array.py
+++ b/chapter8/self-evolution-eval/test_judge_json_array.py
@@ -1,0 +1,27 @@
+"""Judge JSON that is an array must not AttributeError in rubric scoring."""
+from harness import _parse_judge_json, _rubric_dimension_total
+
+
+def test_json_array_parses_as_none():
+    raw = (
+        '[{"error_handling":3,"input_validation":2,'
+        '"documentation":2,"robustness":3,"comment":"ok"}]'
+    )
+    assert _parse_judge_json(raw) is None
+
+
+def test_json_object_still_parses():
+    raw = (
+        '{"error_handling":3,"input_validation":2,'
+        '"documentation":1,"robustness":3,"comment":"ok"}'
+    )
+    rubric = _parse_judge_json(raw)
+    assert isinstance(rubric, dict)
+    assert _rubric_dimension_total(rubric) == 9
+
+
+def test_embedded_object_in_prose_still_parses():
+    raw = '点评如下：\n{"error_handling":1,"input_validation":1,"documentation":1,"robustness":1}\n完'
+    rubric = _parse_judge_json(raw)
+    assert rubric is not None
+    assert _rubric_dimension_total(rubric) == 4


### PR DESCRIPTION
A judge JSON array made _parse_judge_json crash on .get.

Treat non-dict judge payloads as unparseable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 改进评分结果解析：仅接受 JSON 对象，避免数组或其他格式导致评分流程异常。
  * 支持从包含自然语言的输出中提取有效的 JSON 对象。
  * 确保评分维度汇总结果保持准确一致。

* **测试**
  * 新增对 JSON 数组、JSON 对象及混合文本解析场景的覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->