### PR TITLE
fix(context-compression): tolerate malformed tool arguments JSON

### DIFF
--- a/chapter2/context-compression/agent.py
+++ b/chapter2/context-compression/agent.py
@@ -567,8 +567,7 @@ TODAY'S DATE: {date_string}"""
                         try:
                             function_args = json.loads(raw_args)
                         except json.JSONDecodeError:
-                            # Models sometimes emit slightly invalid JSON; match
-                            # chapter1 web-search-agent and keep the ReAct loop alive.
+                            # Tolerate bad tool-arg JSON; keep the loop alive.
                             function_args = {}
                             logger.warning(
                                 "工具参数不是合法 JSON，已按空对象继续: %r",

--- a/chapter2/context-compression/agent.py
+++ b/chapter2/context-compression/agent.py
@@ -563,7 +563,17 @@ TODAY'S DATE: {date_string}"""
                     
                     for tool_call in message['tool_calls']:
                         function_name = tool_call['function']['name']
-                        function_args = json.loads(tool_call['function']['arguments'])
+                        raw_args = tool_call['function'].get('arguments') or "{}"
+                        try:
+                            function_args = json.loads(raw_args)
+                        except json.JSONDecodeError:
+                            # Models sometimes emit slightly invalid JSON; match
+                            # chapter1 web-search-agent and keep the ReAct loop alive.
+                            function_args = {}
+                            logger.warning(
+                                "工具参数不是合法 JSON，已按空对象继续: %r",
+                                raw_args,
+                            )
                         
                         print(f"\n🔧 Executing: {function_name}")
                         print(f"   Args: {function_args}")

--- a/chapter2/context-compression/agent.py
+++ b/chapter2/context-compression/agent.py
@@ -206,6 +206,7 @@ TODAY'S DATE: {date_string}"""
             try:
                 result = self.web_tools.search_web(**arguments)
             except Exception as e:
+                logger.error(f"Failed to execute search_web: {e}")
                 return {"error": f"Failed to execute search_web: {e}"}, None
             
             # Apply compression strategy
@@ -225,6 +226,7 @@ TODAY'S DATE: {date_string}"""
             try:
                 result = self.web_tools.fetch_webpage(**arguments)
             except Exception as e:
+                logger.error(f"Failed to execute fetch_webpage: {e}")
                 return {"error": f"Failed to execute fetch_webpage: {e}"}, None
             
             # For fetch, we typically don't compress (used for follow-ups)
@@ -577,10 +579,22 @@ TODAY'S DATE: {date_string}"""
                         function_name = tool_call['function']['name']
                         raw_args = tool_call['function'].get('arguments') or "{}"
                         try:
-                            function_args = json.loads(raw_args)
+                            if isinstance(raw_args, dict):
+                                function_args = raw_args
+                            elif isinstance(raw_args, (bytes, bytearray)):
+                                function_args = json.loads(raw_args.decode("utf-8"))
+                            elif isinstance(raw_args, str):
+                                function_args = json.loads(raw_args)
+                            else:
+                                function_args = json.loads(str(raw_args))
+
                             if not isinstance(function_args, dict):
+                                logger.warning(
+                                    "Tool argument JSON is not an object, proceeding with empty object: %r",
+                                    raw_args,
+                                )
                                 function_args = {}
-                        except (json.JSONDecodeError, TypeError):
+                        except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
                             # Tolerate bad tool-arg JSON; keep the loop alive.
                             function_args = {}
                             logger.warning(

--- a/chapter2/context-compression/agent.py
+++ b/chapter2/context-compression/agent.py
@@ -203,7 +203,10 @@ TODAY'S DATE: {date_string}"""
         if tool_name == "search_web":
             if "query" not in arguments:
                 return {"error": "Missing required argument 'query' for search_web"}, None
-            result = self.web_tools.search_web(**arguments)
+            try:
+                result = self.web_tools.search_web(**arguments)
+            except Exception as e:
+                return {"error": f"Failed to execute search_web: {e}"}, None
             
             # Apply compression strategy
             query = arguments.get('query', '')
@@ -219,7 +222,10 @@ TODAY'S DATE: {date_string}"""
         elif tool_name == "fetch_webpage":
             if "url" not in arguments:
                 return {"error": "Missing required argument 'url' for fetch_webpage"}, None
-            result = self.web_tools.fetch_webpage(**arguments)
+            try:
+                result = self.web_tools.fetch_webpage(**arguments)
+            except Exception as e:
+                return {"error": f"Failed to execute fetch_webpage: {e}"}, None
             
             # For fetch, we typically don't compress (used for follow-ups)
             return result, None
@@ -574,11 +580,11 @@ TODAY'S DATE: {date_string}"""
                             function_args = json.loads(raw_args)
                             if not isinstance(function_args, dict):
                                 function_args = {}
-                        except json.JSONDecodeError:
+                        except (json.JSONDecodeError, TypeError):
                             # Tolerate bad tool-arg JSON; keep the loop alive.
                             function_args = {}
                             logger.warning(
-                                "工具参数不是合法 JSON，已按空对象继续: %r",
+                                "Tool argument is not valid JSON, proceeding with empty object: %r",
                                 raw_args,
                             )
                         

--- a/chapter2/context-compression/agent.py
+++ b/chapter2/context-compression/agent.py
@@ -197,7 +197,12 @@ TODAY'S DATE: {date_string}"""
         Returns:
             Tuple of (tool result, compressed content if applicable)
         """
+        if not isinstance(arguments, dict):
+            arguments = {}
+
         if tool_name == "search_web":
+            if "query" not in arguments:
+                return {"error": "Missing required argument 'query' for search_web"}, None
             result = self.web_tools.search_web(**arguments)
             
             # Apply compression strategy
@@ -212,11 +217,12 @@ TODAY'S DATE: {date_string}"""
             return result, compressed
             
         elif tool_name == "fetch_webpage":
+            if "url" not in arguments:
+                return {"error": "Missing required argument 'url' for fetch_webpage"}, None
             result = self.web_tools.fetch_webpage(**arguments)
             
             # For fetch, we typically don't compress (used for follow-ups)
             return result, None
-            
         else:
             return {"error": f"Unknown tool: {tool_name}"}, None
     
@@ -566,6 +572,8 @@ TODAY'S DATE: {date_string}"""
                         raw_args = tool_call['function'].get('arguments') or "{}"
                         try:
                             function_args = json.loads(raw_args)
+                            if not isinstance(function_args, dict):
+                                function_args = {}
                         except json.JSONDecodeError:
                             # Tolerate bad tool-arg JSON; keep the loop alive.
                             function_args = {}

--- a/chapter2/context-compression/test_malformed_tool_json.py
+++ b/chapter2/context-compression/test_malformed_tool_json.py
@@ -1,0 +1,48 @@
+"""Malformed tool-argument JSON must not abort execute_research."""
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Optional deps used at import time by web_tools.
+sys.modules.setdefault("html2text", types.ModuleType("html2text"))
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from compression_strategies import CompressionStrategy
+from agent import ResearchAgent, ToolCall
+
+
+def test_execute_research_survives_malformed_tool_arguments_json():
+    with patch("agent.Config.resolve_llm", return_value=("k", "http://x", "m")), \
+         patch("agent.OpenAI"), \
+         patch("agent.WebTools"), \
+         patch("agent.ContextCompressor"):
+        agent = ResearchAgent(
+            api_key="k",
+            compression_strategy=CompressionStrategy.NO_COMPRESSION,
+            verbose=False,
+            enable_streaming=False,
+        )
+
+    bad_call = {
+        "id": "call-bad",
+        "type": "function",
+        "function": {
+            "name": "search_web",
+            "arguments": '{"query": "openai",}',  # trailing comma
+        },
+    }
+    tool_msg = {"role": "assistant", "content": "searching", "tool_calls": [bad_call]}
+    final_msg = {"role": "assistant", "content": "FINAL ANSWER: ok", "tool_calls": None}
+
+    agent._non_streaming_response = MagicMock(side_effect=[tool_msg, final_msg])
+    agent._execute_tool = MagicMock(return_value=({"results": []}, None))
+
+    result = agent.execute_research(max_iterations=3)
+
+    assert result.get("error") is None
+    agent._execute_tool.assert_called()
+    assert agent._execute_tool.call_args[0][1] == {}
+    assert agent._execute_tool.called

--- a/chapter2/context-compression/test_malformed_tool_json.py
+++ b/chapter2/context-compression/test_malformed_tool_json.py
@@ -60,3 +60,82 @@ def test_execute_research_survives_malformed_tool_arguments_json():
     assert len(agent.trajectory.tool_calls) == 2
     assert agent.trajectory.tool_calls[0].result == {"error": "Missing required argument 'query' for search_web"}
     assert agent.trajectory.tool_calls[1].result == {"error": "Missing required argument 'url' for fetch_webpage"}
+
+def test_execute_research_survives_non_dict_and_invalid_bytes_tool_arguments():
+    """
+    Non-dict JSON structures (lists, numbers) and invalid UTF-8 bytes must normalize to {} and not raise.
+    """
+    with patch("agent.Config.resolve_llm", return_value=("k", "http://x", "m")), \
+         patch("agent.OpenAI"), \
+         patch("agent.WebTools") as mock_web_tools_cls, \
+         patch("agent.ContextCompressor"):
+        
+        mock_web_tools = MagicMock()
+        mock_web_tools_cls.return_value = mock_web_tools
+        
+        agent = ResearchAgent(
+            api_key="k",
+            compression_strategy=CompressionStrategy.NO_COMPRESSION,
+            verbose=False,
+            enable_streaming=False,
+        )
+
+    non_dict_calls = [
+        {"id": "c1", "type": "function", "function": {"name": "search_web", "arguments": "[]"}},
+        {"id": "c2", "type": "function", "function": {"name": "fetch_webpage", "arguments": "123"}},
+        {"id": "c3", "type": "function", "function": {"name": "search_web", "arguments": b"\x80\xff"}},
+        {"id": "c4", "type": "function", "function": {"name": "fetch_webpage", "arguments": {"invalid": 1}}},
+    ]
+    tool_msg = {"role": "assistant", "content": "searching", "tool_calls": non_dict_calls}
+    final_msg = {"role": "assistant", "content": "FINAL ANSWER: ok", "tool_calls": None}
+
+    agent._non_streaming_response = MagicMock(side_effect=[tool_msg, final_msg])
+
+    result = agent.execute_research(max_iterations=3)
+
+    assert result.get("error") is None
+    assert len(agent.trajectory.tool_calls) == 4
+    assert agent.trajectory.tool_calls[0].arguments == {}
+    assert agent.trajectory.tool_calls[1].arguments == {}
+    assert agent.trajectory.tool_calls[2].arguments == {}
+    assert agent.trajectory.tool_calls[3].arguments == {"invalid": 1}
+    assert agent.trajectory.tool_calls[0].result == {"error": "Missing required argument 'query' for search_web"}
+    assert agent.trajectory.tool_calls[1].result == {"error": "Missing required argument 'url' for fetch_webpage"}
+
+
+def test_execute_research_survives_tool_execution_exceptions():
+    """
+    Tool execution exceptions in search_web or fetch_webpage must return error dicts with compressed=None and not abort loop.
+    """
+    with patch("agent.Config.resolve_llm", return_value=("k", "http://x", "m")), \
+         patch("agent.OpenAI"), \
+         patch("agent.WebTools") as mock_web_tools_cls, \
+         patch("agent.ContextCompressor"):
+        
+        mock_web_tools = MagicMock()
+        mock_web_tools.search_web.side_effect = RuntimeError("network connection failed")
+        mock_web_tools.fetch_webpage.side_effect = RuntimeError("http 500 error")
+        mock_web_tools_cls.return_value = mock_web_tools
+        
+        agent = ResearchAgent(
+            api_key="k",
+            compression_strategy=CompressionStrategy.NO_COMPRESSION,
+            verbose=False,
+            enable_streaming=False,
+        )
+
+    call_search = {"id": "c1", "type": "function", "function": {"name": "search_web", "arguments": '{"query": "test"}'}}
+    call_fetch = {"id": "c2", "type": "function", "function": {"name": "fetch_webpage", "arguments": '{"url": "http://test.com"}'}}
+    tool_msg = {"role": "assistant", "content": "searching", "tool_calls": [call_search, call_fetch]}
+    final_msg = {"role": "assistant", "content": "FINAL ANSWER: ok", "tool_calls": None}
+
+    agent._non_streaming_response = MagicMock(side_effect=[tool_msg, final_msg])
+
+    result = agent.execute_research(max_iterations=3)
+
+    assert result.get("error") is None
+    assert len(agent.trajectory.tool_calls) == 2
+    assert agent.trajectory.tool_calls[0].result == {"error": "Failed to execute search_web: network connection failed"}
+    assert agent.trajectory.tool_calls[0].compressed_result is None
+    assert agent.trajectory.tool_calls[1].result == {"error": "Failed to execute fetch_webpage: http 500 error"}
+    assert agent.trajectory.tool_calls[1].compressed_result is None

--- a/chapter2/context-compression/test_malformed_tool_json.py
+++ b/chapter2/context-compression/test_malformed_tool_json.py
@@ -32,22 +32,31 @@ def test_execute_research_survives_malformed_tool_arguments_json():
             enable_streaming=False,
         )
 
-    bad_call = {
-        "id": "call-bad",
+    bad_call_search = {
+        "id": "call-bad-search",
         "type": "function",
         "function": {
             "name": "search_web",
             "arguments": '{"query": "openai",}',  # trailing comma
         },
     }
-    tool_msg = {"role": "assistant", "content": "searching", "tool_calls": [bad_call]}
+    bad_call_fetch = {
+        "id": "call-bad-fetch",
+        "type": "function",
+        "function": {
+            "name": "fetch_webpage",
+            "arguments": '{"url": "https://example.com",}',  # malformed JSON
+        },
+    }
+    tool_msg = {"role": "assistant", "content": "searching", "tool_calls": [bad_call_search, bad_call_fetch]}
     final_msg = {"role": "assistant", "content": "FINAL ANSWER: ok", "tool_calls": None}
 
     agent._non_streaming_response = MagicMock(side_effect=[tool_msg, final_msg])
 
-    # Do NOT mock _execute_tool, let real dispatch run over missing query arguments
+    # Do NOT mock _execute_tool, let real dispatch run over missing query/url arguments
     result = agent.execute_research(max_iterations=3)
 
     assert result.get("error") is None
-    assert len(agent.trajectory.tool_calls) == 1
+    assert len(agent.trajectory.tool_calls) == 2
     assert agent.trajectory.tool_calls[0].result == {"error": "Missing required argument 'query' for search_web"}
+    assert agent.trajectory.tool_calls[1].result == {"error": "Missing required argument 'url' for fetch_webpage"}

--- a/chapter2/context-compression/test_malformed_tool_json.py
+++ b/chapter2/context-compression/test_malformed_tool_json.py
@@ -1,4 +1,6 @@
-"""Malformed tool-argument JSON must not abort execute_research."""
+"""
+Malformed tool-argument JSON must not abort execute_research or cause real dispatch to raise TypeError.
+"""
 import sys
 import types
 from pathlib import Path
@@ -11,14 +13,18 @@ sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda: None)
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from compression_strategies import CompressionStrategy
-from agent import ResearchAgent, ToolCall
+from agent import ResearchAgent
 
 
 def test_execute_research_survives_malformed_tool_arguments_json():
     with patch("agent.Config.resolve_llm", return_value=("k", "http://x", "m")), \
          patch("agent.OpenAI"), \
-         patch("agent.WebTools"), \
+         patch("agent.WebTools") as mock_web_tools_cls, \
          patch("agent.ContextCompressor"):
+        
+        mock_web_tools = MagicMock()
+        mock_web_tools_cls.return_value = mock_web_tools
+        
         agent = ResearchAgent(
             api_key="k",
             compression_strategy=CompressionStrategy.NO_COMPRESSION,
@@ -38,11 +44,10 @@ def test_execute_research_survives_malformed_tool_arguments_json():
     final_msg = {"role": "assistant", "content": "FINAL ANSWER: ok", "tool_calls": None}
 
     agent._non_streaming_response = MagicMock(side_effect=[tool_msg, final_msg])
-    agent._execute_tool = MagicMock(return_value=({"results": []}, None))
 
+    # Do NOT mock _execute_tool, let real dispatch run over missing query arguments
     result = agent.execute_research(max_iterations=3)
 
     assert result.get("error") is None
-    agent._execute_tool.assert_called()
-    assert agent._execute_tool.call_args[0][1] == {}
-    assert agent._execute_tool.called
+    assert len(agent.trajectory.tool_calls) == 1
+    assert agent.trajectory.tool_calls[0].result == {"error": "Missing required argument 'query' for search_web"}


### PR DESCRIPTION
Malformed tool-argument JSON aborted ResearchAgent.execute_research.

Catch parse errors and continue like the web-search sibling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 增强工具调用参数校验：当 `arguments` 非法或缺少必要的查询条件/网址时，不再产生压缩结果，并返回明确错误信息。
  * 对工具实际执行新增异常捕获与错误包装，避免意外异常中断研究流程。
  * 改进工具参数 JSON 解析的容错：解析失败会回退为默认空参数并记录告警，保证流程继续。
* **测试**
  * 新增畸形工具参数回归测试：验证研究任务不中止，并正确回传缺参错误（包含多条 tool_call 情况）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->