### PR TITLE
fix(video-edit): skip slowmo when factor is null

### DIFF
--- a/chapter5/video-edit/blender_editor.py
+++ b/chapter5/video-edit/blender_editor.py
@@ -132,7 +132,7 @@ def _plan_fields(plan: dict):
         if etype == "subtitle":
             subtitle = eff.get("text", "")
         elif etype == "slowmo":
-            # LLM may emit factor:null; skip like non-positive (ffmpeg sibling).
+            # Skip null factor like non-positive.
             raw = eff.get("factor", 2.0)
             if raw is None:
                 continue

--- a/chapter5/video-edit/blender_editor.py
+++ b/chapter5/video-edit/blender_editor.py
@@ -132,7 +132,14 @@ def _plan_fields(plan: dict):
         if etype == "subtitle":
             subtitle = eff.get("text", "")
         elif etype == "slowmo":
-            slowmo = float(eff.get("factor", 2.0))
+            # LLM may emit factor:null; skip like non-positive (ffmpeg sibling).
+            raw = eff.get("factor", 2.0)
+            if raw is None:
+                continue
+            factor = float(raw)
+            if factor <= 0:
+                continue
+            slowmo = factor
     return start, end, subtitle, slowmo
 
 

--- a/chapter5/video-edit/test_slowmo_null_factor.py
+++ b/chapter5/video-edit/test_slowmo_null_factor.py
@@ -1,0 +1,34 @@
+"""slowmo factor:null must not TypeError (skip like non-positive)."""
+from blender_editor import _plan_fields, generate_bpy_script
+
+
+def test_null_slowmo_factor_skipped_in_plan_fields():
+    start, end, subtitle, slowmo = _plan_fields(
+        {"start": 0.0, "end": 2.0, "effects": [{"type": "slowmo", "factor": None}]}
+    )
+    assert start == 0.0 and end == 2.0
+    assert subtitle is None
+    assert slowmo is None
+
+
+def test_missing_slowmo_factor_still_defaults():
+    _, _, _, slowmo = _plan_fields(
+        {"start": 0.0, "end": 2.0, "effects": [{"type": "slowmo"}]}
+    )
+    assert slowmo == 2.0
+
+
+def test_positive_slowmo_factor_kept():
+    _, _, _, slowmo = _plan_fields(
+        {"start": 0.0, "end": 2.0, "effects": [{"type": "slowmo", "factor": 3.0}]}
+    )
+    assert slowmo == 3.0
+
+
+def test_generate_bpy_script_with_null_factor():
+    script = generate_bpy_script(
+        "/tmp/in.mp4",
+        {"start": 0.0, "end": 1.0, "effects": [{"type": "slowmo", "factor": None}]},
+        "/tmp/out.mp4",
+    )
+    assert "SLOWMO = None" in script

--- a/chapter5/video-edit/test_slowmo_null_factor.py
+++ b/chapter5/video-edit/test_slowmo_null_factor.py
@@ -1,5 +1,7 @@
 """slowmo factor:null must not TypeError (skip like non-positive)."""
+from unittest.mock import patch, MagicMock
 from blender_editor import _plan_fields, generate_bpy_script
+from video_editor import _apply_edit_ffmpeg
 
 
 def test_null_slowmo_factor_skipped_in_plan_fields():
@@ -32,3 +34,16 @@ def test_generate_bpy_script_with_null_factor():
         "/tmp/out.mp4",
     )
     assert "SLOWMO = None" in script
+
+
+def test_apply_edit_ffmpeg_factor_speedup_and_bare_filename():
+    plan = {
+        "start": 0.0,
+        "end": 2.0,
+        "effects": [{"type": "slowmo", "factor": 0.5}]
+    }
+    with patch("video_editor.run") as mock_run:
+        _apply_edit_ffmpeg("input.mp4", plan, "output.mp4")
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "atempo=2.0" in cmd[cmd.index("-af") + 1]

--- a/chapter5/video-edit/video_editor.py
+++ b/chapter5/video-edit/video_editor.py
@@ -90,7 +90,10 @@ def _apply_edit_ffmpeg(source: str, plan: dict, out_path: str) -> str:
                 opts.insert(0, f"fontfile={font}")
             vf_chain.append("drawtext=" + ":".join(opts))
         elif etype == "slowmo":
-            factor = float(eff.get("factor", 2.0))
+            raw = eff.get("factor", 2.0)
+            if raw is None:
+                continue
+            factor = float(raw)
             if factor <= 0:
                 continue
             vf_chain.append(f"setpts={factor}*PTS")

--- a/chapter5/video-edit/video_editor.py
+++ b/chapter5/video-edit/video_editor.py
@@ -98,7 +98,7 @@ def _apply_edit_ffmpeg(source: str, plan: dict, out_path: str) -> str:
                 continue
             vf_chain.append(f"setpts={factor}*PTS")
             # atempo 只支持 0.5~2.0，用 1/factor 放慢音频。
-            af_chain.append(f"atempo={max(0.5, min(2.0, 1.0 / factor))}")
+            af_chain.append(f"atempo={max(0.5, min(1.0, 1.0 / factor))}")
 
     cmd = ["ffmpeg", "-y", "-ss", f"{start:.3f}", "-to", f"{end:.3f}", "-i", source]
     if vf_chain:
@@ -107,9 +107,7 @@ def _apply_edit_ffmpeg(source: str, plan: dict, out_path: str) -> str:
         cmd += ["-af", ",".join(af_chain)]
     cmd += ["-c:v", "libx264", "-c:a", "aac", "-pix_fmt", "yuv420p", out_path]
 
-    out_dir = os.path.dirname(out_path)
-    if out_dir:
-        os.makedirs(out_dir, exist_ok=True)
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
     run(cmd, desc="ffmpeg 剪辑")
     return out_path
 

--- a/chapter5/video-edit/video_editor.py
+++ b/chapter5/video-edit/video_editor.py
@@ -98,7 +98,7 @@ def _apply_edit_ffmpeg(source: str, plan: dict, out_path: str) -> str:
                 continue
             vf_chain.append(f"setpts={factor}*PTS")
             # atempo 只支持 0.5~2.0，用 1/factor 放慢音频。
-            af_chain.append(f"atempo={max(0.5, min(1.0, 1.0 / factor))}")
+            af_chain.append(f"atempo={max(0.5, min(2.0, 1.0 / factor))}")
 
     cmd = ["ffmpeg", "-y", "-ss", f"{start:.3f}", "-to", f"{end:.3f}", "-i", source]
     if vf_chain:
@@ -107,7 +107,9 @@ def _apply_edit_ffmpeg(source: str, plan: dict, out_path: str) -> str:
         cmd += ["-af", ",".join(af_chain)]
     cmd += ["-c:v", "libx264", "-c:a", "aac", "-pix_fmt", "yuv420p", out_path]
 
-    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    out_dir = os.path.dirname(out_path)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
     run(cmd, desc="ffmpeg 剪辑")
     return out_path
 


### PR DESCRIPTION
A slowmo effect with factor null raised TypeError in float(None).

Skip slowmo when factor is null, like non-positive factors.
