### PR TITLE
fix(coding-agent): support shell commands on Windows

### DIFF
--- a/chapter5/coding-agent/README.md
+++ b/chapter5/coding-agent/README.md
@@ -557,9 +557,10 @@ Check:
 
 Ensure:
 
-- Bash is available at `/bin/bash`
+- Bash is available on `PATH` on macOS/Linux
+- PowerShell is available on `PATH` on Windows (`cmd.exe` is used as a fallback)
 - Working directory exists
-- Commands are properly quoted
+- Commands use the native shell syntax and are properly quoted
 
 ### Testing
 

--- a/chapter5/coding-agent/README_NEW.md
+++ b/chapter5/coding-agent/README_NEW.md
@@ -379,9 +379,10 @@ Check:
 ### Shell commands fail
 
 Ensure:
-- Bash is available at `/bin/bash`
+- Bash is available on `PATH` on macOS/Linux
+- PowerShell is available on `PATH` on Windows (`cmd.exe` is used as a fallback)
 - Working directory exists
-- Commands are properly quoted
+- Commands use the native shell syntax and are properly quoted
 
 ## 🎓 Learning Path
 
@@ -433,4 +434,3 @@ This is an educational implementation. Feel free to adapt and extend!
 ---
 
 **Built with pure Python for maximum portability and learning! 🐍✨**
-

--- a/chapter5/coding-agent/tests/test_bash_output_tool.py
+++ b/chapter5/coding-agent/tests/test_bash_output_tool.py
@@ -95,3 +95,21 @@ class TestBashOutputTool:
         assert "output_size" in result.data
         assert result.data["output_size"] > 0
 
+    def test_background_job_inherits_persistent_environment(self, system_state):
+        """Background Bash jobs retain variables exported earlier in the session."""
+        bash_tool = BashTool(system_state)
+        output_tool = BashOutputTool(system_state)
+
+        bash_tool.execute({"command": "export BACKGROUND_TEST_VALUE=persisted"})
+        bash_result = bash_tool.execute({
+            "command": "echo $BACKGROUND_TEST_VALUE",
+            "run_in_background": True,
+        })
+        time.sleep(0.5)
+
+        result = output_tool.execute({
+            "bash_id": bash_result.data["background_job_id"],
+        })
+
+        assert result.success
+        assert "persisted" in result.data["output"]

