### PR TITLE
fix(self-evolving-tools): keep bare object schemas empty

### DIFF
--- a/chapter8/self-evolving-tools/test_normalize_schema_bare_object.py
+++ b/chapter8/self-evolving-tools/test_normalize_schema_bare_object.py
@@ -1,0 +1,41 @@
+"""normalize_schema must keep bare {"type":"object"} as an empty-object schema."""
+
+from tool_manager import normalize_schema
+
+
+def test_bare_object_type_stays_empty_properties():
+    assert normalize_schema({"type": "object"}) == {
+        "type": "object",
+        "properties": {},
+    }
+
+
+def test_object_with_required_keeps_required_not_as_property():
+    assert normalize_schema({"type": "object", "required": []}) == {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    }
+
+
+def test_object_with_properties_unchanged():
+    schema = {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "required": ["x"],
+    }
+    assert normalize_schema(schema) == schema
+
+
+def test_properties_only_still_gets_object_type():
+    assert normalize_schema({"properties": {"y": {"type": "number"}}}) == {
+        "type": "object",
+        "properties": {"y": {"type": "number"}},
+    }
+
+
+def test_plain_property_map_still_wrapped():
+    assert normalize_schema({"z": {"type": "boolean"}}) == {
+        "type": "object",
+        "properties": {"z": {"type": "boolean"}},
+    }

--- a/chapter8/self-evolving-tools/test_normalize_schema_bare_object.py
+++ b/chapter8/self-evolving-tools/test_normalize_schema_bare_object.py
@@ -1,4 +1,4 @@
-"""normalize_schema must keep bare {"type":"object"} as an empty-object schema."""
+"""normalize_schema must keep bare {"type":"object"} as an empty-object schema while preserving extra metadata."""
 
 from tool_manager import normalize_schema
 
@@ -39,3 +39,20 @@ def test_plain_property_map_still_wrapped():
         "type": "object",
         "properties": {"z": {"type": "boolean"}},
     }
+
+
+def test_object_retains_extra_metadata():
+    schema = {
+        "type": "object",
+        "description": "Tool parameters",
+        "additionalProperties": False,
+        "$defs": {"Item": {"type": "string"}},
+    }
+    expected = {
+        "type": "object",
+        "properties": {},
+        "description": "Tool parameters",
+        "additionalProperties": False,
+        "$defs": {"Item": {"type": "string"}},
+    }
+    assert normalize_schema(schema) == expected

--- a/chapter8/self-evolving-tools/tool_manager.py
+++ b/chapter8/self-evolving-tools/tool_manager.py
@@ -28,7 +28,6 @@ def normalize_schema(params) -> dict:
     if not isinstance(params, dict):
         return {"type": "object", "properties": {}}
     if params.get("type") == "object":
-        # Bare {type:object} is empty-object schema; do not treat type as a property.
         out = {"type": "object", "properties": params.get("properties") or {}}
         if "required" in params:
             out["required"] = params["required"]

--- a/chapter8/self-evolving-tools/tool_manager.py
+++ b/chapter8/self-evolving-tools/tool_manager.py
@@ -27,8 +27,13 @@ def normalize_schema(params) -> dict:
     """
     if not isinstance(params, dict):
         return {"type": "object", "properties": {}}
-    if params.get("type") == "object" and "properties" in params:
-        return params
+    if params.get("type") == "object":
+        # Bare {"type":"object"} (no properties) is a valid empty-object schema.
+        # Do not treat the "type" key itself as a property name.
+        out = {"type": "object", "properties": params.get("properties") or {}}
+        if "required" in params:
+            out["required"] = params["required"]
+        return out
     if "properties" in params:  # 有 properties 但 type 缺失/错误
         out = {"type": "object", "properties": params["properties"]}
         if "required" in params:

--- a/chapter8/self-evolving-tools/tool_manager.py
+++ b/chapter8/self-evolving-tools/tool_manager.py
@@ -28,8 +28,7 @@ def normalize_schema(params) -> dict:
     if not isinstance(params, dict):
         return {"type": "object", "properties": {}}
     if params.get("type") == "object":
-        # Bare {"type":"object"} (no properties) is a valid empty-object schema.
-        # Do not treat the "type" key itself as a property name.
+        # Bare {type:object} is empty-object schema; do not treat type as a property.
         out = {"type": "object", "properties": params.get("properties") or {}}
         if "required" in params:
             out["required"] = params["required"]

--- a/chapter8/self-evolving-tools/tool_manager.py
+++ b/chapter8/self-evolving-tools/tool_manager.py
@@ -28,14 +28,13 @@ def normalize_schema(params) -> dict:
     if not isinstance(params, dict):
         return {"type": "object", "properties": {}}
     if params.get("type") == "object":
-        out = {"type": "object", "properties": params.get("properties") or {}}
-        if "required" in params:
-            out["required"] = params["required"]
+        out = dict(params)
+        out["properties"] = params.get("properties") or {}
         return out
     if "properties" in params:  # 有 properties 但 type 缺失/错误
-        out = {"type": "object", "properties": params["properties"]}
-        if "required" in params:
-            out["required"] = params["required"]
+        out = dict(params)
+        out["type"] = "object"
+        out["properties"] = params.get("properties") or {}
         return out
     # 整个 dict 视为 properties 映射
     return {"type": "object", "properties": params}


### PR DESCRIPTION
normalize_schema turned {"type":"object"} into a schema with a nested properties type object.

Keep bare object schemas empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化对象类型架构的规范化处理，自动补齐缺失的 `properties`，并确保其格式一致。
  * 支持仅提供属性定义的架构自动识别为对象类型。
  * 保留 `required`、描述、额外属性及定义等已有元数据，提升不完整架构的兼容性。

* **测试**
  * 新增多种对象架构场景的验证，覆盖空对象、属性映射及元数据保留等情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->