### PR TITLE
fix(book): correct figure 6-9 arrows across translations

### DIFF
--- a/book-ar/images/fig6-9.svg
+++ b/book-ar/images/fig6-9.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 940 480" width="940" height="480" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
+<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-compact" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto" markerUnits="userSpaceOnUse"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
 
 <rect x="20" y="65" width="220" height="250" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
 <text x="130" y="88" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">المراقبة المتعددة الوسائط</text>
@@ -19,17 +19,17 @@
 <rect x="295" y="105" width="280" height="50" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="450" y="125" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">تشفير الرؤية</text>
 <text x="450" y="145" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">SigLIP → الرموز المرئية</text>
-<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)"/>
 <rect x="295" y="170" width="280" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="450" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">نموذج اللغة</text>
 <text x="450" y="210" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">اللاما 2 7B العمود الفقري</text>
-<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)"/>
 <rect x="295" y="235" width="280" height="78" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="435" y="252" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">فك تشفير العمل</text>
 <text x="435" y="272" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">→ ناقل التحكم المستمر ذو 14 بُعدًا</text>
 <text x="435" y="298" font-family="'Courier New', Courier, monospace" font-size="8" fill="#333333" text-anchor="middle" dominant-baseline="central" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">تقسيم الإجراء: قم بإنشاء 25 إجراءً متتاليًا في وقت واحد</text>
-<line x1="240" y1="160" x2="270" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="240" y1="290" x2="270" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="240" y1="132" x2="278" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="240" y1="257" x2="278" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
 <rect x="300" y="345" width="260" height="32" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="430" y="361" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">التعليمات: "ضع العلبة في الوعاء"</text>
 <line x1="430" y1="345" x2="430" y2="315" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>

--- a/book-en/images/fig6-9.svg
+++ b/book-en/images/fig6-9.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 940 480" width="940" height="480" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
+<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-compact" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto" markerUnits="userSpaceOnUse"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
 
 <rect x="20" y="65" width="220" height="250" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
 <text x="130" y="88" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="19.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Multimodal observation</text>
@@ -19,17 +19,17 @@
 <rect x="295" y="105" width="280" height="50" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="450" y="125" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Vision encoder</text>
 <text x="450" y="145" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">SigLIP → visual tokens</text>
-<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)"/>
 <rect x="295" y="170" width="280" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="450" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Language model</text>
 <text x="450" y="210" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Llama 2 7B backbone</text>
-<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)"/>
 <rect x="295" y="235" width="280" height="78" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="435" y="252" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Action decoder</text>
 <text x="435" y="272" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ 14-dimensional continuous control vector</text>
 <text x="435" y="298" font-family="'Courier New', Courier, monospace" font-size="8" fill="#333333" text-anchor="middle" dominant-baseline="central">Action chunking: generate 25 consecutive actions at once</text>
-<line x1="240" y1="160" x2="270" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="240" y1="290" x2="270" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="240" y1="132" x2="278" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="240" y1="257" x2="278" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
 <rect x="300" y="345" width="260" height="32" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="430" y="361" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Instruction: "Put the can into the pot"</text>
 <line x1="430" y1="345" x2="430" y2="315" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>

--- a/book-ja/images/fig6-9.svg
+++ b/book-ja/images/fig6-9.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 940 480" width="940" height="480" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
+<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-compact" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto" markerUnits="userSpaceOnUse"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
 
 <rect x="20" y="65" width="220" height="250" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
 <text x="130" y="88" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="19.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">マルチモーダル観測</text>
@@ -19,17 +19,17 @@
 <rect x="295" y="105" width="280" height="50" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="450" y="125" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">ビジョンエンコーダ</text>
 <text x="450" y="145" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">SigLIP → ビジュアルトークン</text>
-<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)"/>
 <rect x="295" y="170" width="280" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="450" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">言語モデル</text>
 <text x="450" y="210" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Llama 2 7B バックボーン</text>
-<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)"/>
 <rect x="295" y="235" width="280" height="78" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="435" y="252" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">アクションデコーダ</text>
 <text x="435" y="272" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ 14 次元の連続制御ベクトル</text>
 <text x="435" y="298" font-family="'Courier New', Courier, monospace" font-size="8" fill="#333333" text-anchor="middle" dominant-baseline="central">Action chunking: 連続する 25 個のアクションを一度に生成</text>
-<line x1="240" y1="160" x2="270" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="240" y1="290" x2="270" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="240" y1="132" x2="278" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="240" y1="257" x2="278" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
 <rect x="300" y="345" width="260" height="32" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="430" y="361" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">指示: 「缶を鍋の中に入れて」</text>
 <line x1="430" y1="345" x2="430" y2="315" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>

--- a/book-ru/images/fig6-9.svg
+++ b/book-ru/images/fig6-9.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 940 480" width="940" height="480" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
+<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-compact" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto" markerUnits="userSpaceOnUse"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
 
 <rect x="20" y="65" width="220" height="250" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
 <text x="130" y="88" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Мультимодальное наблюдение</text>
