### PR TITLE
fix: count reasoning chunks in benchmark TTFT

### DIFF
--- a/chapter2/local_llm_serving/benchmark.py
+++ b/chapter2/local_llm_serving/benchmark.py
@@ -92,7 +92,7 @@ def stream_once(
 ) -> Dict[str, float]:
     """发起一次流式请求，返回 TTFT、总时长、输出 token 数与解码吞吐。
 
-    - ttft：从发起请求到收到第一个内容分片的时间（秒）
+    - ttft：从发起请求到收到第一个内容或推理分片的时间（秒）
     - total：整个响应的墙钟时间（秒）
     - output_tokens：优先取服务端返回的 usage.completion_tokens，
       否则用收到的内容分片数量作为近似
@@ -122,7 +122,12 @@ def stream_once(
         if not chunk.choices:
             continue
         delta = chunk.choices[0].delta
-        if getattr(delta, "content", None):
+        text = (
+            getattr(delta, "content", None)
+            or getattr(delta, "reasoning_content", None)
+            or getattr(delta, "reasoning", None)
+        )
+        if text:
             if ttft is None:
                 ttft = time.perf_counter() - start
             chunk_count += 1

--- a/chapter2/local_llm_serving/test_benchmark.py
+++ b/chapter2/local_llm_serving/test_benchmark.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Regression tests for the local LLM serving benchmark."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from benchmark import stream_once
+
+
+class FakeCompletions:
+    def __init__(self, chunks):
+        self.chunks = chunks
+
+    def create(self, **kwargs):
+        return iter(self.chunks)
+
+
+def make_client(chunks):
+    completions = FakeCompletions(chunks)
+    return SimpleNamespace(chat=SimpleNamespace(completions=completions))
+
+
+def run_reasoning_stream(field):
+    delta = SimpleNamespace(**{field: "Thinking about the answer."})
+    chunks = [
+        SimpleNamespace(
+            usage=None,
+            choices=[SimpleNamespace(delta=delta)],
+        ),
+        SimpleNamespace(
+            usage=SimpleNamespace(completion_tokens=8),
+            choices=[],
+        ),
+    ]
+
+    with patch("benchmark.time.perf_counter", side_effect=[0.0, 0.25, 1.0]):
+        return stream_once(
+            make_client(chunks),
+            model="qwen3:0.6b",
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=8,
+            temperature=0.0,
+        )
+
+
+def test_stream_once_uses_reasoning_chunks_for_ttft():
+    for field in ("reasoning_content", "reasoning"):
+        result = run_reasoning_stream(field)
+
+        assert result["ttft"] == 0.25, field
+        assert result["total"] == 1.0, field
+        assert result["output_tokens"] == 8.0, field
+        assert result["decode_tps"] == 8.0 / 0.75, field


### PR DESCRIPTION
## Summary

- count content, reasoning_content, and Ollama reasoning stream chunks when measuring TTFT
- include reasoning chunks in the fallback chunk count when usage metadata is unavailable
- add a deterministic regression test for reasoning-only streams

## Testing

- python -m pytest -q test_benchmark.py test_ollama_thinking.py test_platform_detection.py (6 passed)
- python -m py_compile benchmark.py test_benchmark.py
- git diff --check

Fixes #449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **错误修复**
  - 改进流式响应的性能指标统计。
  - 现在检测到内容或推理文本分片时，均可准确记录首字节时间（TTFT）。
  - 支持 `reasoning_content` 和 `reasoning` 两种推理字段，输出令牌数与解码吞吐率统计更加准确。

- **测试**
  - 新增回归测试，覆盖推理内容流式返回场景及相关性能指标计算。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->