### PR TITLE
fix(log-sanitization): treat null pii_values like empty list

### DIFF
--- a/chapter2/log-sanitization/agent.py
+++ b/chapter2/log-sanitization/agent.py
@@ -193,7 +193,7 @@ class LogSanitizationAgent:
             response_json = json.loads(full_response)
             
             # Extract PII values
-            pii_values = response_json.get('pii_values', [])
+            pii_values = response_json.get('pii_values') or []
             # Strip leading/trailing whitespace and special characters like '-' or empty
             cleaned_pii_values = []
             for pii in pii_values:

--- a/chapter2/log-sanitization/test_null_pii_values.py
+++ b/chapter2/log-sanitization/test_null_pii_values.py
@@ -1,0 +1,38 @@
+"""detect_pii must treat JSON null pii_values like an empty list."""
+import json
+import sys
+import types
+from unittest.mock import patch
+
+sys.modules.setdefault("ollama", types.ModuleType("ollama"))
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+
+from agent import LogSanitizationAgent
+
+
+def test_null_pii_values_returns_empty_list():
+    agent = object.__new__(LogSanitizationAgent)
+    agent.count_tokens = lambda text: len(text) // 4
+    agent._chat_stream = lambda messages: iter(
+        [json.dumps({"pii_values": None})]
+    )
+
+    with patch("builtins.print"):
+        pii_values, metrics = agent.detect_pii("Alice phone 555-0100")
+
+    assert pii_values == []
+    assert metrics["pii_items_found"] == 0
+
+
+def test_list_pii_values_still_cleaned():
+    agent = object.__new__(LogSanitizationAgent)
+    agent.count_tokens = lambda text: len(text) // 4
+    agent._chat_stream = lambda messages: iter(
+        [json.dumps({"pii_values": ["  Alice  ", "-", "Bob"]})]
+    )
+
+    with patch("builtins.print"):
+        pii_values, metrics = agent.detect_pii("text")
+
+    assert pii_values == ["Alice", "Bob"]
+    assert metrics["pii_items_found"] == 2


### PR DESCRIPTION
detect_pii crashed with TypeError when pii_values was null.

Treat null like an empty list.
