### PR TITLE
fix(adaptive-log-parser): keep engine _parser tag over payload key

### DIFF
--- a/chapter5/adaptive-log-parser/engine.py
+++ b/chapter5/adaptive-log-parser/engine.py
@@ -80,8 +80,8 @@ class LogParserEngine:
             except Exception:
                 # 某个解析器对这行报错，不代表别的不行，继续尝试
                 continue
-            if result:
-                return {"_parser": name, **result}
+            if result is not None:
+                return {**result, "_parser": name}
         raise ParseError(line)
 
     # -- 热加载：从 .py 文件加载 parse 函数 ----------------------------------

--- a/chapter5/adaptive-log-parser/test_parser_tag_preserved.py
+++ b/chapter5/adaptive-log-parser/test_parser_tag_preserved.py
@@ -1,0 +1,19 @@
+"""Engine _parser annotation must not be overwritten by a payload key."""
+from engine import LogParserEngine, builtin_json_parser
+
+
+def test_payload_parser_key_does_not_override_engine_tag():
+    engine = LogParserEngine()
+    engine.register("json", builtin_json_parser)
+    line = '{"timestamp": "t", "level": "INFO", "message": "hi", "_parser": "evil"}'
+    out = engine.parse_line(line)
+    assert out["_parser"] == "json"
+    assert out["message"] == "hi"
+
+
+def test_normal_json_still_tagged():
+    engine = LogParserEngine()
+    engine.register("json", builtin_json_parser)
+    out = engine.parse_line('{"timestamp": "t", "level": "INFO", "message": "ok"}')
+    assert out["_parser"] == "json"
+    assert out["level"] == "INFO"


### PR DESCRIPTION
A JSON log line with a _parser field overwrote the engine annotation on the result.

Keep the engine _parser tag when the payload also has that key.
