### PR TITLE
fix(file-tools): reject empty search in edit_file

### DIFF
--- a/chapter4/execution-tools/file_tools.py
+++ b/chapter4/execution-tools/file_tools.py
@@ -146,6 +146,14 @@ class FileTools:
                 "success": False,
                 "error": f"Failed to read file: {str(e)}"
             }
+
+        # Empty search is always "found" (`"" in text` is True) and
+        # str.replace("", x, 1) inserts at the start — reject instead of corrupting.
+        if search == "":
+            return {
+                "success": False,
+                "error": "Search text cannot be empty"
+            }
         
         # Check if search text exists
         if search not in current_content:

--- a/chapter4/execution-tools/file_tools.py
+++ b/chapter4/execution-tools/file_tools.py
@@ -147,8 +147,7 @@ class FileTools:
                 "error": f"Failed to read file: {str(e)}"
             }
 
-        # Empty search is always "found" (`"" in text` is True) and
-        # str.replace("", x, 1) inserts at the start — reject instead of corrupting.
+        # Empty search matches everywhere; reject instead of inserting at start.
         if search == "":
             return {
                 "success": False,

--- a/chapter4/execution-tools/test_edit_reject_empty_search.py
+++ b/chapter4/execution-tools/test_edit_reject_empty_search.py
@@ -1,0 +1,39 @@
+"""Regression: edit_file must reject empty search text (not insert at start)."""
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from llm_helper import LLMHelper
+from file_tools import FileTools
+
+
+@pytest.mark.asyncio
+async def test_empty_search_rejected():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td).resolve()
+        tools = FileTools(LLMHelper())
+        tools.workspace_dir = root
+        target = root / "note.txt"
+        target.write_text("hello world\n", encoding="utf-8")
+
+        result = await tools.edit_file(path="note.txt", search="", replace="INJECT")
+        assert result["success"] is False
+        assert "empty" in result["error"].lower()
+        assert target.read_text(encoding="utf-8") == "hello world\n"
+
+
+@pytest.mark.asyncio
+async def test_normal_edit_still_works():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td).resolve()
+        tools = FileTools(LLMHelper())
+        tools.workspace_dir = root
+        target = root / "note.txt"
+        target.write_text("hello world\n", encoding="utf-8")
+
+        result = await tools.edit_file(
+            path="note.txt", search="hello", replace="hi"
+        )
+        assert result["success"] is True
+        assert target.read_text(encoding="utf-8") == "hi world\n"


### PR DESCRIPTION
edit_file with an empty search string inserted the replacement at the start of the file.

Reject empty search.
