### PR TITLE
docs(i18n): sync autonomous Agent loop diagram

### DIFF
--- a/book-ar/images/fig1-5.svg
+++ b/book-ar/images/fig1-5.svg
@@ -1,34 +1,70 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 820 460" width="820" height="460" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="80" y="60" width="500" height="380" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="330" y="82" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">بينما لم يتم:</text>
-<rect x="120" y="100" width="420" height="60" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="287.954" y="115" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">① فكر (الاستدلال)</text>
-<rect x="130" y="125" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="517.4" y="140" font-family="'Courier New', Courier, monospace" font-size="6" fill="#333333" text-anchor="start" dominant-baseline="central" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">""تحليل نتائج البحث...معلومات غير كافية، بحاجة إلى مزيد من البحث""</text>
-<rect x="120" y="175" width="420" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="197.833" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">② التمثيل</text>
-<rect x="130" y="200" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="520.7" y="215" font-family="'Courier New', Courier, monospace" font-size="6" fill="#333333" text-anchor="start" dominant-baseline="central" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">web_search("تقنيات تدريب الوكيل RL 2025")</text>
-<line x1="330" y1="162" x2="330" y2="173" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="120" y="250" width="420" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="227.561" y="265" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">③ المراقبة</text>
-<rect x="130" y="275" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="484.4" y="290" font-family="'Courier New', Courier, monospace" font-size="6" fill="#333333" text-anchor="start" dominant-baseline="central" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">tool_result: "تم العثور على 3 أوراق ذات صلة..."</text>
-<line x1="330" y1="237" x2="330" y2="248" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<path d="M 540,280 Q 500.0,200.0 540,120" fill="none" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
-<text x="520.0" y="190.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="7" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">مواصلة الحلقة</text>
-<rect x="610" y="60" width="190" height="190" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="729.794" y="78" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="9.5" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="bold" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">شروط الخروج</text>
-<text x="753.376" y="100" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="7" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">① اكتملت المهمة</text>
-<text x="762.256" y="132" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="7" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">② اتصل بـ Final_answer</text>
-<text x="783.616" y="164" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="7" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">③ لم يتم إرجاع أي استدعاء للأداة</text>
-<text x="793.299" y="196" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="7" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">④ تم الوصول إلى الحد الأقصى للجولات</text>
-<text x="793.408" y="228" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="7" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">⑤ تم تجاوز عدد الأخطاء</text>
-<rect x="80" y="360" width="500" height="70" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="330" y="380" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">مثال عملي للتنفيذ: إصلاح كود SWE-bench</text>
-<text x="330" y="405" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="7" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">رمز البحث ← تحديد موقع الخلل ← تحرير الملف ← تشغيل الاختبارات ← فشل الإصلاح ← التحرير مرة أخرى ← اجتياز الاختبارات ← تم</text>
-<text x="330" y="425" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">(5 جولات من التكرار، 12 استدعاء للأداة)</text>
-<line x1="330" y1="312" x2="330" y2="358" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<text x="330.0" y="325.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" direction="rtl" unicode-bidi="plaintext" style="font-family:'Noto Sans Arabic','Noto Sans',Arial,sans-serif">تم = صحيح</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 470" width="820" height="470" role="img" aria-labelledby="title desc" lang="ar" direction="rtl">
+  <title id="title">حلقة تنفيذ الوكيل المستقل</title>
+  <desc id="desc">يفكر الوكيل ويتصرف ويراقب بالتتابع، ثم يتحقق من شروط الخروج ليعيد النتيجة النهائية أو يبدأ دورة جديدة.</desc>
+  <defs>
+    <marker id="arrow-dark" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#333333"/>
+    </marker>
+    <marker id="arrow-light" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#777777"/>
+    </marker>
+    <style>
+      .sans { font-family: Arial, "Helvetica Neue", Helvetica, "Noto Sans Arabic", "Geeza Pro", sans-serif; }
+      .code { font-family: "Courier New", Courier, monospace; }
+      .heading { fill: #333333; font-size: 16px; font-weight: 700; }
+      .body { fill: #333333; font-size: 15px; }
+      .small { font-size: 14px; }
+      .note { fill: #666666; font-size: 14px; }
+      .box { stroke: #333333; stroke-width: 2; }
+      .flow { fill: none; stroke: #333333; stroke-width: 2; marker-end: url(#arrow-dark); }
+    </style>
+  </defs>
+
+  <rect width="820" height="470" fill="#ffffff"/>
+
+  <rect class="box" x="45" y="70" width="210" height="96" rx="8" fill="#e8e8e8"/>
+  <text class="sans heading" x="150" y="95" text-anchor="middle" dominant-baseline="middle" direction="rtl">١. التفكير</text>
+  <rect x="60" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="sans body" x="150" y="132" text-anchor="middle" dominant-baseline="middle" direction="rtl">&quot;بحاجة إلى معلومات&quot;</text>
+
+  <rect class="box" x="305" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="410" y="95" text-anchor="middle" dominant-baseline="middle" direction="rtl">٢. الفعل</text>
+  <rect x="320" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="410" y="132" text-anchor="middle" dominant-baseline="middle" direction="ltr">web_search(...)</text>
+
+  <rect class="box" x="565" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="670" y="95" text-anchor="middle" dominant-baseline="middle" direction="rtl">٣. الملاحظة</text>
+  <rect x="580" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="670" y="132" text-anchor="middle" dominant-baseline="middle" direction="ltr">tool_result: &quot;...&quot;</text>
+
+  <line class="flow" x1="255" y1="118" x2="302" y2="118"/>
+  <line class="flow" x1="515" y1="118" x2="562" y2="118"/>
+  <line class="flow" x1="670" y1="166" x2="670" y2="207"/>
+
+  <rect x="45" y="220" width="430" height="145" rx="8" fill="#ffffff" stroke="#777777" stroke-width="2" stroke-dasharray="7 4"/>
+  <text class="sans heading" x="260" y="244" text-anchor="middle" dominant-baseline="middle" direction="rtl">شروط الخروج (يكفي أحدها)</text>
+  <line x1="65" y1="258" x2="455" y2="258" stroke="#cccccc"/>
+  <text class="sans body small" x="357" y="282" text-anchor="middle" dominant-baseline="middle" direction="rtl">١. اكتملت المهمة</text>
+  <text class="sans body small" x="157" y="282" text-anchor="middle" dominant-baseline="middle" direction="rtl">٢. استدعاء final_answer</text>
+  <text class="sans body small" x="357" y="314" text-anchor="middle" dominant-baseline="middle" direction="rtl">٣. لا يوجد استدعاء أداة</text>
+  <text class="sans body small" x="157" y="314" text-anchor="middle" dominant-baseline="middle" direction="rtl">٤. تجاوز حد الأخطاء</text>
+  <text class="sans body small" x="357" y="346" text-anchor="middle" dominant-baseline="middle" direction="rtl">٥. بلوغ الحد الأقصى للجولات</text>
+
+  <path d="M 475 260 H 587" fill="none" stroke="#777777" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow-light)"/>
+  <rect x="497" y="238" width="72" height="20" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="533" y="248" text-anchor="middle" dominant-baseline="middle" direction="rtl">أساس القرار</text>
+
+  <polygon class="box" points="670,208 750,260 670,312 590,260" fill="#e2e2e2"/>
+  <text class="sans heading" x="670" y="252" text-anchor="middle" dominant-baseline="middle" direction="rtl">تحقق شرط</text>
+  <text class="sans heading" x="670" y="273" text-anchor="middle" dominant-baseline="middle" direction="rtl">الخروج؟</text>
+
+  <path class="flow" d="M 750 260 H 795 V 35 H 150 V 67"/>
+  <text class="sans note" x="773" y="245" text-anchor="middle" dominant-baseline="middle" direction="rtl">لا</text>
+  <rect x="360" y="43" width="120" height="22" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="420" y="54" text-anchor="middle" dominant-baseline="middle" direction="rtl">متابعة الحلقة</text>
+
+  <line class="flow" x1="670" y1="312" x2="670" y2="379"/>
+  <text class="sans note" x="685" y="346" dominant-baseline="middle" direction="rtl">نعم</text>
+  <rect class="box" x="555" y="382" width="230" height="68" rx="8" fill="#d6d6d6"/>
+  <text class="sans heading" x="670" y="416" text-anchor="middle" dominant-baseline="middle" direction="rtl">إرجاع النتيجة النهائية</text>
 </svg>

--- a/book-ja/images/fig1-5.svg
+++ b/book-ja/images/fig1-5.svg
@@ -1,30 +1,69 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 820 260" width="820" height="260" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="55.0" y="65" width="130" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="120.0" y="92.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">要件定義書</text>
-<rect x="200.0" y="65" width="130" height="55" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="265.0" y="82.1" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">LLM：アウト</text>
-<text x="265.0" y="102.89999999999999" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">ライン生成</text>
-<line x1="187.0" y1="92.5" x2="198.0" y2="92.5" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="345.0" y="65" width="130" height="55" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="410.0" y="82.1" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">LLM：本文執</text>
-<text x="410.0" y="102.89999999999999" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">筆</text>
-<line x1="332.0" y1="92.5" x2="343.0" y2="92.5" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="490.0" y="65" width="130" height="55" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="555.0" y="92.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">LLM：翻訳</text>
-<line x1="477.0" y1="92.5" x2="488.0" y2="92.5" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="635.0" y="65" width="130" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="700.0" y="82.1" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">多言語ドキュ</text>
-<text x="700.0" y="102.89999999999999" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">メント</text>
-<line x1="622.0" y1="92.5" x2="633.0" y2="92.5" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<polygon points="265.0,137.0 295.0,157 265.0,177.0 235.0,157" fill="#ffffff" stroke="#333333" stroke-width="2"/>
-<text x="265.0" y="157" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.0" fill="#333333" text-anchor="middle" dominant-baseline="central">ゲート</text>
-<line x1="265.0" y1="120" x2="265.0" y2="137" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
-<polygon points="410.0,137.0 440.0,157 410.0,177.0 380.0,157" fill="#ffffff" stroke="#333333" stroke-width="2"/>
-<text x="410.0" y="157" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.0" fill="#333333" text-anchor="middle" dominant-baseline="central">ゲート</text>
-<line x1="410.0" y1="120" x2="410.0" y2="137" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="70.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">&quot;製品リリースノート&quot;</text>
-<text x="215.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ 5節のアウトライン</text>
-<text x="360.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ 3000語の文書</text>
-<text x="505.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ EN / JP / KR</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 470" width="820" height="470" role="img" aria-labelledby="title desc" lang="ja">
+  <title id="title">自律 Agent の実行ループ</title>
+  <desc id="desc">Agent は思考、行動、観察を順に行い、終了条件に基づいて最終結果を出力するか次のループを続けるかを判断します。</desc>
+  <defs>
+    <marker id="arrow-dark" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#333333"/>
+    </marker>
+    <marker id="arrow-light" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#777777"/>
+    </marker>
+    <style>
+      .sans { font-family: Arial, "Helvetica Neue", Helvetica, "Noto Sans CJK JP", "Hiragino Sans", sans-serif; }
+      .code { font-family: "Courier New", Courier, monospace; }
+      .heading { fill: #333333; font-size: 16px; font-weight: 700; }
+      .body { fill: #333333; font-size: 15px; }
+      .note { fill: #666666; font-size: 14px; }
+      .box { stroke: #333333; stroke-width: 2; }
+      .flow { fill: none; stroke: #333333; stroke-width: 2; marker-end: url(#arrow-dark); }
+    </style>
+  </defs>
+
+  <rect width="820" height="470" fill="#ffffff"/>
+
+  <rect class="box" x="45" y="70" width="210" height="96" rx="8" fill="#e8e8e8"/>
+  <text class="sans heading" x="60" y="95" dominant-baseline="middle">① 思考（Reasoning）</text>
+  <rect x="60" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="150" y="132" text-anchor="middle" dominant-baseline="middle">&quot;情報が不足&quot;</text>
+
+  <rect class="box" x="305" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="320" y="95" dominant-baseline="middle">② 行動（Acting）</text>
+  <rect x="320" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="410" y="132" text-anchor="middle" dominant-baseline="middle">web_search(...)</text>
+
+  <rect class="box" x="565" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="580" y="95" dominant-baseline="middle">③ 観察（Observing）</text>
+  <rect x="580" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="670" y="132" text-anchor="middle" dominant-baseline="middle">tool_result: &quot;...&quot;</text>
+
+  <line class="flow" x1="255" y1="118" x2="302" y2="118"/>
+  <line class="flow" x1="515" y1="118" x2="562" y2="118"/>
+  <line class="flow" x1="670" y1="166" x2="670" y2="207"/>
+
+  <rect x="45" y="220" width="430" height="145" rx="8" fill="#ffffff" stroke="#777777" stroke-width="2" stroke-dasharray="7 4"/>
+  <text class="sans heading" x="65" y="244" dominant-baseline="middle">終了条件（いずれか）</text>
+  <line x1="65" y1="258" x2="455" y2="258" stroke="#cccccc"/>
+  <text class="sans body" x="65" y="282" dominant-baseline="middle">① タスク完了</text>
+  <text class="sans body" x="250" y="282" dominant-baseline="middle">② final_answer を呼び出す</text>
+  <text class="sans body" x="65" y="314" dominant-baseline="middle">③ ツール呼び出しなし</text>
+  <text class="sans body" x="250" y="314" dominant-baseline="middle">④ エラー回数が上限超過</text>
+  <text class="sans body" x="65" y="346" dominant-baseline="middle">⑤ 最大ラウンド数に到達</text>
+
+  <path d="M 475 260 H 587" fill="none" stroke="#777777" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow-light)"/>
+  <rect x="502" y="238" width="62" height="20" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="533" y="248" text-anchor="middle" dominant-baseline="middle">判断基準</text>
+
+  <polygon class="box" points="670,208 750,260 670,312 590,260" fill="#e2e2e2"/>
+  <text class="sans heading" x="670" y="252" text-anchor="middle" dominant-baseline="middle">終了条件を</text>
+  <text class="sans heading" x="670" y="273" text-anchor="middle" dominant-baseline="middle">満たした？</text>
+
+  <path class="flow" d="M 750 260 H 795 V 35 H 150 V 67"/>
+  <text class="sans note" x="773" y="245" text-anchor="middle" dominant-baseline="middle">いいえ</text>
+  <rect x="360" y="43" width="120" height="22" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="420" y="54" text-anchor="middle" dominant-baseline="middle">次のループへ</text>
+
+  <line class="flow" x1="670" y1="312" x2="670" y2="379"/>
+  <text class="sans note" x="685" y="346" dominant-baseline="middle">はい</text>
+  <rect class="box" x="555" y="382" width="230" height="68" rx="8" fill="#d6d6d6"/>
+  <text class="sans heading" x="670" y="416" text-anchor="middle" dominant-baseline="middle">最終結果を出力</text>
 </svg>

--- a/book-ru/images/fig1-5.svg
+++ b/book-ru/images/fig1-5.svg
@@ -1,34 +1,70 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 820 460" width="820" height="460" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="80" y="60" width="500" height="380" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="330" y="82" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">while not done:</text>
-<rect x="120" y="100" width="420" height="60" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="130" y="115" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">① Размышление (Reasoning)</text>
-<rect x="130" y="125" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="140" font-family="'Courier New', Courier, monospace" font-size="7.5" fill="#333333" text-anchor="start" dominant-baseline="central">"Анализ результатов поиска...недостаточно информации, нужен дополнительный поиск"</text>
-<rect x="120" y="175" width="420" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="130" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">② Действие (Acting)</text>
-<rect x="130" y="200" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="215" font-family="'Courier New', Courier, monospace" font-size="13.5" fill="#333333" text-anchor="start" dominant-baseline="central">web_search(&quot;Agent RL training techniques 2025&quot;)</text>
-<line x1="330" y1="162" x2="330" y2="173" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="120" y="250" width="420" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="130" y="265" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">③ Наблюдение</text>
-<rect x="130" y="275" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="290" font-family="'Courier New', Courier, monospace" font-size="13.5" fill="#333333" text-anchor="start" dominant-baseline="central">tool_result: "Найдено 3 релевантные статьи..."</text>
-<line x1="330" y1="237" x2="330" y2="248" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<path d="M 540,280 Q 500.0,200.0 540,120" fill="none" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
-<text x="520.0" y="190.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="5.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Продолжить цикл</text>
-<rect x="610" y="60" width="190" height="190" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="622" y="78" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="bold">Условия выхода</text>
-<text x="620" y="100" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">① Задача выполнена</text>
-<text x="620" y="132" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">② Вызов final_answer</text>
-<text x="620" y="164" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="9.5" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">③ Вызов инструмента не возвращён</text>
-<text x="620" y="196" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="7.5" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">④ Достигнуто максимальное число раундов</text>
-<text x="620" y="228" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.5" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">⑤ Превышено число ошибок</text>
-<rect x="80" y="360" width="500" height="70" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="330" y="380" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Пример практического выполнения: исправление кода SWE-bench</text>
-<text x="330" y="405" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="7" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Поиск кода → Обнаружение бага → Правка файла → Запуск тестов → Исправление ошибок → Правка снова → Тесты пройдены → Готово</text>
-<text x="330" y="425" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">(5 раундов итераций, 12 вызовов инструментов)</text>
-<line x1="330" y1="312" x2="330" y2="358" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<text x="330.0" y="325.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle">done = True</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 470" width="820" height="470" role="img" aria-labelledby="title desc" lang="ru">
+  <title id="title">Цикл выполнения автономного агента</title>
+  <desc id="desc">Агент последовательно размышляет, действует и наблюдает, затем проверяет условия выхода и либо возвращает итоговый результат, либо начинает новую итерацию.</desc>
+  <defs>
+    <marker id="arrow-dark" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#333333"/>
+    </marker>
+    <marker id="arrow-light" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#777777"/>
+    </marker>
+    <style>
+      .sans { font-family: Arial, "Helvetica Neue", Helvetica, sans-serif; }
+      .code { font-family: "Courier New", Courier, monospace; }
+      .heading { fill: #333333; font-size: 16px; font-weight: 700; }
+      .body { fill: #333333; font-size: 15px; }
+      .small { font-size: 14px; }
+      .note { fill: #666666; font-size: 14px; }
+      .box { stroke: #333333; stroke-width: 2; }
+      .flow { fill: none; stroke: #333333; stroke-width: 2; marker-end: url(#arrow-dark); }
+    </style>
+  </defs>
+
+  <rect width="820" height="470" fill="#ffffff"/>
+
+  <rect class="box" x="45" y="70" width="210" height="96" rx="8" fill="#e8e8e8"/>
+  <text class="sans heading" x="60" y="95" dominant-baseline="middle">① Размышление</text>
+  <rect x="60" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body small" x="150" y="132" text-anchor="middle" dominant-baseline="middle">&quot;Нужно больше данных&quot;</text>
+
+  <rect class="box" x="305" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="320" y="95" dominant-baseline="middle">② Действие</text>
+  <rect x="320" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="410" y="132" text-anchor="middle" dominant-baseline="middle">web_search(...)</text>
+
+  <rect class="box" x="565" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="580" y="95" dominant-baseline="middle">③ Наблюдение</text>
+  <rect x="580" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="670" y="132" text-anchor="middle" dominant-baseline="middle">tool_result: &quot;...&quot;</text>
+
+  <line class="flow" x1="255" y1="118" x2="302" y2="118"/>
+  <line class="flow" x1="515" y1="118" x2="562" y2="118"/>
+  <line class="flow" x1="670" y1="166" x2="670" y2="207"/>
+
+  <rect x="45" y="220" width="430" height="145" rx="8" fill="#ffffff" stroke="#777777" stroke-width="2" stroke-dasharray="7 4"/>
+  <text class="sans heading" x="65" y="244" dominant-baseline="middle">Условия выхода (любое)</text>
+  <line x1="65" y1="258" x2="455" y2="258" stroke="#cccccc"/>
+  <text class="sans body small" x="65" y="282" dominant-baseline="middle">① Задача выполнена</text>
+  <text class="sans body small" x="250" y="282" dominant-baseline="middle">② Вызван final_answer</text>
+  <text class="sans body small" x="65" y="314" dominant-baseline="middle">③ Нет вызова инструмента</text>
+  <text class="sans body small" x="250" y="314" dominant-baseline="middle">④ Превышен лимит ошибок</text>
+  <text class="sans body small" x="65" y="346" dominant-baseline="middle">⑤ Достигнут максимум раундов</text>
+
+  <path d="M 475 260 H 587" fill="none" stroke="#777777" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow-light)"/>
+  <rect x="499" y="238" width="68" height="20" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="533" y="248" text-anchor="middle" dominant-baseline="middle">Критерии</text>
+
+  <polygon class="box" points="670,208 750,260 670,312 590,260" fill="#e2e2e2"/>
+  <text class="sans heading small" x="670" y="252" text-anchor="middle" dominant-baseline="middle">Условие выхода</text>
+  <text class="sans heading" x="670" y="273" text-anchor="middle" dominant-baseline="middle">выполнено?</text>
+
+  <path class="flow" d="M 750 260 H 795 V 35 H 150 V 67"/>
+  <text class="sans note" x="773" y="245" text-anchor="middle" dominant-baseline="middle">Нет</text>
+  <rect x="352" y="43" width="136" height="22" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="420" y="54" text-anchor="middle" dominant-baseline="middle">Продолжить цикл</text>
+
+  <line class="flow" x1="670" y1="312" x2="670" y2="379"/>
+  <text class="sans note" x="685" y="346" dominant-baseline="middle">Да</text>
+  <rect class="box" x="555" y="382" width="230" height="68" rx="8" fill="#d6d6d6"/>
+  <text class="sans heading" x="670" y="416" text-anchor="middle" dominant-baseline="middle">Вернуть результат</text>
 </svg>

--- a/book-ta/images/fig1-5.svg
+++ b/book-ta/images/fig1-5.svg
@@ -1,34 +1,69 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 820 460" width="820" height="460" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="80" y="60" width="500" height="380" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="330" y="82" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">while not done:</text>
-<rect x="120" y="100" width="420" height="60" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="130" y="115" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">① Think (Reasoning)</text>
-<rect x="130" y="125" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="140" font-family="'Courier New', Courier, monospace" font-size="8.5" fill="#333333" text-anchor="start" dominant-baseline="central">&quot;Analyzing search results...insufficient information, need further search&quot;</text>
-<rect x="120" y="175" width="420" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="130" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">② Acting</text>
-<rect x="130" y="200" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="215" font-family="'Courier New', Courier, monospace" font-size="13.5" fill="#333333" text-anchor="start" dominant-baseline="central">web_search(&quot;Agent RL training techniques 2025&quot;)</text>
-<line x1="330" y1="162" x2="330" y2="173" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="120" y="250" width="420" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="130" y="265" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">③ Observing</text>
-<rect x="130" y="275" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="290" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">tool_result: &quot;Found 3 relevant papers...&quot;</text>
-<line x1="330" y1="237" x2="330" y2="248" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<path d="M 540,280 Q 500.0,200.0 540,120" fill="none" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
-<text x="520.0" y="190.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="7" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Continue loop</text>
-<rect x="610" y="60" width="190" height="190" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="622" y="78" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="bold">Exit conditions</text>
-<text x="620" y="100" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">① Task completed</text>
-<text x="620" y="132" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">② Call final_answer</text>
-<text x="620" y="164" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">③ No tool call returned</text>
-<text x="620" y="196" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">④ Maximum rounds reached</text>
-<text x="620" y="228" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">⑤ Error count exceeded</text>
-<rect x="80" y="360" width="500" height="70" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="330" y="380" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Practical execution example: SWE-bench code fix</text>
-<text x="330" y="405" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Search code → Locate bug → Edit file → Run tests → Fix fails → Edit again → Tests pass → Done</text>
-<text x="330" y="425" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">(5 rounds of iteration, 12 tool calls)</text>
-<line x1="330" y1="312" x2="330" y2="358" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<text x="330.0" y="325.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle">done = True</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 470" width="820" height="470" role="img" aria-labelledby="title desc" lang="ta">
+  <title id="title">தன்னாட்சி ஏஜெண்டின் செயல்படுத்தும் சுழற்சி</title>
+  <desc id="desc">ஏஜெண்ட் சிந்தித்து, செயல்பட்டு, கவனித்த பிறகு வெளியேறும் நிபந்தனைகளைச் சரிபார்த்து, இறுதி முடிவை வழங்குகிறது அல்லது அடுத்த சுழற்சியைத் தொடங்குகிறது.</desc>
+  <defs>
+    <marker id="arrow-dark" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#333333"/>
+    </marker>
+    <marker id="arrow-light" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#777777"/>
+    </marker>
+    <style>
+      .sans { font-family: "Noto Sans Tamil", "Tamil Sangam MN", Arial, sans-serif; }
+      .code { font-family: "Courier New", Courier, monospace; }
+      .heading { fill: #333333; font-size: 16px; font-weight: 700; }
+      .body { fill: #333333; font-size: 15px; }
+      .small { font-size: 14px; }
+      .note { fill: #666666; font-size: 14px; }
+      .box { stroke: #333333; stroke-width: 2; }
+      .flow { fill: none; stroke: #333333; stroke-width: 2; marker-end: url(#arrow-dark); }
+    </style>
+  </defs>
+
+  <rect width="820" height="470" fill="#ffffff"/>
+
+  <rect class="box" x="45" y="70" width="210" height="96" rx="8" fill="#e8e8e8"/>
+  <text class="sans heading" x="60" y="95" dominant-baseline="middle">① சிந்தனை</text>
+  <rect x="60" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="sans body small" x="150" y="132" text-anchor="middle" dominant-baseline="middle">&quot;மேலும் தகவல் தேவை&quot;</text>
+
+  <rect class="box" x="305" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="320" y="95" dominant-baseline="middle">② செயல்</text>
+  <rect x="320" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="410" y="132" text-anchor="middle" dominant-baseline="middle">web_search(...)</text>
+
+  <rect class="box" x="565" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="580" y="95" dominant-baseline="middle">③ கவனிப்பு</text>
+  <rect x="580" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="670" y="132" text-anchor="middle" dominant-baseline="middle">tool_result: &quot;...&quot;</text>
+
+  <line class="flow" x1="255" y1="118" x2="302" y2="118"/>
+  <line class="flow" x1="515" y1="118" x2="562" y2="118"/>
+  <line class="flow" x1="670" y1="166" x2="670" y2="207"/>
+
+  <rect x="45" y="220" width="430" height="145" rx="8" fill="#ffffff" stroke="#777777" stroke-width="2" stroke-dasharray="7 4"/>
+  <text class="sans heading small" x="65" y="244" dominant-baseline="middle">வெளியேறும் நிபந்தனைகள் (ஏதேனும் ஒன்று)</text>
+  <line x1="65" y1="258" x2="455" y2="258" stroke="#cccccc"/>
+  <text class="sans body small" x="65" y="282" dominant-baseline="middle">① பணி முடிந்தது</text>
+  <text class="sans body small" x="250" y="282" dominant-baseline="middle">② final_answer அழைப்பு</text>
+  <text class="sans body small" x="65" y="314" dominant-baseline="middle">③ கருவி அழைப்பு இல்லை</text>
+  <text class="sans body small" x="250" y="314" dominant-baseline="middle">④ பிழை வரம்பு மீறியது</text>
+  <text class="sans body small" x="65" y="346" dominant-baseline="middle">⑤ அதிகபட்ச சுற்றுகள்</text>
+
+  <path d="M 475 260 H 587" fill="none" stroke="#777777" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow-light)"/>
+  <rect x="493" y="238" width="80" height="20" rx="3" fill="#ffffff"/>
+  <text class="sans note small" x="533" y="248" text-anchor="middle" dominant-baseline="middle">நிபந்தனைகள்</text>
+
+  <polygon class="box" points="670,208 750,260 670,312 590,260" fill="#e2e2e2"/>
+  <text class="sans heading small" x="670" y="260" text-anchor="middle" dominant-baseline="middle">வெளியேறலாமா?</text>
+
+  <path class="flow" d="M 750 260 H 795 V 35 H 150 V 67"/>
+  <text class="sans note" x="773" y="245" text-anchor="middle" dominant-baseline="middle">இல்லை</text>
+  <rect x="345" y="43" width="150" height="22" rx="3" fill="#ffffff"/>
+  <text class="sans note small" x="420" y="54" text-anchor="middle" dominant-baseline="middle">சுழற்சியைத் தொடரவும்</text>
+
+  <line class="flow" x1="670" y1="312" x2="670" y2="379"/>
+  <text class="sans note" x="685" y="346" dominant-baseline="middle">ஆம்</text>
+  <rect class="box" x="555" y="382" width="230" height="68" rx="8" fill="#d6d6d6"/>
+  <text class="sans heading" x="670" y="416" text-anchor="middle" dominant-baseline="middle">இறுதி முடிவை வெளியிடு</text>
 </svg>

--- a/book-tr/images/fig1-5.svg
+++ b/book-tr/images/fig1-5.svg
@@ -1,30 +1,70 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 820 260" width="820" height="260" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="55.0" y="65" width="130" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="120.0" y="82.1" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Gereksinim</text>
-<text x="120.0" y="102.89999999999999" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">belgesi</text>
-<rect x="200.0" y="65" width="130" height="55" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="265.0" y="82.1" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">LLM: Taslak</text>
-<text x="265.0" y="102.89999999999999" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">oluştur</text>
-<line x1="187.0" y1="92.5" x2="198.0" y2="92.5" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="345.0" y="65" width="130" height="55" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="410.0" y="92.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">LLM: Metni yaz</text>
-<line x1="332.0" y1="92.5" x2="343.0" y2="92.5" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="490.0" y="65" width="130" height="55" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="555.0" y="92.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">LLM: Çeviri</text>
-<line x1="477.0" y1="92.5" x2="488.0" y2="92.5" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="635.0" y="65" width="130" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="700.0" y="82.75" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Çok Dilli</text>
-<text x="700.0" y="102.25" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Dokümantasyon</text>
-<line x1="622.0" y1="92.5" x2="633.0" y2="92.5" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<polygon points="265.0,137.0 295.0,157 265.0,177.0 235.0,157" fill="#ffffff" stroke="#333333" stroke-width="2"/>
-<text x="265.0" y="157" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11.0" fill="#333333" text-anchor="middle" dominant-baseline="central">Kontrol</text>
-<line x1="265.0" y1="120" x2="265.0" y2="137" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
-<polygon points="410.0,137.0 440.0,157 410.0,177.0 380.0,157" fill="#ffffff" stroke="#333333" stroke-width="2"/>
-<text x="410.0" y="157" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11.0" fill="#333333" text-anchor="middle" dominant-baseline="central">Kontrol</text>
-<line x1="410.0" y1="120" x2="410.0" y2="137" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="70.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">&quot;Ürün Sürüm Notları&quot;</text>
-<text x="215.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ 5 Bölümlük Taslak</text>
-<text x="360.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ 3000 Kelimelik Belge</text>
-<text x="505.0" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">→ EN / JP / KR</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 470" width="820" height="470" role="img" aria-labelledby="title desc" lang="tr">
+  <title id="title">Otonom Agent yürütme döngüsü</title>
+  <desc id="desc">Agent sırayla düşünür, eyleme geçer ve gözlem yapar; ardından çıkış koşullarını denetleyerek nihai sonucu döndürür veya sonraki döngüye başlar.</desc>
+  <defs>
+    <marker id="arrow-dark" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#333333"/>
+    </marker>
+    <marker id="arrow-light" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#777777"/>
+    </marker>
+    <style>
+      .sans { font-family: Arial, "Helvetica Neue", Helvetica, sans-serif; }
+      .code { font-family: "Courier New", Courier, monospace; }
+      .heading { fill: #333333; font-size: 16px; font-weight: 700; }
+      .body { fill: #333333; font-size: 15px; }
+      .small { font-size: 14px; }
+      .note { fill: #666666; font-size: 14px; }
+      .box { stroke: #333333; stroke-width: 2; }
+      .flow { fill: none; stroke: #333333; stroke-width: 2; marker-end: url(#arrow-dark); }
+    </style>
+  </defs>
+
+  <rect width="820" height="470" fill="#ffffff"/>
+
+  <rect class="box" x="45" y="70" width="210" height="96" rx="8" fill="#e8e8e8"/>
+  <text class="sans heading" x="60" y="95" dominant-baseline="middle">① Düşünme (Reasoning)</text>
+  <rect x="60" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="sans body small" x="150" y="132" text-anchor="middle" dominant-baseline="middle">&quot;Daha fazla bilgi gerek&quot;</text>
+
+  <rect class="box" x="305" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="320" y="95" dominant-baseline="middle">② Eylem (Acting)</text>
+  <rect x="320" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="410" y="132" text-anchor="middle" dominant-baseline="middle">web_search(...)</text>
+
+  <rect class="box" x="565" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="580" y="95" dominant-baseline="middle">③ Gözlem (Observing)</text>
+  <rect x="580" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="670" y="132" text-anchor="middle" dominant-baseline="middle">tool_result: &quot;...&quot;</text>
+
+  <line class="flow" x1="255" y1="118" x2="302" y2="118"/>
+  <line class="flow" x1="515" y1="118" x2="562" y2="118"/>
+  <line class="flow" x1="670" y1="166" x2="670" y2="207"/>
+
+  <rect x="45" y="220" width="430" height="145" rx="8" fill="#ffffff" stroke="#777777" stroke-width="2" stroke-dasharray="7 4"/>
+  <text class="sans heading" x="65" y="244" dominant-baseline="middle">Çıkış koşulları (herhangi biri)</text>
+  <line x1="65" y1="258" x2="455" y2="258" stroke="#cccccc"/>
+  <text class="sans body small" x="65" y="282" dominant-baseline="middle">① Görev tamamlandı</text>
+  <text class="sans body small" x="250" y="282" dominant-baseline="middle">② final_answer çağrıldı</text>
+  <text class="sans body small" x="65" y="314" dominant-baseline="middle">③ Araç çağrısı yok</text>
+  <text class="sans body small" x="250" y="314" dominant-baseline="middle">④ Hata sınırı aşıldı</text>
+  <text class="sans body small" x="65" y="346" dominant-baseline="middle">⑤ Maksimum tura ulaşıldı</text>
+
+  <path d="M 475 260 H 587" fill="none" stroke="#777777" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow-light)"/>
+  <rect x="493" y="238" width="80" height="20" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="533" y="248" text-anchor="middle" dominant-baseline="middle">Karar ölçütü</text>
+
+  <polygon class="box" points="670,208 750,260 670,312 590,260" fill="#e2e2e2"/>
+  <text class="sans heading" x="670" y="252" text-anchor="middle" dominant-baseline="middle">Çıkış koşulu</text>
+  <text class="sans heading" x="670" y="273" text-anchor="middle" dominant-baseline="middle">sağlandı mı?</text>
+
+  <path class="flow" d="M 750 260 H 795 V 35 H 150 V 67"/>
+  <text class="sans note" x="773" y="245" text-anchor="middle" dominant-baseline="middle">Hayır</text>
+  <rect x="340" y="43" width="160" height="22" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="420" y="54" text-anchor="middle" dominant-baseline="middle">Sonraki döngüye geç</text>
+
+  <line class="flow" x1="670" y1="312" x2="670" y2="379"/>
+  <text class="sans note" x="685" y="346" dominant-baseline="middle">Evet</text>
+  <rect class="box" x="555" y="382" width="230" height="68" rx="8" fill="#d6d6d6"/>
+  <text class="sans heading" x="670" y="416" text-anchor="middle" dominant-baseline="middle">Nihai sonucu döndür</text>
 </svg>

--- a/book-vi/images/fig1-5.svg
+++ b/book-vi/images/fig1-5.svg
@@ -1,34 +1,70 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 820 460" width="820" height="460" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333" /></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999" /></marker></defs>
-<rect x="80" y="60" width="500" height="380" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4" />
-<text x="330" y="82" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">while not done:</text>
-<rect x="120" y="100" width="420" height="60" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2" />
-<text x="130" y="115" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">① Suy nghĩ (Reasoning)</text>
-<rect x="130" y="125" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2" />
-<text x="140" y="0" font-family="'Courier New', Courier, monospace" font-size="10" fill="#333333" text-anchor="start" dominant-baseline="central"><tspan x="140" dy="133.6">"Đang phân tích kết quả tìm kiếm... Thông tin chưa</tspan><tspan x="140" dy="10.8">đầy đủ, cần tìm kiếm thêm"</tspan></text>
-<rect x="120" y="175" width="420" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2" />
-<text x="130" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">② Hành động (Acting)</text>
-<rect x="130" y="200" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2" />
-<text x="140" y="215" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">web_search("Agent RL training techniques 2025")</text>
-<line x1="330" y1="162" x2="330" y2="173" stroke="#333333" stroke-width="2" marker-end="url(#ah)" />
-<rect x="120" y="250" width="420" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2" />
-<text x="130" y="265" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">③ Quan sát (Observing)</text>
-<rect x="130" y="275" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2" />
-<text x="140" y="290" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">tool_result: "Found 3 relevant papers..."</text>
-<line x1="330" y1="237" x2="330" y2="248" stroke="#333333" stroke-width="2" marker-end="url(#ah)" />
-<path d="M 540,280 Q 500.0,200.0 540,120" fill="none" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)" />
-<text x="520.0" y="190.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Tiếp tục chu kỳ</text>
-<rect x="610" y="60" width="190" height="190" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4" />
-<text x="622" y="85.88" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="bold">Điều kiện thoát</text>
-<text x="620" y="0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal"><tspan x="620" dy="103.16">① Nhiệm vụ đã hoàn</tspan><tspan x="620" dy="17.28">thành</tspan></text>
-<text x="620" y="137.72" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">② Gọi final_answer</text>
-<text x="620" y="0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal"><tspan x="620" dy="155">③ Trở về mà không</tspan><tspan x="620" dy="17.28">gọi công cụ</tspan></text>
-<text x="620" y="189.56" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">④ Đạt số vòng tối đa</text>
-<text x="620" y="0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal"><tspan x="620" dy="206.84">⑤ Số lỗi vượt quá</tspan><tspan x="620" dy="17.28">giới hạn</tspan></text>
-<rect x="80" y="360" width="500" height="70" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2" />
-<text x="330" y="373.28" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.33" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Ví dụ thực thi thực tế: Sửa mã SWE-bench</text>
-<text x="330" y="0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.41" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal"><tspan x="330" dy="388.8">Tìm kiếm mã → Xác định vị trí bug → Chỉnh sửa tệp → Chạy kiểm tra →</tspan><tspan x="330" dy="14.48">Sửa lỗi → Chỉnh sửa lại → Kiểm tra đạt → Hoàn thành</tspan></text>
-<text x="330" y="417.76" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.41" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">(Lặp lại 5 lần, gọi công cụ 12 lần)</text>
-<line x1="330" y1="312" x2="330" y2="358" stroke="#333333" stroke-width="2" marker-end="url(#ah)" />
-<text x="330.0" y="325.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle">done = True</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 470" width="820" height="470" role="img" aria-labelledby="title desc" lang="vi">
+  <title id="title">Vòng lặp thực thi của Agent tự trị</title>
+  <desc id="desc">Agent lần lượt suy nghĩ, hành động và quan sát, sau đó kiểm tra điều kiện thoát để trả về kết quả cuối cùng hoặc bắt đầu vòng lặp tiếp theo.</desc>
+  <defs>
+    <marker id="arrow-dark" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#333333"/>
+    </marker>
+    <marker id="arrow-light" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#777777"/>
+    </marker>
+    <style>
+      .sans { font-family: Arial, "Helvetica Neue", Helvetica, sans-serif; }
+      .code { font-family: "Courier New", Courier, monospace; }
+      .heading { fill: #333333; font-size: 16px; font-weight: 700; }
+      .body { fill: #333333; font-size: 15px; }
+      .small { font-size: 14px; }
+      .note { fill: #666666; font-size: 14px; }
+      .box { stroke: #333333; stroke-width: 2; }
+      .flow { fill: none; stroke: #333333; stroke-width: 2; marker-end: url(#arrow-dark); }
+    </style>
+  </defs>
+
+  <rect width="820" height="470" fill="#ffffff"/>
+
+  <rect class="box" x="45" y="70" width="210" height="96" rx="8" fill="#e8e8e8"/>
+  <text class="sans heading" x="60" y="95" font-size="16" dominant-baseline="middle">① Suy nghĩ (Reasoning)</text>
+  <rect x="60" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="sans body small" x="150" y="132" font-size="14" text-anchor="middle" dominant-baseline="middle">&quot;Cần thêm thông tin&quot;</text>
+
+  <rect class="box" x="305" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="320" y="95" font-size="16" dominant-baseline="middle">② Hành động (Acting)</text>
+  <rect x="320" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="410" y="132" font-size="15" text-anchor="middle" dominant-baseline="middle">web_search(...)</text>
+
+  <rect class="box" x="565" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="580" y="95" font-size="16" dominant-baseline="middle">③ Quan sát (Observing)</text>
+  <rect x="580" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="670" y="132" font-size="15" text-anchor="middle" dominant-baseline="middle">tool_result: &quot;...&quot;</text>
+
+  <line class="flow" x1="255" y1="118" x2="302" y2="118"/>
+  <line class="flow" x1="515" y1="118" x2="562" y2="118"/>
+  <line class="flow" x1="670" y1="166" x2="670" y2="207"/>
+
+  <rect x="45" y="220" width="430" height="145" rx="8" fill="#ffffff" stroke="#777777" stroke-width="2" stroke-dasharray="7 4"/>
+  <text class="sans heading" x="65" y="244" font-size="16" dominant-baseline="middle">Điều kiện thoát (một điều kiện bất kỳ)</text>
+  <line x1="65" y1="258" x2="455" y2="258" stroke="#cccccc"/>
+  <text class="sans body small" x="65" y="282" font-size="14" dominant-baseline="middle">① Nhiệm vụ hoàn tất</text>
+  <text class="sans body small" x="250" y="282" font-size="14" dominant-baseline="middle">② Đã gọi final_answer</text>
+  <text class="sans body small" x="65" y="314" font-size="14" dominant-baseline="middle">③ Không gọi công cụ</text>
+  <text class="sans body small" x="250" y="314" font-size="14" dominant-baseline="middle">④ Vượt giới hạn lỗi</text>
+  <text class="sans body small" x="65" y="346" font-size="14" dominant-baseline="middle">⑤ Đạt số vòng tối đa</text>
+
+  <path d="M 475 260 H 587" fill="none" stroke="#777777" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow-light)"/>
+  <rect x="499" y="238" width="68" height="20" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="533" y="248" font-size="14" text-anchor="middle" dominant-baseline="middle">Tiêu chí</text>
+
+  <polygon class="box" points="670,208 750,260 670,312 590,260" fill="#e2e2e2"/>
+  <text class="sans heading" x="670" y="252" font-size="16" text-anchor="middle" dominant-baseline="middle">Thỏa điều kiện</text>
+  <text class="sans heading" x="670" y="273" font-size="16" text-anchor="middle" dominant-baseline="middle">thoát?</text>
+
+  <path class="flow" d="M 750 260 H 795 V 35 H 150 V 67"/>
+  <text class="sans note" x="773" y="245" font-size="14" text-anchor="middle" dominant-baseline="middle">Không</text>
+  <rect x="350" y="43" width="140" height="22" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="420" y="54" font-size="14" text-anchor="middle" dominant-baseline="middle">Tiếp tục vòng lặp</text>
+
+  <line class="flow" x1="670" y1="312" x2="670" y2="379"/>
+  <text class="sans note" x="685" y="346" font-size="14" dominant-baseline="middle">Có</text>
+  <rect class="box" x="555" y="382" width="230" height="68" rx="8" fill="#d6d6d6"/>
+  <text class="sans heading" x="670" y="416" font-size="16" text-anchor="middle" dominant-baseline="middle">Trả về kết quả cuối</text>
 </svg>

--- a/book-zhtw/images/fig1-5.svg
+++ b/book-zhtw/images/fig1-5.svg
@@ -1,34 +1,69 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 820 460" width="820" height="460" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="80" y="60" width="500" height="380" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="330" y="82" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">while not done:</text>
-<rect x="120" y="100" width="420" height="60" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="130" y="115" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">① 思考（Reasoning）</text>
-<rect x="130" y="125" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="140" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">&quot;分析搜尋結果...資訊不足,需要進一步搜尋&quot;</text>
-<rect x="120" y="175" width="420" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="130" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">② 行動（Acting）</text>
-<rect x="130" y="200" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="215" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">web_search(&quot;Agent RL training techniques 2025&quot;)</text>
-<line x1="330" y1="162" x2="330" y2="173" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="120" y="250" width="420" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="130" y="265" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">③ 觀察（Observing）</text>
-<rect x="130" y="275" width="400" height="28" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="140" y="290" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">tool_result: &quot;Found 3 relevant papers...&quot;</text>
-<line x1="330" y1="237" x2="330" y2="248" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<path d="M 540,280 Q 500.0,200.0 540,120" fill="none" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
-<text x="520.0" y="190.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">繼續迴圈</text>
-<rect x="610" y="60" width="190" height="190" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="622" y="78" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="bold">退出條件</text>
-<text x="620" y="100" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">① 任務完成</text>
-<text x="620" y="132" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">② 呼叫 final_answer</text>
-<text x="620" y="164" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">③ 無工具呼叫返回</text>
-<text x="620" y="196" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">④ 達到最大輪次</text>
-<text x="620" y="228" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">⑤ 錯誤次數超限</text>
-<rect x="80" y="360" width="500" height="70" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="330" y="380" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">實際執行示例：SWE-bench 程式碼修復</text>
-<text x="330" y="405" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">搜尋程式碼 → 定位 Bug → 編輯檔案 → 執行測試 → 修復失敗 → 再次編輯 → 測試透過 → 完成</text>
-<text x="330" y="425" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">（5 輪迭代，12 次工具呼叫）</text>
-<line x1="330" y1="312" x2="330" y2="358" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<text x="330.0" y="325.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle">done = True</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 470" width="820" height="470" role="img" aria-labelledby="title desc" lang="zh-Hant">
+  <title id="title">自主 Agent 的執行迴圈</title>
+  <desc id="desc">Agent 依次思考、行動和觀察，再根據退出條件決定輸出最終結果或繼續下一輪迴圈。</desc>
+  <defs>
+    <marker id="arrow-dark" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#333333"/>
+    </marker>
+    <marker id="arrow-light" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#777777"/>
+    </marker>
+    <style>
+      .sans { font-family: Arial, "Helvetica Neue", Helvetica, "PingFang TC", "Microsoft JhengHei", sans-serif; }
+      .code { font-family: "Courier New", Courier, monospace; }
+      .heading { fill: #333333; font-size: 16px; font-weight: 700; }
+      .body { fill: #333333; font-size: 15px; }
+      .note { fill: #666666; font-size: 14px; }
+      .box { stroke: #333333; stroke-width: 2; }
+      .flow { fill: none; stroke: #333333; stroke-width: 2; marker-end: url(#arrow-dark); }
+    </style>
+  </defs>
+
+  <rect width="820" height="470" fill="#ffffff"/>
+
+  <rect class="box" x="45" y="70" width="210" height="96" rx="8" fill="#e8e8e8"/>
+  <text class="sans heading" x="60" y="95" dominant-baseline="middle">① 思考（Reasoning）</text>
+  <rect x="60" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="150" y="132" text-anchor="middle" dominant-baseline="middle">&quot;還需更多資訊&quot;</text>
+
+  <rect class="box" x="305" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="320" y="95" dominant-baseline="middle">② 行動（Acting）</text>
+  <rect x="320" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="410" y="132" text-anchor="middle" dominant-baseline="middle">web_search(...)</text>
+
+  <rect class="box" x="565" y="70" width="210" height="96" rx="8" fill="#f0f0f0"/>
+  <text class="sans heading" x="580" y="95" dominant-baseline="middle">③ 觀察（Observing）</text>
+  <rect x="580" y="112" width="180" height="38" rx="5" fill="#ffffff" stroke="#777777"/>
+  <text class="code body" x="670" y="132" text-anchor="middle" dominant-baseline="middle">tool_result: &quot;...&quot;</text>
+
+  <line class="flow" x1="255" y1="118" x2="302" y2="118"/>
+  <line class="flow" x1="515" y1="118" x2="562" y2="118"/>
+  <line class="flow" x1="670" y1="166" x2="670" y2="207"/>
+
+  <rect x="45" y="220" width="430" height="145" rx="8" fill="#ffffff" stroke="#777777" stroke-width="2" stroke-dasharray="7 4"/>
+  <text class="sans heading" x="65" y="244" dominant-baseline="middle">退出條件（任一滿足）</text>
+  <line x1="65" y1="258" x2="455" y2="258" stroke="#cccccc"/>
+  <text class="sans body" x="65" y="282" dominant-baseline="middle">① 任務完成</text>
+  <text class="sans body" x="250" y="282" dominant-baseline="middle">② 呼叫 final_answer</text>
+  <text class="sans body" x="65" y="314" dominant-baseline="middle">③ 無工具呼叫返回</text>
+  <text class="sans body" x="250" y="314" dominant-baseline="middle">④ 錯誤次數超限</text>
+  <text class="sans body" x="65" y="346" dominant-baseline="middle">⑤ 達到最大輪次</text>
+
+  <path d="M 475 260 H 587" fill="none" stroke="#777777" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow-light)"/>
+  <rect x="502" y="238" width="62" height="20" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="533" y="248" text-anchor="middle" dominant-baseline="middle">判斷依據</text>
+
+  <polygon class="box" points="670,208 750,260 670,312 590,260" fill="#e2e2e2"/>
+  <text class="sans heading" x="670" y="252" text-anchor="middle" dominant-baseline="middle">滿足退出</text>
+  <text class="sans heading" x="670" y="273" text-anchor="middle" dominant-baseline="middle">條件？</text>
+
+  <path class="flow" d="M 750 260 H 795 V 35 H 150 V 67"/>
+  <text class="sans note" x="773" y="245" text-anchor="middle" dominant-baseline="middle">否</text>
+  <rect x="360" y="43" width="120" height="22" rx="3" fill="#ffffff"/>
+  <text class="sans note" x="420" y="54" text-anchor="middle" dominant-baseline="middle">繼續下一輪迴圈</text>
+
+  <line class="flow" x1="670" y1="312" x2="670" y2="379"/>
+  <text class="sans note" x="685" y="346" dominant-baseline="middle">是</text>
+  <rect class="box" x="555" y="382" width="230" height="68" rx="8" fill="#d6d6d6"/>
+  <text class="sans heading" x="670" y="416" text-anchor="middle" dominant-baseline="middle">輸出最終結果</text>
 </svg>


### PR DESCRIPTION
## Summary

- synchronize the Figure 1-5 redesign from #476 across Arabic, Japanese, Russian, Tamil, Turkish, Vietnamese, and Traditional Chinese (Taiwan)
- preserve the explicit Reasoning → Acting → Observing → exit decision flow, including the continue-loop and final-result branches
- localize the shorter labels and SVG accessibility metadata for every edition
- replace unrelated Figure 1-5 content in Japanese and Turkish, translate the previously English-only Tamil figure, and restore missing Vietnamese labels

## Verification

- parsed all seven SVGs with `xmllint`
- rendered every SVG at 2× resolution with `rsvg-convert` and visually checked text and connector bounds
- `python3 book-vi/fix_svg_text_layout.py --check` (from `book-vi`) — all 118 Vietnamese SVGs passed
- full PDF builds passed for all seven editions: `book-ar`, `book-ja`, `book-ru`, `book-ta`, `book-tr`, `book-vi`, and `book-zhtw`

Follow-up to #476. Related to the original issue #472.