### PR TITLE
fix(book): prevent fig6-1 arrow overlap

### DIFF
--- a/book/images/fig6-1.svg
+++ b/book/images/fig6-1.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 820 260" width="820" height="260" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
+<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto" markerUnits="userSpaceOnUse"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
 <rect x="30" y="44" width="560" height="64" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="310.0" y="64.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">第一层：评估环境</text>
 <text x="310.0" y="90.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="bold">“在哪里测” — 工具调用型 / 人机交互型 / 仿真环境</text>


### PR DESCRIPTION
## Summary

- render the `fig6-1.svg` connector arrowheads in user-space units
- keep the 12 px arrowheads within the 16 px gaps between cards
- preserve the existing text, card positions, connector coordinates, and figure size

SVG markers default to `markerUnits="strokeWidth"`. The figure uses a 12-unit
marker on lines with `stroke-width="2"`, so each arrowhead is rendered 24 px
long and extends into the card above it. Setting the marker to
`userSpaceOnUse` keeps it at 12 px, which fits the existing gap without moving
the diagram content.

## Validation

- parsed the SVG and verified the marker dimensions, units, connector coordinates, and card gaps
- compared before/after headless Chromium renders at 2x device scale
- `python3 scripts/check_i18n_consistency.py`
- `bash scripts/build_site.sh` and verified the assembled site contains the exact patched SVG
- `git diff --check`

A full MkDocs, PDF, or EPUB build was not run because the local environment
does not have the documentation build dependencies installed. The changed SVG
was rendered directly in Chromium and passed the repository's site assembly.