--- a/chapter5/coding-agent/tests/test_shell_session.py
+++ b/chapter5/coding-agent/tests/test_shell_session.py
@@ -2,7 +2,89 @@
 Test cases for ShellSession __CMD_DONE__ marker handling
 """
 
+from unittest.mock import MagicMock, patch
+
+from tools import shell_session
 from tools.shell_session import ShellSession
+
+
+class TestShellSelection:
+    """Test platform-specific shell selection and command wrapping."""
+
+    def test_windows_prefers_powershell(self):
+        def find_shell(name):
+            if name == "powershell":
+                return r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+            return None
+
+        with patch.object(shell_session.shutil, "which", side_effect=find_shell):
+            kind, command = shell_session._get_shell_configuration("nt")
+
+        assert kind == "powershell"
+        assert command[0].endswith("powershell.exe")
+        assert command[-2:] == ["-Command", "-"]
+        assert "/bin/bash" not in command
+
+    def test_windows_falls_back_to_comspec(self):
+        with patch.object(shell_session.shutil, "which", return_value=None):
+            with patch.dict(
+                shell_session.os.environ,
+                {"COMSPEC": r"C:\Windows\System32\cmd.exe"},
+            ):
+                kind, command = shell_session._get_shell_configuration("nt")
+
+        assert kind == "cmd"
+        assert command == [r"C:\Windows\System32\cmd.exe", "/D", "/Q"]
+
+    def test_execute_uses_selected_windows_shell(self):
+        process = MagicMock()
+        process.communicate.return_value = (
+            "hello\n"
+            "__CMD_DONE_fixed__0\n"
+            "__CMD_ENV_START_fixed__\n"
+            "PATH=C:\\Windows\n"
+            "__CMD_ENV_END_fixed__\n"
+            "__CMD_CWD_fixed__C:\\workspace\n",
+            None,
+        )
+        process.returncode = 0
+        windows_command = ["powershell.exe", "-NoLogo", "-Command", "-"]
+        session = ShellSession(session_id="test_windows_start")
+
+        with patch.object(
+            shell_session,
+            "_get_shell_configuration",
+            return_value=("powershell", windows_command),
+        ):
+            with patch.object(shell_session.uuid, "uuid4") as make_uuid:
+                make_uuid.return_value.hex = "fixed"
+                with patch.object(
+                    shell_session.subprocess, "Popen", return_value=process
+                ) as popen:
+                    output, exit_code = session.execute("Write-Output hello")
+
+        assert session.shell_kind == "powershell"
+        assert popen.call_args.args[0] == windows_command
+        assert "Set-Location" in process.communicate.call_args.args[0]
+        assert output == "hello"
+        assert exit_code == 0
+        assert session.env == {"PATH": r"C:\Windows"}
+
+    def test_powershell_protocol_quotes_windows_working_directory(self):
+        session = ShellSession(
+            session_id="test_windows_protocol",
+            current_directory=r"C:\Users\O'Brien\coding-agent",
+        )
+        session.shell_kind = "powershell"
+
+        script = session._build_command_script(
+            "python hello_world.py", "__DONE__", "__CWD__"
+        )
+
+        assert "Set-Location -LiteralPath 'C:\\Users\\O''Brien\\coding-agent'" in script
+        assert "[Convert]::FromBase64String" in script
+        assert "Write-Output ('__DONE__' + $__agent_exit_code)" in script
+        assert "Write-Output ('__CWD__' + (Get-Location).Path)" in script
 
 
 class TestShellSessionMarker:

--- a/chapter5/coding-agent/tools.json
+++ b/chapter5/coding-agent/tools.json
@@ -36,7 +36,7 @@
           "properties": {
             "command": {
               "type": "string",
-              "description": "The command to execute"
+              "description": "The command to execute. Use Bash syntax on macOS/Linux and PowerShell syntax on Windows (use ';' instead of '&&' for compatibility with Windows PowerShell 5.1)."
             },
             "timeout": {
               "type": "number",

--- a/chapter5/coding-agent/tools/bash_output_tool.py
+++ b/chapter5/coding-agent/tools/bash_output_tool.py
@@ -6,6 +6,7 @@ import os
 import re
 from typing import Dict, Any
 from .base import BaseTool
+from .shell_session import get_background_log_path
 
 
 class BashOutputTool(BaseTool):
@@ -27,7 +28,7 @@ class BashOutputTool(BaseTool):
         bash_id = params["bash_id"]
         filter_pattern = params.get("filter")
         
-        log_file = f"/tmp/{bash_id}.log"
+        log_file = get_background_log_path(bash_id)
         
         if not os.path.exists(log_file):
             return {"error": f"Bash job not found (no output log) for bash_id: {bash_id}"}
@@ -42,7 +43,7 @@ class BashOutputTool(BaseTool):
                 # seeking past the end and returning nothing forever.
                 previous_offset = 0
 
-            with open(log_file, 'r') as f:
+            with open(log_file, 'r', encoding='utf-8', errors='replace') as f:
                 f.seek(previous_offset)
                 output = f.read()
                 self.state.bash_output_offsets[bash_id] = f.tell()
@@ -61,4 +62,3 @@ class BashOutputTool(BaseTool):
             
         except Exception as e:
             return {"error": f"Error reading bash output: {str(e)}"}
-

--- a/chapter5/coding-agent/tools/bash_tool.py
+++ b/chapter5/coding-agent/tools/bash_tool.py
@@ -2,7 +2,6 @@
 Bash tool - Command execution in persistent shell sessions
 """
 
-import subprocess
 import time
 import hashlib
 from typing import Dict, Any
@@ -46,17 +45,13 @@ class BashTool(BaseTool):
         session = self.state.shell_sessions[shell_id]
         
         if run_in_background:
-            # Start background process
+            # Start a separate native-shell process. ShellSession handles the
+            # platform-specific invocation and log location.
             bg_id = f"bg_{int(time.time())}_{hashlib.md5(command.encode()).hexdigest()[:8]}"
-            session.start()
-            # Launch command in background; the subshell grouping ensures the
-            # redirect covers the whole command (incl. && / || chains), so all
-            # output lands in the log file instead of leaking to this session.
-            bg_command = f"( {command} ) > /tmp/{bg_id}.log 2>&1 & echo $!"
-            output, exit_code = session.execute(bg_command, timeout=5)
+            pid = session.start_background(command, bg_id)
             
             return {
-                "output": f"Background job started with ID: {bg_id}\nPID: {output.strip()}",
+                "output": f"Background job started with ID: {bg_id}\nPID: {pid}",
                 "exit_code": 0,
                 "shell_id": shell_id,
                 "background_job_id": bg_id
@@ -78,4 +73,3 @@ class BashTool(BaseTool):
                 "shell_id": shell_id,
                 "working_directory": session.current_directory
             }
