### PR TITLE
fix(conversational-ui): drop apply_edits file items missing a string content

### DIFF
--- a/chapter5/conversational-ui/agent.py
+++ b/chapter5/conversational-ui/agent.py
@@ -180,7 +180,15 @@ def customize(client, model, frontend_dir: Path, requirement: str) -> dict:
         args = {}
 
     # 安全校验：只允许改写白名单内的文件。
-    files = [f for f in (args.get("files") or []) if isinstance(f, dict)]
+    # 要求每个文件项带有字符串 content：否则下游写盘循环会对
+    # {"path": ...}（缺少 content）抛出 KeyError 而中断整个 demo。
+    # 形状不合法的项直接丢弃（与非 dict 过滤一致）；白名单校验仍会对
+    # 带 content 但路径非法的项抛错。
+    files = [
+        f
+        for f in (args.get("files") or [])
+        if isinstance(f, dict) and isinstance(f.get("content"), str)
+    ]
     for f in files:
         path = f.get("path")
         if path not in EDITABLE_FILES:

--- a/chapter5/conversational-ui/test_customize_malformed_args.py
+++ b/chapter5/conversational-ui/test_customize_malformed_args.py
@@ -47,3 +47,12 @@ def test_normal_edits_pass(frontend_dir):
         _fake_client(json.dumps({"summary": "s", "files": files})),
         "model", frontend_dir, "把文字改成红色")
     assert args["files"] == files
+
+
+def test_file_entry_missing_content_dropped(frontend_dir):
+    """文件项有合法 path 但缺 content → 丢弃该项，避免下游写盘 f["content"]
+    抛出 KeyError 而中断整个 demo（与缺 path 抛白名单错误对称处理）。"""
+    args = agent.customize(
+        _fake_client(json.dumps({"summary": "s", "files": [{"path": "src/theme.css"}]})),
+        "model", frontend_dir, "把按钮改成蓝色")
+    assert args["files"] == []


### PR DESCRIPTION
`chapter5/conversational-ui/agent.py` — `customize()` validates that each `apply_edits` file item is a dict with a whitelisted `path`, but never checks that `content` is present. A model reply like `{"path": "src/theme.css"}` (valid path, no content) is kept, and `demo.py`'s write loop then crashes at `new_content = f["content"]` with `KeyError: 'content'`, aborting the whole run.

The author already guards the symmetric missing-`path` case — `test_customize_malformed_args.py::test_file_entry_missing_path_rejected_cleanly` asserts it yields a clean `RuntimeError` "而非 KeyError". This closes the missing-`content` gap (the same class of malformed model output) one layer upstream.

**Fix:** require each kept item to have a string `content`; drop shape-malformed items (consistent with the existing non-dict filter). Items that carry `content` but a non-whitelisted `path` still raise the whitelist `RuntimeError`.

**Verify:** added `test_file_entry_missing_content_dropped` (fails on the old code — `customize` keeps the content-less item → downstream KeyError; passes after — item dropped). Existing customize tests still pass (8/8 across the three `test_customize_*.py`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进文件编辑结果的校验，自动忽略缺少文件内容的无效条目。
  * 防止格式异常的编辑结果导致演示流程中断。
  * 保留可编辑路径校验及异常结果的安全降级行为。

* **Tests**
  * 新增对缺少文件内容的编辑条目的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->