### PR TITLE
docs(ch1): replace curly quotes with straight quotes in code block

### DIFF
--- a/book-ja/chapter1.ja.md
+++ b/book-ja/chapter1.ja.md
@@ -154,37 +154,37 @@ Agent がタスクを実行する核となるパターンは **ReAct**（Reasoni
 
 ```
 軌跡 = [
-  {role: “user” , content: “会社の四半期収入にもとづき：Q1 2.5M 米ドル、Q2 2.1M ユーロ、Q3 1.8M 英ポンド、Q4 380M 日本円。会社の年間総収入と四半期平均収入を計算せよ” },
+  {role: "user" , content: "会社の四半期収入にもとづき：Q1 2.5M 米ドル、Q2 2.1M ユーロ、Q3 1.8M 英ポンド、Q4 380M 日本円。会社の年間総収入と四半期平均収入を計算せよ" },
   
   # 1回目のイテレーション - LLM が上記の軌跡を見て、応答を生成
-  {role: “assistant” , 
-   reasoning: “すべての通貨を USD に変換する必要がある...” ,
-   content: “” ,  # ユーザーに直接返答しない
+  {role: "assistant" , 
+   reasoning: "すべての通貨を USD に変換する必要がある..." ,
+   content: "" ,  # ユーザーに直接返答しない
    tool_calls: [
-     {name: “convert_currency” , args: {amount: 2100000, from: “EUR” , to: “USD” }},
-     {name: “convert_currency” , args: {amount: 1800000, from: “GBP” , to: “USD” }},
-     {name: “convert_currency” , args: {amount: 380000000, from: “JPY” , to: “USD” }}
+     {name: "convert_currency" , args: {amount: 2100000, from: "EUR" , to: "USD" }},
+     {name: "convert_currency" , args: {amount: 1800000, from: "GBP" , to: "USD" }},
+     {name: "convert_currency" , args: {amount: 380000000, from: "JPY" , to: "USD" }}
    ]},
   
   # Agent フレームワークがツールを実行し、結果を軌跡に追加
-  {role: “tool” , content: “EUR->USD: 2282608.7” },
-  {role: “tool” , content: “GBP->USD: 2278481.01” },
-  {role: “tool” , content: “JPY->USD: 2541806.02” },
+  {role: "tool" , content: "EUR->USD: 2282608.7" },
+  {role: "tool" , content: "GBP->USD: 2278481.01" },
+  {role: "tool" , content: "JPY->USD: 2541806.02" },
   
   # 2回目のイテレーション - LLM がツール結果を含む完全な軌跡を見る
-  {role: “assistant” ,
-   reasoning: “変換結果を得た。次は集計計算が必要...” ,
-   content: “” ,
+  {role: "assistant" ,
+   reasoning: "変換結果を得た。次は集計計算が必要..." ,
+   content: "" ,
    tool_calls: [
-     {name: “code_interpreter” , args: {code: “total = 2500000 + 2282608.7 + ...” }}
+     {name: "code_interpreter" , args: {code: "total = 2500000 + 2282608.7 + ..." }}
    ]},
   
-  {role: “tool” , content: “Total: $9,602,895.73, Average: $2,400,723.93...” },
+  {role: "tool" , content: "Total: $9,602,895.73, Average: $2,400,723.93..." },
   
   # 3回目のイテレーション - LLM が完全な軌跡を見て、最終的な答えを生成
-  {role: “assistant” ,
-   reasoning: “すべての計算が完了。結果をまとめる...” ,
-   content: “FINAL ANSWER: 総収入$9,602,895.73...” }
+  {role: "assistant" ,
+   reasoning: "すべての計算が完了。結果をまとめる..." ,
+   content: "FINAL ANSWER: 総収入$9,602,895.73..." }
 ]
 ```
 