@@ -19,17 +19,17 @@
 <rect x="295" y="105" width="280" height="50" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="450" y="125" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Визуальный энкодер</text>
 <text x="450" y="145" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">SigLIP → визуальные токены</text>
-<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)"/>
 <rect x="295" y="170" width="280" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="450" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Языковая модель</text>
 <text x="450" y="210" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Llama 2 7B (основа)</text>
-<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)"/>
 <rect x="295" y="235" width="280" height="78" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="435" y="252" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Декодер действий</text>
 <text x="435" y="272" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ 14-мерный вектор непрерывного управления</text>
 <text x="435" y="298" font-family="'Courier New', Courier, monospace" font-size="6.5" fill="#333333" text-anchor="middle" dominant-baseline="central">Группировка действий: генерация 25 последовательных действий за раз</text>
-<line x1="240" y1="160" x2="270" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="240" y1="290" x2="270" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="240" y1="132" x2="278" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="240" y1="257" x2="278" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
 <rect x="300" y="345" width="260" height="32" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="430" y="361" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Инструкция: «Положи банку в кастрюлю»</text>
 <line x1="430" y1="345" x2="430" y2="315" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>

--- a/book-ta/images/fig6-9.svg
+++ b/book-ta/images/fig6-9.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 480" width="880" height="480" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
+<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-compact" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto" markerUnits="userSpaceOnUse"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
 
 <rect x="20" y="65" width="220" height="250" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
 <text x="130" y="88" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="19.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Multimodal observation</text>
@@ -19,17 +19,17 @@
 <rect x="295" y="105" width="280" height="50" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="450" y="125" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Vision encoder</text>
 <text x="450" y="145" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">SigLIP → visual tokens</text>
-<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)"/>
 <rect x="295" y="170" width="280" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="450" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Language model</text>
 <text x="450" y="210" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Llama 2 7B backbone</text>
-<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)"/>
 <rect x="295" y="235" width="280" height="78" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="435" y="252" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Action decoder</text>
 <text x="435" y="272" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ 14-dimensional continuous control vector</text>
 <text x="435" y="298" font-family="'Courier New', Courier, monospace" font-size="8" fill="#333333" text-anchor="middle" dominant-baseline="central">Action chunking: generate 25 consecutive actions at once</text>
-<line x1="240" y1="160" x2="270" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="240" y1="290" x2="270" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="240" y1="132" x2="278" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="240" y1="257" x2="278" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
 <rect x="300" y="345" width="260" height="32" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="430" y="361" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Instruction: "Put the can into the pot"</text>
 <line x1="430" y1="345" x2="430" y2="315" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>

--- a/book-vi/images/fig6-9.svg
+++ b/book-vi/images/fig6-9.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 480" width="880" height="480" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333" /></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999" /></marker></defs>
+<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333" /></marker><marker id="ah-compact" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto" markerUnits="userSpaceOnUse"><polygon points="0 0, 12 4, 0 8" fill="#333333" /></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999" /></marker></defs>
 
 <rect x="20" y="65" width="220" height="250" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4" />
 <text x="130" y="0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold"><tspan x="130" dy="179.2">quan sát đa phương</tspan><tspan x="130" dy="21.6">thức</tspan></text>
@@ -19,17 +19,17 @@
 <rect x="295" y="105" width="280" height="50" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2" />
 <text x="450" y="125" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">bộ mã hóa hình ảnh</text>
 <text x="450" y="145" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">SigLIP → Tầm nhìn tokens</text>
-<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah)" />
+<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)" />
 <rect x="295" y="170" width="280" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2" />
 <text x="450" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">mô hình ngôn ngữ</text>
 <text x="450" y="210" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Llama 2 7B backbone</text>
-<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah)" />
+<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)" />
 <rect x="295" y="235" width="280" height="78" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2" />
 <text x="435" y="254.56" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">bộ giải mã hành động</text>
 <text x="435" y="270.76" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ Vectơ điều khiển liên tục chiều 14</text>
 <text x="435" y="0" font-family="'Courier New', Courier, monospace" font-size="11" fill="#333333" text-anchor="middle" dominant-baseline="central"><tspan x="435" dy="284.26">Phân chia hành động: 1 lần tạo ra các hành</tspan><tspan x="435" dy="11.88">động liên tiếp 25</tspan></text>
-<line x1="240" y1="160" x2="270" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)" />
-<line x1="240" y1="290" x2="270" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)" />
+<line x1="240" y1="132" x2="278" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)" />
+<line x1="240" y1="257" x2="278" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)" />
 <rect x="300" y="345" width="260" height="32" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2" />
 <text x="430" y="361" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Hướng dẫn: "Đặt lọ vào nồi"</text>
 <line x1="430" y1="345" x2="430" y2="315" stroke="#333333" stroke-width="2" marker-end="url(#ah)" />