-

--- a/chapter5/coding-agent/tools/shell_session.py
+++ b/chapter5/coding-agent/tools/shell_session.py
@@ -1,39 +1,88 @@
 """
-Shell session management for persistent bash execution
+Cross-platform shell session management for persistent command execution.
 """
 
-import subprocess
-import time
+import base64
 import os
+import queue
 import re
 import shlex
-import queue
+import shutil
+import subprocess
+import tempfile
 import threading
+import time
+import uuid
 from dataclasses import dataclass, field
-from typing import Optional, Tuple, Dict
+from typing import Dict, List, Optional, TextIO, Tuple
+
+
+def get_background_log_path(job_id: str) -> str:
+    """Return a platform-appropriate path for a background job log."""
+    return os.path.join(tempfile.gettempdir(), f"{job_id}.log")
+
+
+def _get_shell_configuration(platform_name: Optional[str] = None) -> Tuple[str, List[str]]:
+    """Return the shell dialect and command for the current platform."""
+    platform_name = platform_name or os.name
+
+    if platform_name == "nt":
+        # PowerShell is available by default on supported Windows versions and
+        # accepts common commands such as `python`, `git`, and `ls`. Prefer the
+        # newer cross-platform edition when the user has installed it.
+        powershell = shutil.which("pwsh") or shutil.which("powershell")
+        if powershell:
+            return "powershell", [
+                powershell,
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                "-",
+            ]
+
+        # COMSPEC is a last-resort fallback for stripped-down Windows images
+        # where PowerShell is unavailable.
+        return "cmd", [os.environ.get("COMSPEC", "cmd.exe"), "/D", "/Q"]
+
+    bash = shutil.which("bash") or "/bin/bash"
+    return "bash", [bash]
 
 
 @dataclass
 class ShellSession:
-    """Manages a persistent shell session"""
+    """Manage a persistent native shell session."""
+
     session_id: str
     process: Optional[subprocess.Popen] = None
-    current_directory: str = field(default_factory=lambda: os.getcwd())
+    current_directory: str = field(default_factory=os.getcwd)
     env: Dict[str, str] = field(default_factory=lambda: os.environ.copy())
     output_buffer: str = ""
-    
-    def start(self):
-        """Start the shell process"""
+    shell_kind: str = field(default="", init=False)
+    shell_command: List[str] = field(default_factory=list, init=False, repr=False)
+    background_processes: Dict[str, subprocess.Popen] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    def _configure_shell(self) -> None:
+        if not self.shell_command:
+            self.shell_kind, self.shell_command = _get_shell_configuration()
+
+    def start(self) -> None:
+        """Start the persistent shell process."""
         if self.process is None or self.process.poll() is not None:
+            self._configure_shell()
             self.process = subprocess.Popen(
-                ["/bin/bash"],
+                self.shell_command,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
                 bufsize=1,
                 cwd=self.current_directory,
-                env=self.env
+                env=self.env,
             )
             # Reader thread feeds stdout lines into a queue so that execute()
             # can wait on them with a real timeout (a bare readline() would
@@ -42,43 +91,190 @@ class ShellSession:
             reader = threading.Thread(
                 target=self._read_stdout,
                 args=(self.process, self._output_queue),
-                daemon=True
+                daemon=True,
             )
             reader.start()
 
-    def _read_stdout(self, process, q):
+    @staticmethod
+    def _read_stdout(process: subprocess.Popen, output_queue: queue.Queue) -> None:
         """Pump stdout lines into the queue; None marks end of stream."""
-        for line in iter(process.stdout.readline, ''):
-            q.put(line)
-        q.put(None)
+        for line in iter(process.stdout.readline, ""):
+            output_queue.put(line)
+        output_queue.put(None)
 
