### PR TITLE
fix(user-memory): return empty recent turns for limit=0

### DIFF
--- a/chapter3/user-memory/conversation_history.py
+++ b/chapter3/user-memory/conversation_history.py
@@ -125,7 +125,7 @@ class ConversationHistory:
         Returns:
             List of recent conversation turns
         """
-        # limit<=0 must return []: Python's list[-0:] is list[0:] (the full list).
+        # limit<=0 → []; list[-0:] would return the full list.
         if limit <= 0 or not self.conversations:
             return []
         return self.conversations[-limit:]

--- a/chapter3/user-memory/conversation_history.py
+++ b/chapter3/user-memory/conversation_history.py
@@ -125,7 +125,10 @@ class ConversationHistory:
         Returns:
             List of recent conversation turns
         """
-        return self.conversations[-limit:] if self.conversations else []
+        # limit<=0 must return []: Python's list[-0:] is list[0:] (the full list).
+        if limit <= 0 or not self.conversations:
+            return []
+        return self.conversations[-limit:]
     
     def get_session_turns(self, session_id: str) -> List[ConversationTurn]:
         """

--- a/chapter3/user-memory/test_recent_turns_limit_zero.py
+++ b/chapter3/user-memory/test_recent_turns_limit_zero.py
@@ -1,0 +1,31 @@
+"""get_recent_turns(limit=0) must return [], not the full history."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from config import Config
+from conversation_history import ConversationHistory, ConversationTurn
+
+
+def test_limit_zero_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "CONVERSATION_HISTORY_DIR", str(tmp_path))
+    monkeypatch.setattr(Config, "ENABLE_HISTORY_SEARCH", False)
+    hist = ConversationHistory("u1")
+    hist.conversations = [
+        ConversationTurn("s", "u0", "a0", "t0", 1),
+        ConversationTurn("s", "u1", "a1", "t1", 2),
+        ConversationTurn("s", "u2", "a2", "t2", 3),
+    ]
+    assert hist.get_recent_turns(0) == []
+
+
+def test_positive_limit_still_returns_recent(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "CONVERSATION_HISTORY_DIR", str(tmp_path))
+    monkeypatch.setattr(Config, "ENABLE_HISTORY_SEARCH", False)
+    hist = ConversationHistory("u1")
+    t1 = ConversationTurn("s", "u1", "a1", "t1", 1)
+    t2 = ConversationTurn("s", "u2", "a2", "t2", 2)
+    t3 = ConversationTurn("s", "u3", "a3", "t3", 3)
+    hist.conversations = [t1, t2, t3]
+    assert hist.get_recent_turns(2) == [t2, t3]


### PR DESCRIPTION
get_recent_turns(0) returned the full history via Python's -0 slice.

Honor 0 as no turns.
