### PR TITLE
fix(paper-to-video): skip null bullet items when rendering

### DIFF
--- a/chapter5/paper-to-video/demo.py
+++ b/chapter5/paper-to-video/demo.py
@@ -221,6 +221,12 @@ def load_script_file(path: Path) -> list:
 # ---------------------------------------------------------------------------
 # 步骤 1：渲染幻灯片 PNG
 # ---------------------------------------------------------------------------
+def _slide_bullets(slide: dict) -> list[str]:
+    """Keep string bullets only; JSON null / non-str items are skipped."""
+    bullets = slide.get("bullets") or []
+    return [b for b in bullets if isinstance(b, str)]
+
+
 def render_slide(slide: dict, index: int, total: int) -> Path:
     """把一页幻灯片渲染为 1280x720 的 PNG。"""
     img = Image.new("RGB", (WIDTH, HEIGHT), color=(23, 32, 56))  # 深蓝底
@@ -246,7 +252,7 @@ def render_slide(slide: dict, index: int, total: int) -> Path:
     y += 70
 
     # 要点
-    for bullet in slide["bullets"]:
+    for bullet in _slide_bullets(slide):
         draw.ellipse([94, y + 14, 110, y + 30], fill=(88, 166, 255))
         for j, line in enumerate(textwrap.wrap(bullet, width=30)):
             draw.text((130, y), line, font=bullet_font, fill=(220, 226, 240))
@@ -267,7 +273,7 @@ def render_slide(slide: dict, index: int, total: int) -> Path:
 # ---------------------------------------------------------------------------
 def offline_narration(slide: dict) -> str:
     """离线占位讲解词：不调用 LLM，用副标题+要点拼出一段可读文本（供占位音轨估时）。"""
-    return f"{slide['subtitle']}。" + "；".join(slide["bullets"]) + "。"
+    return f"{slide['subtitle']}。" + "；".join(_slide_bullets(slide)) + "。"
 
 
 def generate_narration(client, cfg: Config, slide: dict, index: int, total: int) -> str:
@@ -282,7 +288,7 @@ def generate_narration(client, cfg: Config, slide: dict, index: int, total: int)
         f"当前是第 {index + 1}/{total} 页幻灯片。{position}。\n\n"
         f"幻灯片标题：{slide['title']}\n"
         f"副标题：{slide['subtitle']}\n"
-        f"要点：\n- " + "\n- ".join(slide["bullets"]) + "\n\n"
+        f"要点：\n- " + "\n- ".join(_slide_bullets(slide)) + "\n\n"
         "请生成这一页的口语化讲解词，要求：\n"
         "1) 是引导性的口语叙述，而不是逐条复述要点；\n"
         "2) 自然流畅、有过渡，像真人讲课；\n"

--- a/chapter5/paper-to-video/test_null_bullet_item.py
+++ b/chapter5/paper-to-video/test_null_bullet_item.py
@@ -1,0 +1,15 @@
+"""Slide bullets containing null must still render a PNG."""
+import demo
+
+
+def test_render_slide_skips_null_bullet(tmp_path, monkeypatch):
+    monkeypatch.setattr(demo, "SLIDES_DIR", tmp_path)
+    slide = {
+        "title": "Demo Title",
+        "subtitle": "Demo Subtitle",
+        "bullets": ["ok", None, "also"],
+    }
+    path = demo.render_slide(slide, 0, 1)
+    assert path.exists()
+    assert path.stat().st_size > 0
+    assert path == tmp_path / "slide_01.png"


### PR DESCRIPTION
render_slide crashed when a bullets list contained null.

Skip null bullet items.
