### PR TITLE
fix: add missing load_dotenv() in config.py for 9 experiment projects

### DIFF
--- a/chapter1/web-search-agent/config.py
+++ b/chapter1/web-search-agent/config.py
@@ -4,6 +4,9 @@
 
 import os
 from typing import Optional
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 def map_model_to_openrouter(model: str) -> str:

--- a/chapter2/system-hint/config.py
+++ b/chapter2/system-hint/config.py
@@ -5,6 +5,9 @@ Configuration module for System-Hint Enhanced Agent
 import os
 from typing import Optional
 from dataclasses import dataclass
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 @dataclass

--- a/chapter3/agentic-rag-for-user-memory/config.py
+++ b/chapter3/agentic-rag-for-user-memory/config.py
@@ -5,6 +5,9 @@ from dataclasses import dataclass, field
 from typing import Optional, Dict, Any, List
 from enum import Enum
 from pathlib import Path
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 def _reasoning_safe_temperature(model, requested=1.0):
@@ -278,7 +281,7 @@ class Config:
     def load(cls, path: str) -> "Config":
         """Load configuration from JSON file"""
         import json
-        
+
         with open(path, 'r') as f:
             config_dict = json.load(f)
         

--- a/chapter3/agentic-rag/config.py
+++ b/chapter3/agentic-rag/config.py
@@ -4,6 +4,9 @@ import os
 from dataclasses import dataclass, field
 from typing import Optional, Dict, Any
 from enum import Enum
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 def _openrouter_model_id(model: Optional[str]) -> str:

--- a/chapter3/contextual-retrieval-for-user-memory/config.py
+++ b/chapter3/contextual-retrieval-for-user-memory/config.py
@@ -5,6 +5,9 @@ from dataclasses import dataclass, field
 from typing import Optional, Dict, Any, List
 from enum import Enum
 from pathlib import Path
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 def _reasoning_safe_temperature(model, requested=1.0):
@@ -267,7 +270,7 @@ class Config:
     def load(cls, path: str) -> "Config":
         """Load configuration from JSON file"""
         import json
-        
+
         with open(path, 'r') as f:
             config_dict = json.load(f)
         

--- a/chapter3/contextual-retrieval/config.py
+++ b/chapter3/contextual-retrieval/config.py
@@ -4,6 +4,9 @@ import os
 from dataclasses import dataclass, field
 from typing import Optional, Dict, Any
 from enum import Enum
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 def _openrouter_model_id(model: Optional[str]) -> str:

--- a/chapter3/multimodal-agent/config.py
+++ b/chapter3/multimodal-agent/config.py
@@ -6,6 +6,9 @@ import os
 from typing import Optional, Dict, Any
 from dataclasses import dataclass
 from enum import Enum
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 def _openrouter_model_id(model) -> str:

--- a/chapter6/agent-cost-analysis/config.py
+++ b/chapter6/agent-cost-analysis/config.py
@@ -20,6 +20,9 @@
 
 import os
 from dataclasses import dataclass
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # 使用的模型（默认当前廉价旗舰 gpt-5.6-luna；可用 COST_DEMO_MODEL / --model 覆盖）
 MODEL = os.environ.get("COST_DEMO_MODEL", "gpt-5.6-luna")

--- a/chapter6/agent-cost-analysis/requirements.txt
+++ b/chapter6/agent-cost-analysis/requirements.txt
@@ -1,2 +1,3 @@
 openai>=1.40.0
+python-dotenv>=1.0.0
 tiktoken>=0.7.0

--- a/chapter6/tts-quality-eval/config.py
+++ b/chapter6/tts-quality-eval/config.py
@@ -6,7 +6,11 @@
   - 一组带挑战性的参考文本（数字 / 多音字 / 长句 / 专有名词 + 情感）。
 """
 
+import os
 from dataclasses import dataclass, field
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # ---------------------------------------------------------------------------
 # 模型名（均为 OpenAI，读 OPENAI_API_KEY）。

--- a/chapter6/tts-quality-eval/requirements.txt
+++ b/chapter6/tts-quality-eval/requirements.txt
@@ -1,2 +1,3 @@
 openai>=1.40.0
+python-dotenv>=1.0.0
 # 无需其它第三方库：ffprobe 走系统命令，Gemini 可选评审走内置 urllib（REST）。


### PR DESCRIPTION
## 问题

多个实验项目的 `config.py` 使用 `os.getenv()` / `os.environ.get()` 读取环境变量，但从未调用 `load_dotenv()`，导致项目根目录下的 `.env` 文件被静默忽略。用户按 README 在 `.env` 中配置 API Key 后，仍会收到「未设置 API Key」的错误。

## 修复

在 9 个实验的 `config.py` 顶部添加 `from dotenv import load_dotenv` 与 `load_dotenv()` 调用，使其在模块导入时加载 `.env`。

### 修复清单

| 项目 | 说明 |
|------|------|
| chapter1/web-search-agent | 全项目无 load_dotenv |
| chapter2/system-hint | 全项目无 load_dotenv |
| chapter3/multimodal-agent | 全项目无 load_dotenv |
| chapter3/contextual-retrieval | 全项目无 load_dotenv |
| chapter3/agentic-rag | config 无（入口脚本有） |
| chapter3/agentic-rag-for-user-memory | config 无（入口脚本有） |
| chapter3/contextual-retrieval-for-user-memory | config 无（入口脚本有） |
| chapter6/agent-cost-analysis | 全项目无，requirements.txt 补 python-dotenv |
| chapter6/tts-quality-eval | 全项目无，requirements.txt 补 python-dotenv |

## 兼容性

`load_dotenv()` 的行为：
- 有 `.env` → 加载其中变量
- 无 `.env` → 静默跳过
- `.env` 与 `export` 环境变量同名 → `export` 优先（不会覆盖已设置的环境变量）
- `--api-key` 参数 → 优先级最高

因此与 README 中现有的 `export`、`.env`、`--api-key` 三种配置方式均不冲突，只是补上了 `.env` 这条路径原本失效的问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持从项目 `.env` 文件自动加载配置。
  * 各示例模块可直接读取 API 密钥、模型设置、超时及其他运行参数。

* **依赖更新**
  * 新增 `python-dotenv` 依赖，确保环境变量加载功能正常运行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->