### PR TITLE
fix(execution-tools): treat timeout<=0 like the default

### DIFF
--- a/chapter4/execution-tools/terminal_controller.py
+++ b/chapter4/execution-tools/terminal_controller.py
@@ -56,6 +56,11 @@ class TerminalController:
             self.command_history.append(command)
             if len(self.command_history) > self.max_history:
                 self.command_history.pop(0)
+
+            # timeout<=0: treat like omit (default 30s). Exact 0 makes subprocess
+            # raise TimeoutExpired before the command can finish.
+            if timeout is None or timeout <= 0:
+                timeout = 30
             
             # Execute command
             result = subprocess.run(

--- a/chapter4/execution-tools/test_execute_timeout_zero.py
+++ b/chapter4/execution-tools/test_execute_timeout_zero.py
@@ -1,0 +1,43 @@
+"""execute_command(timeout=0) must use the default timeout, not fail immediately."""
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+class Config:
+    WORKSPACE_DIR = Path(tempfile.mkdtemp())
+    AUTO_VERIFY_CODE = False
+    REQUIRE_APPROVAL_FOR_DANGEROUS_OPS = False
+
+
+sys.modules["config"] = type(sys)("config")
+sys.modules["config"].Config = Config
+
+from terminal_controller import TerminalController
+
+
+@pytest.fixture
+def tc():
+    Config.WORKSPACE_DIR = Path(tempfile.mkdtemp())
+    controller = TerminalController()
+    yield controller
+    if Config.WORKSPACE_DIR.exists():
+        shutil.rmtree(Config.WORKSPACE_DIR, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_timeout_zero_runs_command_with_default(tc):
+    result = await tc.execute_command("echo ok-timeout-zero", timeout=0)
+    assert result["success"] is True
+    assert "ok-timeout-zero" in result["stdout"]
+    assert result["returncode"] == 0
+
+
+@pytest.mark.asyncio
+async def test_positive_timeout_still_works(tc):
+    result = await tc.execute_command("echo ok-timeout-pos", timeout=5)
+    assert result["success"] is True
+    assert "ok-timeout-pos" in result["stdout"]


### PR DESCRIPTION
execute_command with timeout<=0 used a non-default wait path.

Treat timeout<=0 like omitting timeout.
