### PR TITLE
fix(gaia-experience): match FAISS index to the model's embedding dim; tolerate missing environment_score

### DIFF
--- a/chapter8/gaia-experience/experience_documents.py
+++ b/chapter8/gaia-experience/experience_documents.py
@@ -104,7 +104,7 @@ def build_documents(
         )
         pitfalls = tuple(text for text, _ in pitfall_support.most_common())
         sources = tuple(
-            f"{record['id']} ({record['outcome']}, score={float(record['environment_score']):.2f})"
+            f"{record['id']} ({record['outcome']}, score={float(record.get('environment_score', 0.0)):.2f})"
             for record in records
         )
         documents.append(ExperienceDocument(

--- a/chapter8/gaia-experience/knowledge_base.py
+++ b/chapter8/gaia-experience/knowledge_base.py
@@ -41,6 +41,14 @@ class KnowledgeBase:
         # Initialize the sentence transformer
         try:
             self.encoder = SentenceTransformer(model_name)
+            # Derive the real embedding dimension from the loaded model so the
+            # FAISS index matches it. A fixed 384 silently breaks any non-384
+            # model chosen via --embedding-model / config.yaml (e.g.
+            # all-mpnet-base-v2 = 768): index.add() then raises, is swallowed,
+            # and every search falls back to keyword-only for the whole KB.
+            model_dim = self.encoder.get_sentence_embedding_dimension()
+            if model_dim:
+                self.embedding_dim = model_dim
         except Exception as e:
             logger.warning(f"Failed to load SentenceTransformer, falling back to simple search: {e}")
             self.encoder = None

--- a/chapter8/gaia-experience/knowledge_base.py
+++ b/chapter8/gaia-experience/knowledge_base.py
@@ -83,7 +83,22 @@ class KnowledgeBase:
                         self.metadata = pickle.load(f)
                 else:
                     self.metadata = [{}] * len(self.documents)
-                    
+
+                # A persisted index carries no model id / dimension, so a run
+                # that switched embedding models would reuse an index whose
+                # dimension no longer matches the encoder — every add()/search()
+                # would then raise a dimension mismatch (swallowed) and silently
+                # disable semantic search. Detect the mismatch and rebuild the
+                # index from the stored query texts.
+                if (self.encoder and self.index is not None
+                        and self.index.d != self.embedding_dim):
+                    logger.warning(
+                        "Persisted FAISS index dim %s != model dim %s "
+                        "(embedding model changed); rebuilding from stored queries.",
+                        self.index.d, self.embedding_dim,
+                    )
+                    self._rebuild_index_from_metadata()
+
                 logger.info(f"Loaded knowledge base with {len(self.documents)} documents")
             except Exception as e:
                 logger.error(f"Failed to load index: {e}")
@@ -97,6 +112,26 @@ class KnowledgeBase:
             self.index = faiss.IndexFlatL2(self.embedding_dim)
         self.documents = []
         self.metadata = []
+
+    def _rebuild_index_from_metadata(self):
+        """Rebuild the FAISS index at the current embedding dimension by
+        re-encoding the query texts persisted in metadata (used when a loaded
+        index was built with a different embedding model). One embedding per
+        document, in order, so index rows stay aligned with self.documents."""
+        self.index = faiss.IndexFlatL2(self.embedding_dim)
+        if not self.documents:
+            return
+        queries = [
+            (self.metadata[i].get('query', '') if i < len(self.metadata) else '')
+            for i in range(len(self.documents))
+        ]
+        try:
+            embeddings = self.encoder.encode(queries)
+            self.index.add(embeddings)
+            self._save_index()
+            logger.info(f"Rebuilt FAISS index with {self.index.ntotal} embeddings")
+        except Exception as e:
+            logger.error(f"Failed to rebuild FAISS index: {e}")
     
     def _save_index(self):
         """Save index to disk."""

--- a/chapter8/gaia-experience/test_experience_documents.py
+++ b/chapter8/gaia-experience/test_experience_documents.py
@@ -42,6 +42,23 @@ class ExperienceDocumentTest(unittest.TestCase):
             self.assertEqual(2, len(paths))
             self.assertTrue(all(path.suffix == ".md" for path in paths))
 
+    def test_build_documents_tolerates_missing_environment_score(self):
+        # outcome_label already reads the score with .get(default); the sources
+        # line must too, otherwise a record missing environment_score raises
+        # KeyError instead of scoring 0.0.
+        record = {
+            "id": "gaia-x",
+            "task_family": "web_research",
+            "observed_strategies": ["s"],
+            "mistakes": [],
+            "exceptions": [],
+            "applies_when": [],
+            "capabilities": [],
+        }
+        documents = build_documents([record])
+        self.assertEqual(1, len(documents))
+        self.assertIn("gaia-x (failure, score=0.00)", documents[0].sources)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/chapter8/gaia-experience/test_kb_faiss_negative_idx.py
+++ b/chapter8/gaia-experience/test_kb_faiss_negative_idx.py
@@ -10,3 +10,14 @@ def test_search_guards_negative_indices():
     indices = [0, -1, -1]
     results = [documents[idx] for idx in indices if 0 <= idx < len(documents)]
     assert results == [{"id": 0}]
+
+
+def test_index_dimension_tracks_model_and_rebuilds_on_mismatch():
+    """The FAISS index dimension must come from the loaded model (not a fixed
+    384), and a persisted index built with a different model must be rebuilt on
+    load — otherwise every add()/search() raises a swallowed dimension mismatch
+    and semantic search silently degrades to keyword-only."""
+    src = Path(__file__).with_name("knowledge_base.py").read_text()
+    assert "get_sentence_embedding_dimension()" in src
+    assert "self.index.d != self.embedding_dim" in src
+    assert "_rebuild_index_from_metadata" in src


### PR DESCRIPTION
Two fixes in `chapter8/gaia-experience/`.

### 1. `knowledge_base.py` — FAISS index dimension hardcoded to 384 silently disables semantic search for any non-384 model (major)
`KnowledgeBase` builds `faiss.IndexFlatL2(self.embedding_dim)` from the constructor's hardcoded `embedding_dim=384` and never derives it from the loaded model. The `--embedding-model` CLI flag (`run_with_experience.py`) and `config.yaml`'s `embedding_model` let users pick a different sentence-transformer, but no call site passes `embedding_dim`. So choosing e.g. `all-mpnet-base-v2` (768-dim) makes every `index.add()` raise a dimension mismatch, which is swallowed at `knowledge_base.py:264` (only logged). `index.ntotal` stays 0, so `search()` (`self.index.ntotal > 0` is False) falls back to keyword-only for the **entire** KB — semantic retrieval is silently off with no error surfaced. The default `all-MiniLM-L6-v2` (384) masks it.

**Fix:** derive the dimension from the loaded model via `get_sentence_embedding_dimension()`.
**Verify:** construct `KnowledgeBase(model_name="all-mpnet-base-v2")`; before, `index.d == 384` and `add()` raises; after, `index.d == 768` so `add()` succeeds and semantic search runs.

### 2. `experience_documents.py` — `build_documents` KeyError on a record missing `environment_score` (minor)
Line 82 reads the score defensively as `record.get("environment_score", 0.0)`, but line 107 (building `sources`) uses a hard `record['environment_score']`, so a record lacking the field passes the first read and then raises `KeyError`. Use the same `.get(default)` form.
**Verify:** the added regression test (`test_build_documents_tolerates_missing_environment_score`) fails on the old code with `KeyError` and passes after; the existing suite still passes (5/5 via `python -m unittest test_experience_documents`).

(No CI covers this module; verified locally — the KB major via a faiss-invariant repro, the doc minor via the unittest suite.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 缺少环境评分时，文档生成不再失败，并将评分显示为 0.00。
  * 向量检索会自动匹配所选模型的实际维度，提升非默认模型下的检索稳定性。

* **测试**
  * 新增缺少环境评分场景的验证，确保文档仍可正常生成。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->