-    def _restart(self):
-        """Kill a stuck shell and start a fresh one (keeps current_directory)."""
-        self.kill()
+    @staticmethod
+    def _quote_powershell(value: str) -> str:
+        """Quote a string as a PowerShell single-quoted literal."""
+        return "'" + value.replace("'", "''") + "'"
+
+    def _build_command_script(
+        self,
+        command: str,
+        done_marker: str,
+        cwd_marker: str,
+        env_start_marker: str = "",
+        env_end_marker: str = "",
+    ) -> str:
+        """Wrap a command with platform-specific completion markers."""
+        if self.shell_kind == "powershell":
+            cwd = self._quote_powershell(self.current_directory)
+            # Capture status inside the generated script block immediately
+            # after the user's final statement. Checking `$?` after invoking a
+            # script block can incorrectly turn command-not-found into success.
+            command_with_status = (
+                f"{command}\n"
+                "$global:__agent_command_succeeded = $?\n"
+                "$global:__agent_native_exit_code = $LASTEXITCODE"
+            )
+            encoded_command = base64.b64encode(
+                command_with_status.encode("utf-8")
+            ).decode("ascii")
+            return (
+                "[Console]::OutputEncoding = [Text.Encoding]::UTF8; "
+                "$OutputEncoding = [Console]::OutputEncoding; "
+                f"Set-Location -LiteralPath {cwd}; "
+                "$global:LASTEXITCODE = $null; "
+                "$global:__agent_command_succeeded = $false; "
+                "$global:__agent_native_exit_code = $null; "
+                "$__agent_command = [Text.Encoding]::UTF8.GetString("
+                f"[Convert]::FromBase64String('{encoded_command}')); "
+                "& ([ScriptBlock]::Create($__agent_command)); "
+                "$__agent_exit_code = $global:__agent_native_exit_code; "
+                "if ($null -eq $__agent_exit_code) { "
+                "  if ($global:__agent_command_succeeded) { $__agent_exit_code = 0 } "
+                "else { $__agent_exit_code = 1 } "
+                "}; "
+                f"Write-Output ('{done_marker}' + $__agent_exit_code); "
+                f"Write-Output '{env_start_marker}'; "
+                "Get-ChildItem Env: | ForEach-Object { "
+                "Write-Output ($_.Name + '=' + $_.Value) }; "
+                f"Write-Output '{env_end_marker}'; "
+                f"Write-Output ('{cwd_marker}' + (Get-Location).Path)\n"
+            )
+
+        if self.shell_kind == "cmd":
+            # Double quotes are sufficient for normal Windows paths. A quote
+            # cannot occur in a Windows file or directory name.
+            cwd = f'"{self.current_directory}"'
+            return (
+                "chcp 65001 > nul\n"
+                f"cd /d {cwd}\n"
+                f"{command}\n"
+                'set "__agent_exit_code=%errorlevel%"\n'
+                f"echo {done_marker}%__agent_exit_code%\n"
+                f"echo {env_start_marker}\n"
+                "set\n"
+                f"echo {env_end_marker}\n"
+                f"echo {cwd_marker}%CD%\n"
+            )
+
+        cwd = shlex.quote(self.current_directory)
+        return (
+            f"cd {cwd}\n"
+            "{\n"
+            f"{command}\n"
+            "}\n"
+            "__agent_exit_code=$?\n"
+            f"printf '%s%s\\n' '{done_marker}' \"$__agent_exit_code\"\n"
+            f"printf '%s%s\\n' '{cwd_marker}' \"$PWD\"\n"
+        )
+
+    def _parse_protocol_output(
+        self,
+        output_lines: List[str],
+        done_marker: str,
+        cwd_marker: str,
+        env_start_marker: str = "",
+        env_end_marker: str = "",
+        fallback_exit_code: int = -1,
+    ) -> Tuple[str, int]:
+        """Remove internal markers and apply shell state from command output."""
+        command_output = []
+        environment_lines = []
+        reading_environment = False
+        exit_code = fallback_exit_code
+
+        for line in output_lines:
+            stripped = line.rstrip("\r\n")
+            match = re.fullmatch(re.escape(done_marker) + r"(-?\d+)", stripped)
+            if match:
+                exit_code = int(match.group(1))
+                continue
+
+            if env_start_marker and stripped == env_start_marker:
+                reading_environment = True
+                continue
+            if env_end_marker and stripped == env_end_marker:
+                reading_environment = False
+                updated_environment = {}
+                for entry in environment_lines:
+                    name, separator, value = entry.partition("=")
+                    if separator and name:
+                        updated_environment[name] = value
+                if updated_environment:
+                    self.env = updated_environment
+                continue
+            if reading_environment:
+                environment_lines.append(stripped)
+                continue
+
+            if stripped.startswith(cwd_marker) and exit_code != -1:
+                new_directory = stripped[len(cwd_marker):]
+                if new_directory and os.path.isdir(new_directory):
+                    self.current_directory = new_directory
+                continue
+
+            command_output.append(stripped)
+
+        return "\n".join(command_output), exit_code
+
+    def _restart(self) -> None:
+        """Replace a stuck shell while retaining session state."""
+        self._terminate_process(self.process)
         self.process = None
         self.start()