--- a/book-ru/chapter1.md
+++ b/book-ru/chapter1.md
@@ -152,37 +152,37 @@ tool: {                            assistant: {
 
 ```
 траектория = [
-  {role: “user” , content: “По квартальным доходам компании: Q1 2.5M долларов, Q2 2.1M евро, Q3 1.8M фунтов, Q4 380M иен, рассчитай годовой суммарный доход компании и средний квартальный доход” },
+  {role: "user" , content: "По квартальным доходам компании: Q1 2.5M долларов, Q2 2.1M евро, Q3 1.8M фунтов, Q4 380M иен, рассчитай годовой суммарный доход компании и средний квартальный доход" },
   
   # Первая итерация — LLM видит указанную выше траекторию и генерирует ответ
-  {role: “assistant” , 
-   reasoning: “Нужно перевести все валюты в USD...” ,
-   content: “” ,  # Нет прямого ответа пользователю
+  {role: "assistant" , 
+   reasoning: "Нужно перевести все валюты в USD..." ,
+   content: "" ,  # Нет прямого ответа пользователю
    tool_calls: [
-     {name: “convert_currency” , args: {amount: 2100000, from: “EUR” , to: “USD” }},
-     {name: “convert_currency” , args: {amount: 1800000, from: “GBP” , to: “USD” }},
-     {name: “convert_currency” , args: {amount: 380000000, from: “JPY” , to: “USD” }}
+     {name: "convert_currency" , args: {amount: 2100000, from: "EUR" , to: "USD" }},
+     {name: "convert_currency" , args: {amount: 1800000, from: "GBP" , to: "USD" }},
+     {name: "convert_currency" , args: {amount: 380000000, from: "JPY" , to: "USD" }}
    ]},
   
   # Фреймворк агента выполняет инструменты и добавляет результаты в траекторию
-  {role: “tool” , content: “EUR->USD: 2282608.7” },
-  {role: “tool” , content: “GBP->USD: 2278481.01” },
-  {role: “tool” , content: “JPY->USD: 2541806.02” },
+  {role: "tool" , content: "EUR->USD: 2282608.7" },
+  {role: "tool" , content: "GBP->USD: 2278481.01" },
+  {role: "tool" , content: "JPY->USD: 2541806.02" },
   
   # Вторая итерация — LLM видит полную траекторию, включая результаты инструментов
-  {role: “assistant” ,
-   reasoning: “Результаты конвертации получены, теперь нужно свести и рассчитать...” ,
-   content: “” ,
+  {role: "assistant" ,
+   reasoning: "Результаты конвертации получены, теперь нужно свести и рассчитать..." ,
+   content: "" ,
    tool_calls: [
-     {name: “code_interpreter” , args: {code: “total = 2500000 + 2282608.7 + ...” }}
+     {name: "code_interpreter" , args: {code: "total = 2500000 + 2282608.7 + ..." }}
    ]},
   
-  {role: “tool” , content: “Total: $9,602,895.73, Average: $2,400,723.93...” },
+  {role: "tool" , content: "Total: $9,602,895.73, Average: $2,400,723.93..." },
   
   # Третья итерация — LLM видит полную траекторию и генерирует итоговый ответ
-  {role: “assistant” ,
-   reasoning: “Все расчёты завершены, подводим итог...” ,
-   content: “FINAL ANSWER: Суммарный доход $9,602,895.73...” }
+  {role: "assistant" ,
+   reasoning: "Все расчёты завершены, подводим итог..." ,
+   content: "FINAL ANSWER: Суммарный доход $9,602,895.73..." }
 ]
 ```
 

--- a/book-vi/chapter1.vi.md
+++ b/book-vi/chapter1.vi.md
@@ -157,34 +157,34 @@ trajectory = [
 {role: "user" , content: "Dựa trên doanh thu hàng quý của công ty: Quý 1 2,5 triệu đô la Mỹ, quý 2 2,1 triệu euro, quý 3 1,8 triệu bảng Anh, quý 4 380 triệu yên, tính tổng doanh thu hàng năm và doanh thu trung bình hàng quý của công ty" },
 
 # Lần lặp đầu tiên - LLM nhìn thấy trajectory trên và tạo ra phản hồi
-  {role: “assistant” ,
+  {role: "assistant" ,
 lý do: "Cần chuyển đổi tất cả các loại tiền tệ sang USD..." ,
 nội dung: "" , # Không trả lời trực tiếp cho người dùng
    tool_calls: [
-     {name: “convert_currency” , args: {amount: 2100000, from: “EUR” , to: “USD” }},
-     {name: “convert_currency” , args: {amount: 1800000, from: “GBP” , to: “USD” }},
-     {name: “convert_currency” , args: {amount: 380000000, from: “JPY” , to: “USD” }}
+     {name: "convert_currency" , args: {amount: 2100000, from: "EUR" , to: "USD" }},
+     {name: "convert_currency" , args: {amount: 1800000, from: "GBP" , to: "USD" }},
+     {name: "convert_currency" , args: {amount: 380000000, from: "JPY" , to: "USD" }}
    ]},
 
 # Công cụ thực thi khung tác nhân, thêm kết quả vào trajectory
-  {role: “tool” , content: “EUR->USD: 2282608.7” },
-  {role: “tool” , content: “GBP->USD: 2278481.01” },
-  {role: “tool” , content: “JPY->USD: 2541806.02” },
+  {role: "tool" , content: "EUR->USD: 2282608.7" },
+  {role: "tool" , content: "GBP->USD: 2278481.01" },
+  {role: "tool" , content: "JPY->USD: 2541806.02" },
 
 # Lần lặp thứ hai - LLM nhìn thấy toàn bộ trajectory, bao gồm cả kết quả công cụ
-  {role: “assistant” ,
+  {role: "assistant" ,
 lý do: "Kết quả quy đổi đã có và bây giờ cần tổng hợp, tính toán..." ,
-   content: “” ,
+   content: "" ,
    tool_calls: [
-     {name: “code_interpreter” , args: {code: “total = 2500000 + 2282608.7 + ...” }}
+     {name: "code_interpreter" , args: {code: "total = 2500000 + 2282608.7 + ..." }}
    ]},
 
-  {role: “tool” , content: “Total: $9,602,895.73, Average: $2,400,723.93...” },
+  {role: "tool" , content: "Total: $9,602,895.73, Average: $2,400,723.93..." },
 
 # Lần lặp thứ ba - LLM nhìn thấy trajectory hoàn chỉnh và đưa ra câu trả lời cuối cùng
-  {role: “assistant” ,
+  {role: "assistant" ,
 lý do: "Mọi tính toán đã hoàn tất, tổng hợp kết quả..." ,
-nội dung: “CÂU TRẢ LỜI CUỐI CÙNG: Tổng thu nhập $9.602.895,73…” }
+nội dung: "CÂU TRẢ LỜI CUỐI CÙNG: Tổng thu nhập $9.602.895,73…" }
 ]
 ```
 

--- a/book-zhtw/chapter1.zhtw.md
+++ b/book-zhtw/chapter1.zhtw.md
@@ -152,37 +152,37 @@ Agent 執行任務的核心模式叫做 **ReAct**（Reasoning + Acting）。雖�
 
 ```
 軌跡 = [
-  {role: “user” , content: “根據公司季度收入：Q1 2.5M 美元，Q2 2.1M 歐元，Q3 1.8M 英鎊，Q4 380M 日元，計算公司年度總收入和季度平均收入” },
+  {role: "user" , content: "根據公司季度收入：Q1 2.5M 美元，Q2 2.1M 歐元，Q3 1.8M 英鎊，Q4 380M 日元，計算公司年度總收入和季度平均收入" },
   
   # 第一次迭代 - LLM 看到上述軌跡，生成響應
-  {role: “assistant” , 
-   reasoning: “需要將所有貨幣轉換為 USD...” ,
-   content: “” ,  # 沒有直接回複使用者
+  {role: "assistant" , 
+   reasoning: "需要將所有貨幣轉換為 USD..." ,
+   content: "" ,  # 沒有直接回複使用者
    tool_calls: [
-     {name: “convert_currency” , args: {amount: 2100000, from: “EUR” , to: “USD” }},
-     {name: “convert_currency” , args: {amount: 1800000, from: “GBP” , to: “USD” }},
-     {name: “convert_currency” , args: {amount: 380000000, from: “JPY” , to: “USD” }}
+     {name: "convert_currency" , args: {amount: 2100000, from: "EUR" , to: "USD" }},
+     {name: "convert_currency" , args: {amount: 1800000, from: "GBP" , to: "USD" }},
+     {name: "convert_currency" , args: {amount: 380000000, from: "JPY" , to: "USD" }}
    ]},
   
   # Agent 框架執行工具，新增結果到軌跡
-  {role: “tool” , content: “EUR->USD: 2282608.7” },
-  {role: “tool” , content: “GBP->USD: 2278481.01” },
-  {role: “tool” , content: “JPY->USD: 2541806.02” },
+  {role: "tool" , content: "EUR->USD: 2282608.7" },
+  {role: "tool" , content: "GBP->USD: 2278481.01" },
+  {role: "tool" , content: "JPY->USD: 2541806.02" },
   
   # 第二次迭代 - LLM 看到完整軌跡，包括工具結果
-  {role: “assistant” ,
-   reasoning: “已獲得轉換結果，現在需要彙總計算...” ,
-   content: “” ,
+  {role: "assistant" ,
+   reasoning: "已獲得轉換結果，現在需要彙總計算..." ,
+   content: "" ,
    tool_calls: [
-     {name: “code_interpreter” , args: {code: “total = 2500000 + 2282608.7 + ...” }}
+     {name: "code_interpreter" , args: {code: "total = 2500000 + 2282608.7 + ..." }}
    ]},
   
-  {role: “tool” , content: “Total: $9,602,895.73, Average: $2,400,723.93...” },
+  {role: "tool" , content: "Total: $9,602,895.73, Average: $2,400,723.93..." },
   
   # 第三次迭代 - LLM 看到完整軌跡，生成最終答案
-  {role: “assistant” ,
-   reasoning: “所有計算完成，總結結果...” ,
-   content: “FINAL ANSWER: 總收入$9,602,895.73...” }
+  {role: "assistant" ,
+   reasoning: "所有計算完成，總結結果..." ,
+   content: "FINAL ANSWER: 總收入$9,602,895.73..." }
 ]
 ```
 

--- a/book/chapter1.md
+++ b/book/chapter1.md
@@ -152,37 +152,37 @@ Agent 执行任务的核心模式叫做 **ReAct**（Reasoning + Acting）。虽�
 
 ```
 轨迹 = [
-  {role: “user” , content: “根据公司季度收入：Q1 2.5M 美元，Q2 2.1M 欧元，Q3 1.8M 英镑，Q4 380M 日元，计算公司年度总收入和季度平均收入” },
+  {role: "user" , content: "根据公司季度收入：Q1 2.5M 美元，Q2 2.1M 欧元，Q3 1.8M 英镑，Q4 380M 日元，计算公司年度总收入和季度平均收入" },
   
   # 第一次迭代 - LLM 看到上述轨迹，生成响应
-  {role: “assistant” , 
-   reasoning: “需要将所有货币转换为 USD...” ,
-   content: “” ,  # 没有直接回复用户
+  {role: "assistant" , 
+   reasoning: "需要将所有货币转换为 USD..." ,
+   content: "" ,  # 没有直接回复用户
    tool_calls: [
-     {name: “convert_currency” , args: {amount: 2100000, from: “EUR” , to: “USD” }},
-     {name: “convert_currency” , args: {amount: 1800000, from: “GBP” , to: “USD” }},
-     {name: “convert_currency” , args: {amount: 380000000, from: “JPY” , to: “USD” }}
+     {name: "convert_currency" , args: {amount: 2100000, from: "EUR" , to: "USD" }},
+     {name: "convert_currency" , args: {amount: 1800000, from: "GBP" , to: "USD" }},
+     {name: "convert_currency" , args: {amount: 380000000, from: "JPY" , to: "USD" }}
    ]},
   
   # Agent 框架执行工具，添加结果到轨迹
-  {role: “tool” , content: “EUR->USD: 2282608.7” },
-  {role: “tool” , content: “GBP->USD: 2278481.01” },
-  {role: “tool” , content: “JPY->USD: 2541806.02” },
+  {role: "tool" , content: "EUR->USD: 2282608.7" },
+  {role: "tool" , content: "GBP->USD: 2278481.01" },
+  {role: "tool" , content: "JPY->USD: 2541806.02" },
   
   # 第二次迭代 - LLM 看到完整轨迹，包括工具结果
-  {role: “assistant” ,
-   reasoning: “已获得转换结果，现在需要汇总计算...” ,
-   content: “” ,
+  {role: "assistant" ,
+   reasoning: "已获得转换结果，现在需要汇总计算..." ,
+   content: "" ,
    tool_calls: [
-     {name: “code_interpreter” , args: {code: “total = 2500000 + 2282608.7 + ...” }}
+     {name: "code_interpreter" , args: {code: "total = 2500000 + 2282608.7 + ..." }}
    ]},
   
-  {role: “tool” , content: “Total: $9,602,895.73, Average: $2,400,723.93...” },
+  {role: "tool" , content: "Total: $9,602,895.73, Average: $2,400,723.93..." },
   
   # 第三次迭代 - LLM 看到完整轨迹，生成最终答案
-  {role: “assistant” ,
-   reasoning: “所有计算完成，总结结果...” ,
-   content: “FINAL ANSWER: 总收入$9,602,895.73...” }
+  {role: "assistant" ,
+   reasoning: "所有计算完成，总结结果..." ,
+   content: "FINAL ANSWER: 总收入$9,602,895.73..." }
 ]
 ```
 


### PR DESCRIPTION
第 1 章的「Agent 轨迹」伪代码代码块中，字符串误用了中文弯引号 “ ”，看起来不够清晰，应使用英文直引号 " "。

已经检查并将修改同步到了其他语言（其中 en、ta 不存在此问题，无需修改）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 统一多语言版本中 ReAct 循环示例的引号、缩进和对象格式。
  - 提升伪代码的可读性与一致性，使示例更便于理解和复制。
  - 保持原有工具调用流程、计算结果及示例内容不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->