### PR TITLE
fix(cot-distillation): skip SFT rows with null assistant content

### DIFF
--- a/chapter7/cot-distillation/analyze_data.py
+++ b/chapter7/cot-distillation/analyze_data.py
@@ -25,7 +25,6 @@ def main():
             n_skipped_short += 1
             continue
         assistant_msg = messages[1]
-        # Explicit null / missing content must not TypeError on re.search.
         if not isinstance(assistant_msg, dict):
             n_skipped_short += 1
             continue

--- a/chapter7/cot-distillation/analyze_data.py
+++ b/chapter7/cot-distillation/analyze_data.py
@@ -24,7 +24,15 @@ def main():
         if len(messages) < 2:
             n_skipped_short += 1
             continue
-        assistant = messages[1]["content"]
+        assistant_msg = messages[1]
+        # Explicit null / missing content must not TypeError on re.search.
+        if not isinstance(assistant_msg, dict):
+            n_skipped_short += 1
+            continue
+        assistant = assistant_msg.get("content")
+        if not isinstance(assistant, str):
+            n_skipped_short += 1
+            continue
         m = re.search(r"<think>\n?(.*?)\n?</think>", assistant, re.DOTALL)
         think = m.group(1) if m else ""
         think_lens.append(len(think))

--- a/chapter7/cot-distillation/test_analyze_null_assistant_content.py
+++ b/chapter7/cot-distillation/test_analyze_null_assistant_content.py
@@ -1,0 +1,66 @@
+"""SFT rows with null assistant content must not TypeError in analyze_data."""
+
+import json
+import sys
+
+import analyze_data as ad
+
+
+def test_null_assistant_content_skipped(tmp_path, monkeypatch, capsys):
+    sft = tmp_path / "sft.jsonl"
+    rows = [
+        {
+            "messages": [
+                {"role": "user", "content": "q"},
+                {"role": "assistant", "content": None},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "q"},
+                {
+                    "role": "assistant",
+                    "content": "<think>\n验算一遍\n</think>\nFinal Answer: 1",
+                },
+            ]
+        },
+    ]
+    sft.write_text(
+        "\n".join(json.dumps(r, ensure_ascii=False) for r in rows) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["analyze_data.py", "--sft", str(sft), "--raw", str(tmp_path / "missing.jsonl")],
+    )
+    ad.main()
+    out = capsys.readouterr().out
+    assert "SFT 样本数：2" in out
+    assert "跳过 messages 不足 2 条的样本：1" in out
+    assert "含反思/验算行为的样本：1/1" in out
+
+
+def test_missing_content_key_skipped(tmp_path, monkeypatch, capsys):
+    sft = tmp_path / "sft.jsonl"
+    sft.write_text(
+        json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "q"},
+                    {"role": "assistant"},
+                ]
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["analyze_data.py", "--sft", str(sft), "--raw", str(tmp_path / "missing.jsonl")],
+    )
+    ad.main()
+    out = capsys.readouterr().out
+    assert "跳过 messages 不足 2 条的样本：1" in out


### PR DESCRIPTION
analyze_data crashed with TypeError when an SFT row had null assistant content.

Skip those rows like other malformed message shapes.