-    
-    def execute(self, command: str, timeout: float = 120) -> Tuple[str, int]:
-        """Execute command in the persistent shell"""
-        self.start()
-        
+
+    @staticmethod
+    def _terminate_process(process: Optional[subprocess.Popen]) -> None:
+        if process is None or process.poll() is not None:
+            return
+        process.terminate()
         try:
-            # Send command
-            full_command = f"cd {shlex.quote(self.current_directory)} && {command}\n"
-            self.process.stdin.write(full_command)
-            self.process.stdin.write("echo __CMD_DONE__$?\n")
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+    def execute(self, command: str, timeout: float = 120) -> Tuple[str, int]:
+        """Execute a command in the persistent native shell."""
+        self._configure_shell()
+
+        # PowerShell and cmd read redirected stdin through end-of-file rather
+        # than executing it incrementally. Run one process per Windows command
+        # and carry its directory/environment forward to preserve session state.
+        if self.shell_kind in {"powershell", "cmd"}:
+            return self._execute_windows(command, timeout)
+
+        self.start()
+
+        try:
+            # A per-command nonce prevents command output that happens to look
+            # like a protocol marker from truncating or desynchronizing output.
+            nonce = uuid.uuid4().hex
+            done_marker = f"__CMD_DONE_{nonce}__"
+            cwd_marker = f"__CMD_CWD_{nonce}__"
+            script = self._build_command_script(command, done_marker, cwd_marker)
+
+            self.process.stdin.write(script)
             self.process.stdin.flush()
-            
-            # Read output until marker
+
             output_lines = []
-            deadline = time.time() + timeout
-            exit_code = -1
+            deadline = time.monotonic() + timeout
 
             while True:
-                remaining = deadline - time.time()
+                remaining = deadline - time.monotonic()
                 if remaining <= 0:
-                    # Kill the stuck shell so the pending marker of the
-                    # timed-out command cannot corrupt the next command.
+                    # Replace the stuck shell so its pending marker cannot
+                    # corrupt output from the next command.
                     self._restart()
                     return f"Command timed out (timeout: {timeout}s)", -1
 
@@ -91,41 +287,147 @@ class ShellSession:
                 if line is None:  # shell exited unexpectedly
                     break
 
-                # 只认独占一行的结束标记；命令输出中恰好包含标记字符串的行
-                # 视为普通输出，避免误截断或与下一命令的输出错位。
-                m = re.fullmatch(r"__CMD_DONE__(\d+)", line.strip())
-                if m:
-                    exit_code = int(m.group(1))
+                stripped = line.rstrip("\r\n")
+                output_lines.append(stripped)
+                if stripped.startswith(cwd_marker):
                     break
 
-                output_lines.append(line.rstrip())
+            return self._parse_protocol_output(
+                output_lines,
+                done_marker,
+                cwd_marker,
+            )
 
-            output = "\n".join(output_lines)
+        except Exception as exc:
+            return f"Error executing command: {exc}", -1
 
-            # Update current directory if cd was used
-            if command.strip().startswith("cd "):
-                try:
-                    self.process.stdin.write("pwd\n")
-                    self.process.stdin.flush()
-                    new_dir = self._output_queue.get(timeout=5)
-                    if new_dir:
-                        new_dir = new_dir.strip()
-                        if new_dir and os.path.isdir(new_dir):
-                            self.current_directory = new_dir
-                except Exception:
-                    pass
+    def _execute_windows(self, command: str, timeout: float) -> Tuple[str, int]:
+        """Execute one Windows command while preserving logical session state."""
+        nonce = uuid.uuid4().hex
+        done_marker = f"__CMD_DONE_{nonce}__"
+        cwd_marker = f"__CMD_CWD_{nonce}__"
+        env_start_marker = f"__CMD_ENV_START_{nonce}__"
+        env_end_marker = f"__CMD_ENV_END_{nonce}__"
+        script = self._build_command_script(
+            command,
+            done_marker,
+            cwd_marker,
+            env_start_marker,
+            env_end_marker,
+        )
 
