### PR TITLE
fix(execution-tools): return empty history for count=0

### DIFF
--- a/chapter4/execution-tools/terminal_controller.py
+++ b/chapter4/execution-tools/terminal_controller.py
@@ -490,7 +490,7 @@ class TerminalController:
         Returns:
             Dictionary with command history
         """
-        # count<=0 must return []: Python's history[-0:] is history[0:] (the full list).
+        # count<=0 → []; history[-0:] would return the full list.
         if count <= 0 or not self.command_history:
             recent = []
         else:

--- a/chapter4/execution-tools/terminal_controller.py
+++ b/chapter4/execution-tools/terminal_controller.py
@@ -490,7 +490,11 @@ class TerminalController:
         Returns:
             Dictionary with command history
         """
-        recent = self.command_history[-count:] if self.command_history else []
+        # count<=0 must return []: Python's history[-0:] is history[0:] (the full list).
+        if count <= 0 or not self.command_history:
+            recent = []
+        else:
+            recent = self.command_history[-count:]
         
         return {
             "success": True,

--- a/chapter4/execution-tools/test_command_history_count_zero.py
+++ b/chapter4/execution-tools/test_command_history_count_zero.py
@@ -1,0 +1,48 @@
+"""get_command_history(count=0) must return an empty list, not the full history."""
+import asyncio
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+class Config:
+    WORKSPACE_DIR = Path(tempfile.mkdtemp())
+    AUTO_VERIFY_CODE = False
+    REQUIRE_APPROVAL_FOR_DANGEROUS_OPS = False
+
+
+sys.modules["config"] = type(sys)("config")
+sys.modules["config"].Config = Config
+
+from terminal_controller import TerminalController
+
+
+@pytest.fixture
+def tc():
+    Config.WORKSPACE_DIR = Path(tempfile.mkdtemp())
+    controller = TerminalController()
+    controller.command_history = ["cmd0", "cmd1", "cmd2", "cmd3", "cmd4"]
+    yield controller
+    if Config.WORKSPACE_DIR.exists():
+        shutil.rmtree(Config.WORKSPACE_DIR, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_count_zero_returns_empty_history(tc):
+    result = await tc.get_command_history(count=0)
+    assert result["success"] is True
+    assert result["history"] == []
+    assert result["count"] == 0
+    assert result["total"] == 5
+
+
+@pytest.mark.asyncio
+async def test_positive_count_still_returns_recent(tc):
+    result = await tc.get_command_history(count=2)
+    assert result["success"] is True
+    assert result["history"] == ["cmd3", "cmd4"]
+    assert result["count"] == 2
+    assert result["total"] == 5


### PR DESCRIPTION
get_command_history(count=0) returned the full history via Python's -0 slice.

Honor 0 as an empty history.
