### PR TITLE
docs(ch1): redraw autonomous Agent execution loop

### DIFF
--- a/book-en/images/fig1-5.svg
+++ b/book-en/images/fig1-5.svg
@@ -1,34 +1,72 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 820 460" width="820" height="460" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="80" y="60" width="500" height="380" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="330" y="82" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">while not done:</text>
-<rect x="120" y="100" width="420" height="60" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="130" y="115" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">① Think (Reasoning)</text>
-<rect x="130" y="125" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="140" font-family="'Courier New', Courier, monospace" font-size="8.5" fill="#333333" text-anchor="start" dominant-baseline="central">&quot;Analyzing search results...insufficient information, need further search&quot;</text>
-<rect x="120" y="175" width="420" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="130" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">② Acting</text>
-<rect x="130" y="200" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="215" font-family="'Courier New', Courier, monospace" font-size="13.5" fill="#333333" text-anchor="start" dominant-baseline="central">web_search(&quot;Agent RL training techniques 2025&quot;)</text>
-<line x1="330" y1="162" x2="330" y2="173" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="120" y="250" width="420" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="130" y="265" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">③ Observing</text>
-<rect x="130" y="275" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="290" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">tool_result: &quot;Found 3 relevant papers...&quot;</text>
-<line x1="330" y1="237" x2="330" y2="248" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<path d="M 540,280 Q 500.0,200.0 540,120" fill="none" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
-<text x="520.0" y="190.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="7" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Continue loop</text>
-<rect x="610" y="60" width="190" height="190" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="622" y="78" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="bold">Exit conditions</text>
-<text x="620" y="100" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">① Task completed</text>
-<text x="620" y="132" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">② Call final_answer</text>
-<text x="620" y="164" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">③ No tool call returned</text>
-<text x="620" y="196" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">④ Maximum rounds reached</text>
-<text x="620" y="228" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">⑤ Error count exceeded</text>
-<rect x="80" y="360" width="500" height="70" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="330" y="380" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Practical execution example: SWE-bench code fix</text>
-<text x="330" y="405" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Search code → Locate bug → Edit file → Run tests → Fix fails → Edit again → Tests pass → Done</text>
-<text x="330" y="425" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">(5 rounds of iteration, 12 tool calls)</text>
-<line x1="330" y1="312" x2="330" y2="358" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<text x="330.0" y="325.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle">done = True</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 470" width="820" height="470" role="img" aria-labelledby="title desc">
+  <title id="title">Execution loop of an autonomous Agent</title>
+  <desc id="desc">The Agent reasons, acts, and observes before checking exit conditions and either returning the final result or starting another iteration.</desc>
+  <defs>
+    <marker id="arrow-dark" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#333333"/>
+    </marker>
+    <marker id="arrow-light" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#777777"/>
+    </marker>
+    <style>
+      .sans { font-family: Arial, "Helvetica Neue", Helvetica, "PingFang SC", "Microsoft YaHei", sans-serif; }
+      .code { font-family: "Courier New", Courier, monospace; }
+      .heading { fill: #333333; font-size: 16px; font-weight: 700; }
+      .body { fill: #333333; font-size: 15px; }
+      .note { fill: #666666; font-size: 14px; }
+      .box { stroke: #333333; stroke-width: 2; }
+      .flow { fill: none; stroke: #333333; stroke-width: 2; marker-end: url(#arrow-dark); }
+    </style>
+  </defs>
+
+  <rect width="820" height="470" fill="#ffffff"/>
+
+  <!-- ReAct steps -->
+  <rect class="box" x="45" y="70" width="210" height="96" rx="8" fill="#e8e8e8"/>
+  <text class="sans heading" x="60" y="95" dominant-baseline="middle">① Think (Reasoning)</text>
+  <rect x="60" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="150" y="132" text-anchor="middle" dominant-baseline="middle">&quot;Need more info&quot;</text>
+
+  <rect class="box" x="305" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="320" y="95" dominant-baseline="middle">② Acting</text>
+  <rect x="320" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="410" y="132" text-anchor="middle" dominant-baseline="middle">web_search(...)</text>
+
+  <rect class="box" x="565" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="580" y="95" dominant-baseline="middle">③ Observing</text>
+  <rect x="580" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="670" y="132" text-anchor="middle" dominant-baseline="middle">tool_result: &quot;...&quot;</text>
+
+  <line class="flow" x1="255" y1="118" x2="302" y2="118"/>
+  <line class="flow" x1="515" y1="118" x2="562" y2="118"/>
+  <line class="flow" x1="670" y1="166" x2="670" y2="207"/>
+
+  <!-- Exit criteria feed the decision point -->
+  <rect x="45" y="220" width="430" height="145" rx="8" fill="#ffffff" stroke="#777777" stroke-width="2" stroke-dasharray="7 4"/>
+  <text class="sans heading" x="65" y="244" dominant-baseline="middle">Exit conditions (any one)</text>
+  <line x1="65" y1="258" x2="455" y2="258" stroke="#cccccc"/>
+  <text class="sans body" x="65" y="282" dominant-baseline="middle">① Task complete</text>
+  <text class="sans body" x="250" y="282" dominant-baseline="middle">② final_answer called</text>
+  <text class="sans body" x="65" y="314" dominant-baseline="middle">③ No tool call</text>
+  <text class="sans body" x="250" y="314" dominant-baseline="middle">④ Error limit exceeded</text>
+  <text class="sans body" x="65" y="346" dominant-baseline="middle">⑤ Max rounds reached</text>
+
+  <path d="M 475 260 H 587" fill="none" stroke="#777777" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow-light)"/>
+  <rect x="493" y="238" width="80" height="20" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="533" y="248" text-anchor="middle" dominant-baseline="middle">Decision criteria</text>
+
+  <!-- Stop decision and branches -->
+  <polygon class="box" points="670,208 750,260 670,312 590,260" fill="#e2e2e2"/>
+  <text class="sans heading" x="670" y="252" text-anchor="middle" dominant-baseline="middle">Exit condition</text>
+  <text class="sans heading" x="670" y="273" text-anchor="middle" dominant-baseline="middle">met?</text>
+
+  <path class="flow" d="M 750 260 H 795 V 35 H 150 V 67"/>
+  <text class="sans note" x="765" y="245" dominant-baseline="middle">No</text>
+  <rect x="360" y="43" width="120" height="22" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="420" y="54" text-anchor="middle" dominant-baseline="middle">Continue the loop</text>
+
+  <line class="flow" x1="670" y1="312" x2="670" y2="379"/>
+  <text class="sans note" x="685" y="346" dominant-baseline="middle">Yes</text>
+  <rect class="box" x="555" y="382" width="230" height="68" rx="8" fill="#d6d6d6"/>
+  <text class="sans heading" x="670" y="416" text-anchor="middle" dominant-baseline="middle">Return final result</text>
 </svg>

--- a/book/images/fig1-5.svg
+++ b/book/images/fig1-5.svg
@@ -1,34 +1,72 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 820 460" width="820" height="460" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="80" y="60" width="500" height="380" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="330" y="82" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">while not done:</text>
-<rect x="120" y="100" width="420" height="60" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="130" y="115" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">① 思考（Reasoning）</text>
-<rect x="130" y="125" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="140" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">&quot;分析搜索结果...信息不足,需要进一步搜索&quot;</text>
-<rect x="120" y="175" width="420" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="130" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">② 行动（Acting）</text>
-<rect x="130" y="200" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="215" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">web_search(&quot;Agent RL training techniques 2025&quot;)</text>
-<line x1="330" y1="162" x2="330" y2="173" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="120" y="250" width="420" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="130" y="265" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">③ 观察（Observing）</text>
-<rect x="130" y="275" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="290" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">tool_result: &quot;Found 3 relevant papers...&quot;</text>
-<line x1="330" y1="237" x2="330" y2="248" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<path d="M 540,280 Q 500.0,200.0 540,120" fill="none" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
-<text x="520.0" y="190.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">继续循环</text>
-<rect x="610" y="60" width="190" height="190" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="622" y="78" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="bold">退出条件</text>
-<text x="620" y="100" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">① 任务完成</text>
-<text x="620" y="132" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">② 调用 final_answer</text>
-<text x="620" y="164" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">③ 无工具调用返回</text>
-<text x="620" y="196" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">④ 达到最大轮次</text>
-<text x="620" y="228" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">⑤ 错误次数超限</text>
-<rect x="80" y="360" width="500" height="70" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="330" y="380" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">实际执行示例：SWE-bench 代码修复</text>
-<text x="330" y="405" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">搜索代码 → 定位 Bug → 编辑文件 → 运行测试 → 修复失败 → 再次编辑 → 测试通过 → 完成</text>
-<text x="330" y="425" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">（5 轮迭代，12 次工具调用）</text>
-<line x1="330" y1="312" x2="330" y2="358" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<text x="330.0" y="325.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle">done = True</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 470" width="820" height="470" role="img" aria-labelledby="title desc">
+  <title id="title">自主 Agent 的执行循环</title>
+  <desc id="desc">Agent 依次思考、行动和观察，再根据退出条件决定输出最终结果或继续下一轮循环。</desc>
+  <defs>
+    <marker id="arrow-dark" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#333333"/>
+    </marker>
+    <marker id="arrow-light" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#777777"/>
+    </marker>
+    <style>
+      .sans { font-family: Arial, "Helvetica Neue", Helvetica, "PingFang SC", "Microsoft YaHei", sans-serif; }
+      .code { font-family: "Courier New", Courier, monospace; }
+      .heading { fill: #333333; font-size: 16px; font-weight: 700; }
+      .body { fill: #333333; font-size: 15px; }
+      .note { fill: #666666; font-size: 14px; }
+      .box { stroke: #333333; stroke-width: 2; }
+      .flow { fill: none; stroke: #333333; stroke-width: 2; marker-end: url(#arrow-dark); }
+    </style>
+  </defs>
+
+  <rect width="820" height="470" fill="#ffffff"/>
+
+  <!-- ReAct steps -->
+  <rect class="box" x="45" y="70" width="210" height="96" rx="8" fill="#e8e8e8"/>
+  <text class="sans heading" x="60" y="95" dominant-baseline="middle">① 思考（Reasoning）</text>
+  <rect x="60" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="150" y="132" text-anchor="middle" dominant-baseline="middle">&quot;还需更多信息&quot;</text>
+
+  <rect class="box" x="305" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="320" y="95" dominant-baseline="middle">② 行动（Acting）</text>
+  <rect x="320" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="410" y="132" text-anchor="middle" dominant-baseline="middle">web_search(...)</text>
+
+  <rect class="box" x="565" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="580" y="95" dominant-baseline="middle">③ 观察（Observing）</text>
+  <rect x="580" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="670" y="132" text-anchor="middle" dominant-baseline="middle">tool_result: &quot;...&quot;</text>
+
+  <line class="flow" x1="255" y1="118" x2="302" y2="118"/>
+  <line class="flow" x1="515" y1="118" x2="562" y2="118"/>
+  <line class="flow" x1="670" y1="166" x2="670" y2="207"/>
+
+  <!-- Exit criteria feed the decision point -->
+  <rect x="45" y="220" width="430" height="145" rx="8" fill="#ffffff" stroke="#777777" stroke-width="2" stroke-dasharray="7 4"/>
+  <text class="sans heading" x="65" y="244" dominant-baseline="middle">退出条件（任一满足）</text>
+  <line x1="65" y1="258" x2="455" y2="258" stroke="#cccccc"/>
+  <text class="sans body" x="65" y="282" dominant-baseline="middle">① 任务完成</text>
+  <text class="sans body" x="250" y="282" dominant-baseline="middle">② 调用 final_answer</text>
+  <text class="sans body" x="65" y="314" dominant-baseline="middle">③ 无工具调用返回</text>
+  <text class="sans body" x="250" y="314" dominant-baseline="middle">④ 错误次数超限</text>
+  <text class="sans body" x="65" y="346" dominant-baseline="middle">⑤ 达到最大轮次</text>
+
+  <path d="M 475 260 H 587" fill="none" stroke="#777777" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow-light)"/>
+  <rect x="502" y="238" width="62" height="20" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="533" y="248" text-anchor="middle" dominant-baseline="middle">判断依据</text>
+
+  <!-- Stop decision and branches -->
+  <polygon class="box" points="670,208 750,260 670,312 590,260" fill="#e2e2e2"/>
+  <text class="sans heading" x="670" y="252" text-anchor="middle" dominant-baseline="middle">满足退出</text>
+  <text class="sans heading" x="670" y="273" text-anchor="middle" dominant-baseline="middle">条件？</text>
+
+  <path class="flow" d="M 750 260 H 795 V 35 H 150 V 67"/>
+  <text class="sans note" x="765" y="245" dominant-baseline="middle">否</text>
+  <rect x="360" y="43" width="120" height="22" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="420" y="54" text-anchor="middle" dominant-baseline="middle">继续下一轮循环</text>
+
+  <line class="flow" x1="670" y1="312" x2="670" y2="379"/>
+  <text class="sans note" x="685" y="346" dominant-baseline="middle">是</text>
+  <rect class="box" x="555" y="382" width="230" height="68" rx="8" fill="#d6d6d6"/>
+  <text class="sans heading" x="670" y="416" text-anchor="middle" dominant-baseline="middle">输出最终结果</text>
 </svg>


### PR DESCRIPTION
## Summary

- redraw Figure 1-5 around the core Reasoning → Acting → Observing control flow
- connect all exit criteria to an explicit decision node, with the continue branch returning to Reasoning and the exit branch returning the final result
- shorten code snippets and remove the crowded SWE-bench trajectory from the figure while keeping the example in the surrounding text
- keep the Chinese and English figures structurally aligned

## Verification

- `xmllint --noout book/images/fig1-5.svg book-en/images/fig1-5.svg`
- rendered both SVGs at 2× resolution with `rsvg-convert` and visually checked text/connector bounds
- `(cd book && bash build_pdf.sh)` — 316-page Chinese PDF built successfully
- `(cd book-en && bash build_pdf.sh)` — 393-page English PDF built successfully

Closes #472