-            return output, exit_code
-            
-        except Exception as e:
-            return f"Error executing command: {str(e)}", -1
-    
-    def kill(self):
-        """Terminate the shell session"""
-        if self.process and self.process.poll() is None:
-            self.process.terminate()
+        process = subprocess.Popen(
+            self.shell_command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=self.current_directory,
+            env=self.env,
+        )
+        try:
+            output, _ = process.communicate(script, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            self._terminate_process(process)
+            return f"Command timed out (timeout: {timeout}s)", -1
+        except Exception:
+            self._terminate_process(process)
+            raise
+
+        return self._parse_protocol_output(
+            output.splitlines(),
+            done_marker,
+            cwd_marker,
+            env_start_marker,
+            env_end_marker,
+            fallback_exit_code=process.returncode,
+        )
+
+    def _background_shell_command(self, command: str) -> List[str]:
+        """Build a one-shot shell command for a background process."""
+        self._configure_shell()
+        executable = self.shell_command[0]
+
+        if self.shell_kind == "powershell":
+            encoded_command = base64.b64encode(
+                (
+                    "[Console]::OutputEncoding = [Text.Encoding]::UTF8; "
+                    "$OutputEncoding = [Console]::OutputEncoding; "
+                    + command
+                ).encode("utf-16-le")
+            ).decode("ascii")
+            return [
+                executable,
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-EncodedCommand",
+                encoded_command,
+            ]
+        if self.shell_kind == "cmd":
+            return [executable, "/D", "/S", "/C", f"chcp 65001 > nul & {command}"]
+        return [executable, "-c", command]
+
+    def start_background(self, command: str, job_id: str) -> int:
+        """Start a command in a separate process and log combined output."""
+        log_path = get_background_log_path(job_id)
+
+        # Keep POSIX background jobs in the persistent Bash process so exports
+        # made by earlier commands remain visible, matching the original tool
+        # behavior. Windows commands use one-shot native shell processes.
+        self._configure_shell()
+        if self.shell_kind == "bash":
+            background_command = (
+                f"( {command} ) > {shlex.quote(log_path)} 2>&1 & echo $!"
+            )
+            output, exit_code = self.execute(background_command, timeout=5)
+            if exit_code != 0:
+                raise RuntimeError(f"Unable to start background command: {output}")
             try:
-                self.process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                self.process.kill()
+                return int(output.strip().splitlines()[-1])
+            except (IndexError, ValueError) as exc:
+                raise RuntimeError(
+                    f"Unable to determine background command PID: {output}"
+                ) from exc
 
+        log_handle = open(log_path, "w", encoding="utf-8")
+        try:
+            process = subprocess.Popen(
+                self._background_shell_command(command),
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                cwd=self.current_directory,
+                env=self.env,
+                text=True,
+            )
+        except Exception:
+            log_handle.close()
+            try:
+                os.remove(log_path)
+            except OSError:
+                pass
+            raise
+
+        self.background_processes[job_id] = process
+        closer = threading.Thread(
+            target=self._close_log_when_done,
+            args=(process, log_handle),
+            daemon=True,
+        )
+        closer.start()
+        return process.pid
+
+    @staticmethod
+    def _close_log_when_done(process: subprocess.Popen, log_handle: TextIO) -> None:
+        process.wait()
+        log_handle.close()
+
+    def kill(self) -> None:
+        """Terminate the persistent shell and its background processes."""
+        self._terminate_process(self.process)
+        for process in list(self.background_processes.values()):
+            self._terminate_process(process)


### PR DESCRIPTION
## Summary

- select PowerShell on Windows instead of unconditionally launching `/bin/bash`, with `cmd.exe` as a fallback
- preserve working-directory, environment, exit-code, timeout, Unicode-output, and background-job behavior across native shell implementations
- use the platform temp directory for background logs and document/test the Windows command syntax

## Testing

- [x] `pytest -q` — 162 passed
- [x] Python compile and `tools.json` validation
- [x] PowerShell 7.6.4 smoke tests for Unicode output, persistent environment/directory state, failure exit codes, and background output

Closes #410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持 macOS、Linux 和 Windows 上的跨平台 Shell 命令执行。
  * Windows 优先使用 PowerShell，不可用时自动回退至 `cmd.exe`。
  * 后台任务可继承当前会话中的环境变量，并支持持续读取输出。
  * 改进后台任务日志处理，增强非 UTF-8 输出的兼容性。

* **文档**
  * 更新 Shell 命令故障排查说明及跨平台命令语法提示。

* **修复**
  * 改善 Windows 工作目录、特殊字符路径及后台任务执行的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->