### PR TITLE
fix(cron): reject non-positive recurring timer intervals

### DIFF
--- a/chapter4/collaboration-tools/src/timer_tools.py
+++ b/chapter4/collaboration-tools/src/timer_tools.py
@@ -291,6 +291,13 @@ async def set_recurring_timer(
         Dictionary with recurring timer ID
     """
     try:
+        if interval_seconds is None or interval_seconds <= 0:
+            return {
+                "success": False,
+                "error": "interval_seconds must be positive",
+                "message": "Failed to set recurring timer"
+            }
+
         timer_id = str(uuid.uuid4())
         
         timer_data = {

--- a/chapter4/collaboration-tools/test_recurring_interval_positive.py
+++ b/chapter4/collaboration-tools/test_recurring_interval_positive.py
@@ -1,0 +1,46 @@
+"""Recurring timers with interval_seconds <= 0 must not busy-loop."""
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
+import timer_tools as t
+
+
+async def _probe(interval):
+    t._active_timers.clear()
+    t._timer_tasks.clear()
+    result = await t.set_recurring_timer(interval, max_occurrences=None, timer_name="probe")
+    await asyncio.sleep(0.05)
+    for task in list(t._timer_tasks.values()):
+        task.cancel()
+    await asyncio.sleep(0)
+    return result
+
+
+def test_zero_interval_rejected():
+    result = asyncio.run(_probe(0))
+    assert result["success"] is False
+    assert "positive" in result["error"]
+    assert t._active_timers == {}
+
+
+def test_negative_interval_rejected():
+    result = asyncio.run(_probe(-5))
+    assert result["success"] is False
+    assert t._active_timers == {}
+
+
+def test_positive_interval_still_accepted():
+    async def run():
+        t._active_timers.clear()
+        t._timer_tasks.clear()
+        result = await t.set_recurring_timer(60, max_occurrences=1, timer_name="ok")
+        for task in list(t._timer_tasks.values()):
+            task.cancel()
+        await asyncio.sleep(0)
+        return result
+
+    result = asyncio.run(run())
+    assert result["success"] is True
+    assert result["interval_seconds"] == 60


### PR DESCRIPTION
set_recurring_timer with interval_seconds=0 busy-looped.

Reject non-positive intervals.
