### PR TITLE
fix(contextual-retrieval): treat conversation_history_limit=0 as no history

### DIFF
--- a/chapter3/contextual-retrieval/agent.py
+++ b/chapter3/contextual-retrieval/agent.py
@@ -157,10 +157,12 @@ Remember: Your credibility depends on providing accurate, well-cited information
         
         # Add conversation history (limited)
         history_limit = self.config.agent.conversation_history_limit
-        if len(self.conversation_history) > history_limit:
-            messages.extend(self.conversation_history[-history_limit:])
-        else:
-            messages.extend(self.conversation_history)
+        # limit<=0 means no history: Python's list[-0:] is list[0:] (the full list).
+        if history_limit > 0:
+            if len(self.conversation_history) > history_limit:
+                messages.extend(self.conversation_history[-history_limit:])
+            else:
+                messages.extend(self.conversation_history)
         
         # Add current user query
         messages.append({"role": "user", "content": user_query})

--- a/chapter3/contextual-retrieval/agent.py
+++ b/chapter3/contextual-retrieval/agent.py
@@ -157,7 +157,7 @@ Remember: Your credibility depends on providing accurate, well-cited information
         
         # Add conversation history (limited)
         history_limit = self.config.agent.conversation_history_limit
-        # limit<=0 means no history: Python's list[-0:] is list[0:] (the full list).
+        # limit<=0 → no history; list[-0:] would include all turns.
         if history_limit > 0:
             if len(self.conversation_history) > history_limit:
                 messages.extend(self.conversation_history[-history_limit:])

--- a/chapter3/contextual-retrieval/test_history_limit_zero.py
+++ b/chapter3/contextual-retrieval/test_history_limit_zero.py
@@ -1,0 +1,39 @@
+"""conversation_history_limit=0 must omit history, not include all via [-0:]."""
+from types import SimpleNamespace
+
+from agent import AgenticRAG
+
+
+def test_history_limit_zero_omits_history():
+    agent = object.__new__(AgenticRAG)
+    agent.config = SimpleNamespace(
+        agent=SimpleNamespace(conversation_history_limit=0)
+    )
+    agent._get_system_prompt = lambda: "sys"
+    agent.conversation_history = [
+        {"role": "user", "content": "old1"},
+        {"role": "assistant", "content": "old2"},
+    ]
+    msgs = agent._build_messages("new question")
+    assert msgs == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "new question"},
+    ]
+
+
+def test_positive_history_limit_still_keeps_tail():
+    agent = object.__new__(AgenticRAG)
+    agent.config = SimpleNamespace(
+        agent=SimpleNamespace(conversation_history_limit=1)
+    )
+    agent._get_system_prompt = lambda: "sys"
+    agent.conversation_history = [
+        {"role": "user", "content": "old1"},
+        {"role": "assistant", "content": "old2"},
+    ]
+    msgs = agent._build_messages("new question")
+    assert msgs == [
+        {"role": "system", "content": "sys"},
+        {"role": "assistant", "content": "old2"},
+        {"role": "user", "content": "new question"},
+    ]


### PR DESCRIPTION
conversation_history_limit=0 included the full history via Python's -0 slice.

Honor 0 as no history.
