### PR TITLE
fix(browser-use-rpa): validate learned workflow with its example parameters; template longest values first

### DIFF
--- a/chapter8/browser-use-rpa/learning_agent/agent.py
+++ b/chapter8/browser-use-rpa/learning_agent/agent.py
@@ -458,18 +458,27 @@ class LearningAgent:
                 parameters = dict(step_data['parameters'])
                 for key, value in parameters.items():
                     if isinstance(value, str):
-                        # Template longest values first so a shorter param value
-                        # that is a substring of another field (e.g. subject
-                        # "Report" inside body "Report is ready") can't pre-empt
-                        # the longer match and mis-tag the field.
-                        for param_key, param_value in sorted(
+                        # Replace each captured literal with its {token}. Match
+                        # longest values first so a shorter value that is a
+                        # substring of a longer field (e.g. subject "Report"
+                        # inside body "Report is ready") can't pre-empt it, and
+                        # stage substitutions through unique sentinels so an
+                        # already-inserted {token} is never re-scanned by a later
+                        # parameter whose value happens to appear in the token
+                        # text — the result no longer depends on iteration order.
+                        sentinels = {}
+                        for i, (param_key, param_value) in enumerate(sorted(
                             example_params.items(),
                             key=lambda kv: len(str(kv[1])),
                             reverse=True,
-                        ):
+                        )):
                             pv = str(param_value)
                             if pv and pv in value:
-                                value = value.replace(pv, f"{{{param_key}}}")
+                                sentinel = f"\x00{i}\x00"
+                                sentinels[sentinel] = f"{{{param_key}}}"
+                                value = value.replace(pv, sentinel)
+                        for sentinel, token in sentinels.items():
+                            value = value.replace(sentinel, token)
                         parameters[key] = value
 
                 step = WorkflowStep(

--- a/chapter8/browser-use-rpa/learning_agent/agent.py
+++ b/chapter8/browser-use-rpa/learning_agent/agent.py
@@ -458,7 +458,15 @@ class LearningAgent:
                 parameters = dict(step_data['parameters'])
                 for key, value in parameters.items():
                     if isinstance(value, str):
-                        for param_key, param_value in example_params.items():
+                        # Template longest values first so a shorter param value
+                        # that is a substring of another field (e.g. subject
+                        # "Report" inside body "Report is ready") can't pre-empt
+                        # the longer match and mis-tag the field.
+                        for param_key, param_value in sorted(
+                            example_params.items(),
+                            key=lambda kv: len(str(kv[1])),
+                            reverse=True,
+                        ):
                             pv = str(param_value)
                             if pv and pv in value:
                                 value = value.replace(pv, f"{{{param_key}}}")
@@ -521,7 +529,15 @@ class LearningAgent:
                 await reset_result
             await self.replayer.setup()
             try:
-                validation = await self.replayer.replay_workflow(workflow)
+                # Validate with the learned example parameters so the replay
+                # substitutes the {placeholder} tokens back to concrete values.
+                # Without this the validation run types the literal token text
+                # (e.g. "{recipient}") into the page, so a correctly-learned
+                # workflow fails validation and is never published — every later
+                # replay then falls back to the LLM. (empty dict => no-op.)
+                validation = await self.replayer.replay_workflow(
+                    workflow, parameters=workflow.example_parameters
+                )
             finally:
                 await self.replayer.cleanup()
             if validation['success']:


### PR DESCRIPTION
Two fixes in `chapter8/browser-use-rpa/learning_agent/agent.py` (`_save_learned_workflow`).

### 1. Validation replay never substitutes the learned parameters, so a learned workflow is never published (major)
The captured steps are templated into `{placeholder}` tokens and the concrete values stored in `workflow.example_parameters`. But the validate-before-publish replay calls `self.replayer.replay_workflow(workflow)` with **no** parameters. `replay_workflow` only substitutes when parameters are passed (`replay.py`: `if parameters:` → `workflow.parameterize(parameters)`), so the validation run types the literal token text (e.g. `"{recipient}"`) into the page. A correctly-learned workflow therefore fails its own final `URL_CONTAINS` predicate, `publish_validated` is skipped, and it stays a candidate — every later Phase-2 replay finds no match and falls back to the LLM, defeating the learn→replay feature. (If a site happens to accept the token, validation passes with garbage input — false confidence.)

**Fix:** pass `parameters=workflow.example_parameters` (an empty dict hits the existing `if parameters:` no-op guard).
**Verify:** with a `{recipient}` INPUT_TEXT step and `example_parameters={'recipient': 'test@example.com'}`, `parameterize` now yields `"test@example.com"` (was `"{recipient}"`).

### 2. Parameter templating corrupts a field when one value is a substring of another (minor)
Templating iterates `example_parameters` in insertion order. If a shorter value is a substring of a longer field's captured text — subject `"Report"` inside body `"Report is ready"`, subject processed first — the body is rewritten to `"{subject} is ready"`, so replay later substitutes the wrong parameter (wrong message sent).

**Fix:** template longest values first (`sorted(..., key=len, reverse=True)`).
**Verify:** body now templates to `"{content}"` instead of `"{subject} is ready"`.

(No CI covers this module; the `_save_learned_workflow` path needs the full Playwright/browser-use stack, so both fixes were verified with a targeted repro against `workflow.parameterize` and the templating loop — old-vs-new.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复工作流参数模板化错误，避免较短参数值被误识别为较长参数值的一部分。
  * 修复工作流发布前的验证问题，确保回放时使用实际参数值进行验证。
  * 提升正确学习的工作流通过验证并成功发布的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->