--- a/book-zhtw/images/fig6-9.svg
+++ b/book-zhtw/images/fig6-9.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 480" width="880" height="480" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
+<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-compact" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto" markerUnits="userSpaceOnUse"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
 
 <rect x="20" y="65" width="220" height="250" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
 <text x="130" y="88" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">多模態觀測</text>
@@ -19,17 +19,17 @@
 <rect x="295" y="105" width="280" height="50" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="450" y="125" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">視覺編碼器</text>
 <text x="450" y="145" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">SigLIP → 視覺 tokens</text>
-<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)"/>
 <rect x="295" y="170" width="280" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="450" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">語言模型</text>
 <text x="450" y="210" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Llama 2 7B backbone</text>
-<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)"/>
 <rect x="295" y="235" width="280" height="78" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="435" y="252" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">動作解碼器</text>
 <text x="435" y="272" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ 14維連續控制向量</text>
 <text x="435" y="298" font-family="'Courier New', Courier, monospace" font-size="11" fill="#333333" text-anchor="middle" dominant-baseline="central">動作分塊: 1次生成25個連續動作</text>
-<line x1="240" y1="160" x2="270" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="240" y1="290" x2="270" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="240" y1="132" x2="278" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="240" y1="257" x2="278" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
 <rect x="300" y="345" width="260" height="32" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="430" y="361" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">指令: &quot;將罐子放入鍋中&quot;</text>
 <line x1="430" y1="345" x2="430" y2="315" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>

--- a/book/images/fig6-9.svg
+++ b/book/images/fig6-9.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 480" width="880" height="480" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
+<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-compact" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto" markerUnits="userSpaceOnUse"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
 
 <rect x="20" y="65" width="220" height="250" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
 <text x="130" y="88" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">多模态观测</text>
@@ -19,17 +19,17 @@
 <rect x="295" y="105" width="280" height="50" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="450" y="125" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">视觉编码器</text>
 <text x="450" y="145" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">SigLIP → 视觉 tokens</text>
-<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="435" y1="157" x2="435" y2="168" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)"/>
 <rect x="295" y="170" width="280" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="450" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">语言模型</text>
 <text x="450" y="210" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Llama 2 7B backbone</text>
-<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="435" y1="222" x2="435" y2="233" stroke="#333333" stroke-width="2" marker-end="url(#ah-compact)"/>
 <rect x="295" y="235" width="280" height="78" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="435" y="252" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">动作解码器</text>
 <text x="435" y="272" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ 14维连续控制向量</text>
 <text x="435" y="298" font-family="'Courier New', Courier, monospace" font-size="11" fill="#333333" text-anchor="middle" dominant-baseline="central">动作分块: 1次生成25个连续动作</text>
-<line x1="240" y1="160" x2="270" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="240" y1="290" x2="270" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="240" y1="132" x2="278" y2="132" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="240" y1="257" x2="278" y2="257" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
 <rect x="300" y="345" width="260" height="32" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="430" y="361" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">指令: &quot;将罐子放入锅中&quot;</text>
 <line x1="430" y1="345" x2="430" y2="315" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>


### PR DESCRIPTION
## Summary

- align the two left-side observation/state inputs horizontally with their VLA destinations across all eight existing language versions
- use the original marker for the left inputs and upward instruction connector, preserving the established full-size arrows
- use a compact 12-by-8 `userSpaceOnUse` marker only for the two short VLA-stage transitions

The original left input paths cross the 40 px inter-panel gap diagonally and do not enter the destination modules on their centerlines. They now run horizontally from `x=240` to `x=278` at `y=132` and `y=257`, matching the right-side connector corridor and arrow size.

The two 11 px VLA-stage gaps cannot accommodate the existing stroke-relative marker: on a 2 px connector stroke, its 12-by-8 geometry renders at approximately 24 by 16 px and overlaps adjacent cards. A dedicated `userSpaceOnUse` marker keeps only those two arrowheads at 12 by 8 px. The instruction arrow retains its original marker and geometry.

## Validation

- parsed all eight SVGs and verified exactly two VLA-stage connectors use the compact marker while the other five connectors retain the original marker
- rendered all eight SVGs with Chromium at 2x device scale (1760 x 960 or 1880 x 960) and inspected the arrow alignment and sizing
- `python3 scripts/check_i18n_consistency.py`
- `bash scripts/build_site.sh` and byte-compared all eight assembled SVGs with their source copies
- `git diff upstream/main --check`

## Notes

- preserves canvas dimensions, cards, text, colors, right-side connector geometry, and instruction connector geometry across all eight copies
- full MkDocs, PDF, and EPUB builds were not run because those toolchains are unavailable locally; the changed SVGs were rendered directly and passed the repository's site assembly
- font fallback can differ across documentation environments, but the changed marker and connector geometry is font-independent
