### PR TITLE
fix(context): update broken Adobe sample PDF URL

### DIFF
--- a/chapter1/context/main.py
+++ b/chapter1/context/main.py
@@ -81,7 +81,7 @@ Provide a comprehensive financial summary with all calculations shown."""
             Task description  
         """
         return """A multinational company has the following Q1 2024 expenses documented in this report:
-https://github.com/adobe/pdf-services-node-sdk-samples/raw/refs/heads/master/resources/extractPDFInput.pdf
+https://raw.githubusercontent.com/adobe/pdfservices-node-sdk-samples/master/resources/extractPDFInput.pdf
 
 Tasks to complete:
 1. Parse the PDF and extract all monetary values mentioned


### PR DESCRIPTION
## What changed

- Replace the broken Adobe sample PDF URL used by the Chapter 1 context ablation experiment.
- Point the task at the canonical raw file in Adobe's current `pdfservices-node-sdk-samples` repository.

## Root cause

The existing URL references the non-existent repository name `pdf-services-node-sdk-samples`. Adobe's official repository is named `pdfservices-node-sdk-samples`, so the original request returns HTTP 404 and prevents `parse_pdf` from receiving a PDF.

## Impact

The default `python main.py --mode ablation` workflow can download and parse its intended sample PDF again. No experiment logic or task requirements are changed.

## Validation

- Confirmed the original URL returns HTTP 404.
- Loaded the updated URL from the actual default task and parsed it through `ToolRegistry.parse_pdf`: 3 pages and non-empty extracted text.
- `python -m pytest -q` — 23 passed.
- `python -m compileall -q .`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 更新预算测试所使用的 PDF 资源链接，确保外部文档能够通过正确的直连地址访问。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->