### PR TITLE
fix(system-hint): tolerate malformed tool-arg JSON

### DIFF
--- a/chapter2/system-hint/agent.py
+++ b/chapter2/system-hint/agent.py
@@ -884,7 +884,29 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                     
                     for tool_call in message.tool_calls:
                         function_name = tool_call.function.name
-                        function_args = json.loads(tool_call.function.arguments)
+                        raw_args = tool_call.function.arguments or "{}"
+                        try:
+                            function_args = json.loads(raw_args)
+                        except json.JSONDecodeError as exc:
+                            # Malformed/truncated args must not abort the turn: the
+                            # assistant message with tool_calls is already in
+                            # history, so bailing would leave tool_call_id unanswered.
+                            err = (
+                                f"Invalid tool arguments (not valid JSON): {exc}. "
+                                f"Raw arguments: {raw_args[:500]}"
+                            )
+                            logger.warning(f"  ❌ {err}")
+                            self.tool_calls.append(ToolCall(
+                                tool_name=function_name,
+                                arguments={},
+                                error=err,
+                            ))
+                            self.conversation_history.append({
+                                "role": "tool",
+                                "tool_call_id": tool_call.id,
+                                "content": json.dumps({"error": err}),
+                            })
+                            continue
                         
                         # Track tool call count
                         if self.config.enable_tool_counter:

--- a/chapter2/system-hint/agent.py
+++ b/chapter2/system-hint/agent.py
@@ -888,9 +888,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                         try:
                             function_args = json.loads(raw_args)
                         except json.JSONDecodeError as exc:
-                            # Malformed/truncated args must not abort the turn: the
-                            # assistant message with tool_calls is already in
-                            # history, so bailing would leave tool_call_id unanswered.
+                            # Keep the turn alive on bad tool-arg JSON.
                             err = (
                                 f"Invalid tool arguments (not valid JSON): {exc}. "
                                 f"Raw arguments: {raw_args[:500]}"

--- a/chapter2/system-hint/test_malformed_tool_json.py
+++ b/chapter2/system-hint/test_malformed_tool_json.py
@@ -1,0 +1,73 @@
+"""Regression: malformed tool-argument JSON must not abort the ReAct loop."""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent import SystemHintAgent, SystemHintConfig
+
+
+def test_execute_task_survives_malformed_tool_arguments_json():
+    config = SystemHintConfig(
+        enable_timestamps=False,
+        enable_tool_counter=False,
+        enable_todo_list=False,
+        enable_detailed_errors=False,
+        enable_system_state=False,
+        save_trajectory=False,
+    )
+    agent = SystemHintAgent(
+        api_key="test-key",
+        provider="kimi",
+        config=config,
+        verbose=False,
+    )
+
+    bad_call = SimpleNamespace(
+        id="call-bad",
+        function=SimpleNamespace(
+            name="read_file",
+            arguments='{"file_path": "x.txt",}',  # trailing comma
+        ),
+    )
+    tool_msg = SimpleNamespace(
+        content=None,
+        tool_calls=[bad_call],
+        model_dump=lambda: {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call-bad",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"file_path": "x.txt",}',
+                    },
+                }
+            ],
+        },
+    )
+    final_msg = SimpleNamespace(
+        content="FINAL ANSWER: recovered",
+        tool_calls=None,
+        model_dump=lambda: {
+            "role": "assistant",
+            "content": "FINAL ANSWER: recovered",
+        },
+    )
+    tool_turn = SimpleNamespace(choices=[SimpleNamespace(message=tool_msg)])
+    final_turn = SimpleNamespace(choices=[SimpleNamespace(message=final_msg)])
+    agent.client = MagicMock()
+    agent.client.chat.completions.create = MagicMock(
+        side_effect=[tool_turn, final_turn]
+    )
+
+    result = agent.execute_task("read something", max_iterations=5)
+
+    assert "error" not in result or result.get("error") is None
+    assert result.get("final_answer") == "recovered" or "recovered" in str(
+        result.get("final_answer") or result
+    )
+    tool_roles = [m for m in agent.conversation_history if m.get("role") == "tool"]
+    assert tool_roles
+    assert "Invalid tool arguments" in tool_roles[0]["content"]
+    assert agent.client.chat.completions.create.call_count == 2


### PR DESCRIPTION
Malformed tool-argument JSON aborted SystemHintAgent.execute_task.

Catch parse errors and continue like the web-search sibling.
