### PR TITLE
fix: load .env files across runnable examples

### DIFF
--- a/chapter1/search-codegen/example_request.py
+++ b/chapter1/search-codegen/example_request.py
@@ -8,6 +8,12 @@ import requests
 import os
 from typing import Dict, Any
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 def make_gpt5_openrouter_request(
     api_key: str,
     system_prompt: str,

--- a/chapter2/kv-cache/README.md
+++ b/chapter2/kv-cache/README.md
@@ -66,7 +66,8 @@ Both modes append tool results within an iteration so the API sees a complete tu
 ```bash
 cd chapter2/kv-cache
 pip install -r requirements.txt
-export MOONSHOT_API_KEY="your-api-key-here"
+cp env.example .env                  # edit .env with your key
+# Or export MOONSHOT_API_KEY="your-api-key-here"
 ```
 
 > **OpenRouter fallback:** If `MOONSHOT_API_KEY` / `KIMI_API_KEY` is unset but `OPENROUTER_API_KEY` is set, the experiment uses OpenRouter (`kimi-*` → `moonshotai/kimi-k2`). With a Moonshot key set, behavior is unchanged.
@@ -289,7 +290,8 @@ KV Cache 存储注意力机制中的键值对。对话上下文稳定时，可�
 ```bash
 cd chapter2/kv-cache
 pip install -r requirements.txt
-export MOONSHOT_API_KEY="your-api-key-here"
+cp env.example .env                  # 编辑 .env，填入 API Key
+# 或 export MOONSHOT_API_KEY="your-api-key-here"
 ```
 
 > **通用回退（OpenRouter）**：未设置 `MOONSHOT_API_KEY` / `KIMI_API_KEY` 时，只要配置了 `OPENROUTER_API_KEY`，实验会自动改走 OpenRouter（`kimi-*` 会映射为 `moonshotai/kimi-k2`）。设置了 Moonshot key 时行为完全不变。

--- a/chapter2/kv-cache/agent.py
+++ b/chapter2/kv-cache/agent.py
@@ -18,6 +18,12 @@ from openai import OpenAI
 import glob as glob_module
 import subprocess
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 
 def _is_reasoning_model(model) -> bool:
     """True for models that emit reasoning_content and only accept temperature=1.

--- a/chapter2/kv-cache/demo_quick.py
+++ b/chapter2/kv-cache/demo_quick.py
@@ -6,6 +6,13 @@ Shows the difference between correct and incorrect implementations
 
 import os
 import sys
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 from agent import KVCacheAgent, KVCacheMode
 
 def main():

--- a/chapter2/kv-cache/main.py
+++ b/chapter2/kv-cache/main.py
@@ -12,6 +12,13 @@ import logging
 from typing import Dict, List, Any
 from datetime import datetime
 from dataclasses import asdict
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 from agent import KVCacheAgent, KVCacheMode, AgentMetrics, compare_implementations
 
 # Default model (Moonshot / Kimi). The whole current Kimi family (k2.5/k2.6/

--- a/chapter2/log-sanitization/agent.py
+++ b/chapter2/log-sanitization/agent.py
@@ -10,6 +10,12 @@ from typing import List, Tuple, Dict, Optional
 from pathlib import Path
 import ollama
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 from config import (
     OLLAMA_MODEL, 
     OLLAMA_TEMPERATURE,

--- a/chapter2/log-sanitization/requirements.txt
+++ b/chapter2/log-sanitization/requirements.txt
@@ -1,3 +1,4 @@
 # Core dependencies
 ollama>=0.3.0
 pyyaml>=6.0
+python-dotenv>=1.0.0

--- a/chapter2/prompt-engineering/run.py
+++ b/chapter2/prompt-engineering/run.py
@@ -1,6 +1,13 @@
 # Copyright Sierra
 
 import argparse
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 from tau_bench.types import RunConfig
 from tau_bench.run import run
 from litellm import provider_list

--- a/chapter2/prompt-engineering/run_ablation.py
+++ b/chapter2/prompt-engineering/run_ablation.py
@@ -12,6 +12,13 @@ import random
 import os
 import json
 from datetime import datetime
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 from tau_bench.types import RunConfig
 # from litellm import provider_list  # This returns enums, not strings
 # Define provider choices as strings

--- a/chapter2/prompt-engineering/test_ablation.py
+++ b/chapter2/prompt-engineering/test_ablation.py
@@ -11,6 +11,12 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 import sys
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 
 def run_experiment(
     name: str,

--- a/chapter2/prompt-engineering/test_openrouter_direct.py
+++ b/chapter2/prompt-engineering/test_openrouter_direct.py
@@ -6,6 +6,13 @@ This helps isolate API connection issues from tau-bench logic
 
 import os
 import sys
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 from litellm import completion
 
 def test_openrouter():

--- a/chapter2/system-hint/agent.py
+++ b/chapter2/system-hint/agent.py
@@ -22,6 +22,12 @@ import tempfile
 import shutil
 from pathlib import Path
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 
 def _reasoning_safe_temperature(model, requested=1.0):
     """Reasoning models (Kimi K3, GPT-5, ...) only accept temperature=1.

--- a/chapter3/memobase/profile_demo.py
+++ b/chapter3/memobase/profile_demo.py
@@ -27,6 +27,12 @@ import os
 import sys
 from pathlib import Path
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 # 示例多轮对话：内容刻意覆盖三个画像主题，便于观察 Profile 的两级结构
 SAMPLE_CONVERSATION = [
     {"role": "user", "content": "你好，我叫李明，今年 28 岁，住在上海。"},

--- a/chapter4/agent-with-event-trigger/agent.py
+++ b/chapter4/agent-with-event-trigger/agent.py
@@ -27,6 +27,12 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from mcp.types import TextContent
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 
 def _reasoning_safe_temperature(model, requested=1.0):
     """Reasoning models (Kimi K3, GPT-5, ...) only accept temperature=1.

--- a/chapter4/collaboration-tools/src/llm_fallback.py
+++ b/chapter4/collaboration-tools/src/llm_fallback.py
@@ -16,6 +16,12 @@ credential resolution so that:
 import os
 from typing import Optional, Tuple
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 
 def map_model_for_openrouter(model: str) -> str:
     """Map a plain model id onto OpenRouter's `provider/model` form.

--- a/chapter5/code-for-math/demo.py
+++ b/chapter5/code-for-math/demo.py
@@ -18,6 +18,12 @@ import sys
 import json
 import argparse
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 from sandbox import run_python
 
 # ---------------------------------------------------------------------------

--- a/chapter5/code-for-math/requirements.txt
+++ b/chapter5/code-for-math/requirements.txt
@@ -2,3 +2,4 @@ openai>=1.30.0
 sympy>=1.12
 numpy>=1.26
 scipy>=1.11
+python-dotenv>=1.0.0

--- a/chapter5/coding-agent/agent.py
+++ b/chapter5/coding-agent/agent.py
@@ -11,6 +11,12 @@ from datetime import datetime
 import anthropic
 import openai
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 from system_state import SystemState
 from tool_registry import ToolRegistry
 
@@ -514,4 +520,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/chapter5/coding-agent/agent_new.py
+++ b/chapter5/coding-agent/agent_new.py
@@ -10,6 +10,12 @@ from pathlib import Path
 from datetime import datetime
 import anthropic
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 from system_state import SystemState
 from tool_registry import ToolRegistry
 
@@ -293,4 +299,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/chapter6/elo-leaderboard/llm_judge.py
+++ b/chapter6/elo-leaderboard/llm_judge.py
@@ -32,6 +32,12 @@ Bradley-Terry pipeline.
 import os
 from typing import Dict, List, Optional
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 # Default candidate roster and judge (Claude models). Kept small because every
 # battle costs several API calls (two responses + two swapped judgements).
 DEFAULT_CANDIDATE_MODELS = ["claude-opus-4-8", "claude-haiku-4-5"]

--- a/chapter6/elo-leaderboard/requirements.txt
+++ b/chapter6/elo-leaderboard/requirements.txt
@@ -6,4 +6,4 @@ requests>=2.31.0
 plotly>=5.14.0
 tqdm>=4.65.0
 scikit-learn>=1.3.0
-
+python-dotenv>=1.0.0

--- a/chapter6/public-health-reporting-eval/demo.py
+++ b/chapter6/public-health-reporting-eval/demo.py
@@ -7,6 +7,12 @@ import json
 import os
 from pathlib import Path
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 from agent import DeterministicReportingAgent
 from evaluator import evaluate, expected_by_task, load_json
 from reporting_tools import ReportingEnvironment

--- a/chapter6/public-health-reporting-eval/requirements.txt
+++ b/chapter6/public-health-reporting-eval/requirements.txt
@@ -1,1 +1,2 @@
 pytest>=8.0,<9.0
+python-dotenv>=1.0.0

--- a/chapter8/browser-use-rpa/browser-use/examples/cloud/01_basic_task.py
+++ b/chapter8/browser-use-rpa/browser-use/examples/cloud/01_basic_task.py
@@ -20,6 +20,12 @@ from typing import Any
 import requests
 from requests.exceptions import RequestException
 
+try:
+	from dotenv import load_dotenv
+	load_dotenv()
+except ImportError:
+	pass
+
 # Configuration
 API_KEY = os.getenv('BROWSER_USE_API_KEY')
 if not API_KEY:

--- a/chapter8/browser-use-rpa/browser-use/examples/cloud/02_fast_mode_gemini.py
+++ b/chapter8/browser-use-rpa/browser-use/examples/cloud/02_fast_mode_gemini.py
@@ -24,6 +24,12 @@ from typing import Any
 import requests
 from requests.exceptions import RequestException
 
+try:
+	from dotenv import load_dotenv
+	load_dotenv()
+except ImportError:
+	pass
+
 # Configuration
 API_KEY = os.getenv('BROWSER_USE_API_KEY')
 if not API_KEY:

--- a/chapter8/browser-use-rpa/browser-use/examples/cloud/03_structured_output.py
+++ b/chapter8/browser-use-rpa/browser-use/examples/cloud/03_structured_output.py
@@ -23,6 +23,12 @@ import requests
 from pydantic import BaseModel, Field, ValidationError
 from requests.exceptions import RequestException
 
+try:
+	from dotenv import load_dotenv
+	load_dotenv()
+except ImportError:
+	pass
+
 # Configuration
 API_KEY = os.getenv('BROWSER_USE_API_KEY')
 if not API_KEY:

--- a/chapter8/browser-use-rpa/browser-use/examples/cloud/04_proxy_usage.py
+++ b/chapter8/browser-use-rpa/browser-use/examples/cloud/04_proxy_usage.py
@@ -22,6 +22,12 @@ from typing import Any
 import requests
 from requests.exceptions import RequestException
 
+try:
+	from dotenv import load_dotenv
+	load_dotenv()
+except ImportError:
+	pass
+
 # Configuration
 API_KEY = os.getenv('BROWSER_USE_API_KEY')
 if not API_KEY:

--- a/chapter8/browser-use-rpa/browser-use/examples/cloud/05_search_api.py
+++ b/chapter8/browser-use-rpa/browser-use/examples/cloud/05_search_api.py
@@ -20,6 +20,12 @@ from typing import Any
 
 import aiohttp
 
+try:
+	from dotenv import load_dotenv
+	load_dotenv()
+except ImportError:
+	pass
+
 # Configuration
 API_KEY = os.getenv('BROWSER_USE_API_KEY')
 if not API_KEY:

--- a/chapter8/self-evolution-eval/agent.py
+++ b/chapter8/self-evolution-eval/agent.py
@@ -9,6 +9,12 @@ import re
 import time
 from typing import Any, Dict
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 
 BASELINE_ACTIONS = {
     "refund": "issue_full_refund",

--- a/chapter8/self-evolution-eval/requirements.txt
+++ b/chapter8/self-evolution-eval/requirements.txt
@@ -1,4 +1,5 @@
-# The experiment uses only the Python standard library.
-# pytest is optional for the retained compatibility test.
+# The offline experiment uses only the Python standard library.
+# pytest and python-dotenv support testing and optional .env configuration.
 pytest>=8.0.0
 openai>=1.68.0
+python-dotenv>=1.0.0

--- a/chapter8/self-modifying-agent/llm_generator.py
+++ b/chapter8/self-modifying-agent/llm_generator.py
@@ -7,6 +7,12 @@ import os
 import re
 from typing import Any, Dict
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 from evolution import candidate_from_source
 
 

--- a/chapter8/self-modifying-agent/requirements.txt
+++ b/chapter8/self-modifying-agent/requirements.txt
@@ -1,1 +1,2 @@
 openai>=1.68.0
+python-dotenv>=1.0.0

--- a/chapter8/trajectory-verifier/llm_judge.py
+++ b/chapter8/trajectory-verifier/llm_judge.py
@@ -7,6 +7,12 @@ import os
 import re
 from typing import Any, Dict, Iterable
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 from verifier import DimensionResult, FAIL, PASS, UNCERTAIN
 
 

--- a/chapter8/trajectory-verifier/requirements.txt
+++ b/chapter8/trajectory-verifier/requirements.txt
@@ -1,1 +1,2 @@
 openai>=1.68.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary

- load `.env` before Chapter 2 KV-cache resolves `MOONSHOT_API_KEY`, `KIMI_API_KEY`, or `OPENROUTER_API_KEY`
- document the supported `cp env.example .env` setup for the KV-cache experiment
- audit every tracked env template against Python environment readers, documented entrypoints, and transitive local imports
- fix the same bypass in 15 other runnable project paths, including prompt engineering, System Hint, Event Trigger, collaboration tools, Memobase, code-for-math, coding-agent, Elo, browser cloud, and Chapter 8 LLM modes
- add `python-dotenv` to project requirements where `.env` support was advertised but the dependency was absent

The imports remain optional so exported shell variables and dependency-free offline modes keep their existing behavior. `load_dotenv()` also preserves already-exported values because override remains disabled.

## Audit result

The final scan finds no tracked `env.example` / `.env.example` / `env.template` project that reads environment variables while having no dotenv loader. The audit also checked the non-Python template consumers: Next.js handles the live-audio frontend `.env` automatically, and the GAIA launcher already loads its template-backed environment.

## Verification

- sentinel `.env` smoke test passed through every fixed entry/shared module, including all five Browser Use Cloud examples
- `python -m compileall` passed for every changed Python file
- `git diff --check` passed
- 251 targeted unit tests passed across KV-cache, System Hint, Event Trigger, collaboration tools, coding-agent, Elo, public-health evaluation, self-evolution, self-modification, and trajectory verification
- `chapter5/code-for-math`: offline self-check passed 11/11 cases
- prompt-engineering entrypoints: both `--help` smoke tests passed
- log-sanitization and collaboration-tools offline demos passed

One additional Elo test (`test_tie_bothbad.py`) cannot collect in the current local environment because installed Numba requires NumPy <=2.2 while NumPy 2.4 is installed; the other 33 Elo tests pass and this dependency mismatch is unrelated to the change.

Closes #455


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持从本地 `.env` 文件自动加载 API 密钥及其他环境变量，简化示例和实验配置。
  * 未安装相关配置加载组件时，程序仍可正常启动。
  * 重置代理状态时新增状态日志提示。

* **文档**
  * 更新安装说明，推荐通过示例环境文件配置密钥，同时保留命令行环境变量设置方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->