### PR TITLE
fix(paper-to-ppt): drop non-dict review issue entries

### DIFF
--- a/chapter5/paper-to-ppt/demo.py
+++ b/chapter5/paper-to-ppt/demo.py
@@ -55,7 +55,7 @@ def save_text(name, text):
 
 
 def _review_issues(review: dict) -> list:
-    """Null/non-list issues → []; drop non-dict entries so callers can use .get."""
+    """Return issue dicts; null/non-list → []; skip non-dict entries."""
     issues = review.get("issues")
     if issues is None:
         return []

--- a/chapter5/paper-to-ppt/demo.py
+++ b/chapter5/paper-to-ppt/demo.py
@@ -55,9 +55,13 @@ def save_text(name, text):
 
 
 def _review_issues(review: dict) -> list:
-    """JSON null issues must behave like omit ([])."""
+    """Null/non-list issues → []; drop non-dict entries so callers can use .get."""
     issues = review.get("issues")
-    return issues if issues is not None else []
+    if issues is None:
+        return []
+    if not isinstance(issues, list):
+        return []
+    return [i for i in issues if isinstance(i, dict)]
 
 
 def summarize_review(review: dict) -> str:

--- a/chapter5/paper-to-ppt/test_null_issues.py
+++ b/chapter5/paper-to-ppt/test_null_issues.py
@@ -23,3 +23,11 @@ def test_issues_preserved():
     assert _review_issues({"issues": issues}) == issues
     text = summarize_review({"overall_score": 50, "pass": False, "issues": issues})
     assert "high=1" in text
+
+
+def test_non_dict_issue_items_dropped():
+    assert _review_issues({"issues": [None, {"severity": "high"}, "x"]}) == [{"severity": "high"}]
+    text = summarize_review({"overall_score": 40, "pass": False, "issues": [None, {"severity": "high"}]})
+    assert "high=1" in text
+    assert "issues=1" in text
+


### PR DESCRIPTION
summarize_review crashed on .get when an issues list contained a non-dict entry.

Skip non-dict issue items.
