### PR TITLE
fix(AttentionModal): correct hovered cell coordinate when scrolled

### DIFF
--- a/chapter2/attention_visualization/frontend/components/AttentionModal.tsx
+++ b/chapter2/attention_visualization/frontend/components/AttentionModal.tsx
@@ -300,14 +300,14 @@ export default function AttentionModal({ isOpen, onClose, tokens, attentionWeigh
 
     const canvas = canvasRef.current;
     const rect = canvas.getBoundingClientRect();
-    const container = containerRef.current;
-    
-    // Account for scroll position
-    const scrollLeft = container?.scrollLeft || 0;
-    const scrollTop = container?.scrollTop || 0;
-    
-    const x = e.clientX - rect.left + scrollLeft;
-    const y = e.clientY - rect.top + scrollTop;
+    // NOTE: getBoundingClientRect() already reflects the canvas' position
+    // *after* the container has scrolled, so (clientX - rect.left) already
+    // gives the correct canvas-internal coordinate. Do NOT add scrollLeft/
+    // scrollTop on top - that double-counts the scroll and pushes the
+    // computed row/col past the hovered cell once you scroll right/down,
+    // making the tooltip (hoveredCell) fall out of bounds and never show.
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
 
     const cellSize = 5 * zoomLevel;
     const margin = { top: 100, left: 100 };


### PR DESCRIPTION
Description

 ### Problem

 In the attention heatmap modal (AttentionModal), hovering a cell to see its weight / From / To token worked fine near
 the top-left of the matrix, but after scrolling the heatmap right or down the hover tooltip stopped appearing
 entirely.

 ### Root cause

 handleMouseMove converted mouse coordinates to a canvas/cell index like this:

 ```js
   const rect = canvas.getBoundingClientRect();
   const scrollLeft = container?.scrollLeft || 0;
   const scrollTop  = container?.scrollTop  || 0;

   const x = e.clientX - rect.left + scrollLeft;   // ← double-counts scroll
   const y = e.clientY - rect.top  + scrollTop;     // ← double-counts scroll
 ```

 canvas.getBoundingClientRect() already returns the canvas's position after the scroll container has been scrolled.
 When you scroll right by S px, rect.left decreases by exactly S, so e.clientX - rect.left already yields the correct
 canvas-internal coordinate. Adding scrollLeft/scrollTop on top double-counts the scroll, so the computed col/row
 overshoot the cell actually under the cursor.

 Once you've scrolled far enough, that overshoot pushes row/col past the matrix dimensions, tripping this guard:

 ```js
   if (row >= 0 && row < attentionWeights.length &&
       col >= 0 && col < tokens.length && ...) {
     setHoveredCell(...);
   } else {
     setHoveredCell(null);   // ← no tooltip
   }
 ```

 This exactly explains the reported behavior:
 - Top-left (scroll = 0): the added term is 0, so it happens to work.
 - Scrolled right / down: the double-counted offset pushes the index out of bounds → no tooltip.

 ### Fix

 Remove the manual scroll additions. Coordinates now come straight from the client position minus the (already
 scroll-aware) canvas rect:

 ```js
   const rect = canvas.getBoundingClientRect();
   // getBoundingClientRect() already reflects post-scroll position, so
   // (clientX - rect.left) is the correct canvas-internal coordinate.
   const x = e.clientX - rect.left;
   const y = e.clientY - rect.top;
 ```

 No behavioral change at scroll = 0; tooltips now render for every cell at any scroll offset.

 Files changed

 - frontend/components/AttentionModal.tsx — handleMouseMove coordinate math.

 How to reproduce / verify

 1. cd frontend && npm run dev, open the app and click a trajectory's attention preview to open the modal.
 2. Before fix: scroll the heatmap to the right (or down) and hover — no weight/token tooltip appears. Hovering near
    the top-left works.
 3. After fix: hover values appear for every cell at any scroll position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复注意力可视化弹窗在画布滚动后鼠标悬停位置计算不准确的问题。
  * 提升悬停单元格行列定位的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->