### PR TITLE
fix(elo): keep fractional wins in animation frames

### DIFF
--- a/chapter6/elo-leaderboard/animation.py
+++ b/chapter6/elo-leaderboard/animation.py
@@ -47,7 +47,8 @@ def prepare_animation_data(history_df: pd.DataFrame, top_n: int = 15) -> dict:
                 'name': row.model,
                 'rating': float(row.rating),
                 'matches': int(row.matches),
-                'wins': int(row.wins)
+                # Elo ties credit 0.5 wins; int() would truncate those to 0.
+                'wins': float(row.wins)
             })
         
         frames.append(frame)

--- a/chapter6/elo-leaderboard/animation.py
+++ b/chapter6/elo-leaderboard/animation.py
@@ -47,7 +47,6 @@ def prepare_animation_data(history_df: pd.DataFrame, top_n: int = 15) -> dict:
                 'name': row.model,
                 'rating': float(row.rating),
                 'matches': int(row.matches),
-                # Elo ties credit 0.5 wins; int() would truncate those to 0.
                 'wins': float(row.wins)
             })
         

--- a/chapter6/elo-leaderboard/test_animation_tie_wins.py
+++ b/chapter6/elo-leaderboard/test_animation_tie_wins.py
@@ -1,0 +1,35 @@
+"""prepare_animation_data must keep fractional wins from Elo ties."""
+import pandas as pd
+from animation import prepare_animation_data
+
+
+def test_tie_half_wins_are_not_truncated():
+    history = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-07", "2024-01-07"]),
+            "model": ["A", "B"],
+            "rating": [1000.0, 1000.0],
+            "rank": [1, 2],
+            "matches": [1, 1],
+            "wins": [0.5, 0.5],
+        }
+    )
+    data = prepare_animation_data(history, top_n=2)
+    wins = {m["name"]: m["wins"] for m in data["frames"][0]["models"]}
+    assert wins["A"] == 0.5
+    assert wins["B"] == 0.5
+
+
+def test_whole_wins_still_serialize():
+    history = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-07"]),
+            "model": ["A"],
+            "rating": [1010.0],
+            "rank": [1],
+            "matches": [2],
+            "wins": [2.0],
+        }
+    )
+    data = prepare_animation_data(history, top_n=1)
+    assert data["frames"][0]["models"][0]["wins"] == 2.0


### PR DESCRIPTION
prepare_animation_data used int(wins), so tie half-wins (0.5) became 0.

Keep fractional wins in the animation frames.
