### PR TITLE
fix(dense-embedding): avoid ZeroDivisionError when encode_batch receives empty texts list

### DIFF
--- a/chapter3/dense-embedding/embedding_service.py
+++ b/chapter3/dense-embedding/embedding_service.py
@@ -143,7 +143,8 @@ class EmbeddingService:
             self.logger.logger.info(f"📚 Batch encoding {len(texts)} texts")
             total_chars = sum(len(t) for t in texts)
             self.logger.logger.debug(f"  Total characters: {total_chars}")
-            self.logger.logger.debug(f"  Average text length: {total_chars/len(texts):.1f} chars")
+            avg_len = total_chars / len(texts) if texts else 0.0
+            self.logger.logger.debug(f"  Average text length: {avg_len:.1f} chars")
         
         # Encode all texts
         embeddings = self.model.encode(
@@ -171,7 +172,8 @@ class EmbeddingService:
         
         if self.logger:
             self.logger.logger.info(f"✅ Batch encoding completed in {encoding_time:.4f} seconds")
-            self.logger.logger.debug(f"  Average time per text: {encoding_time/len(texts):.4f} seconds")
+            avg_time = encoding_time / len(texts) if texts else 0.0
+            self.logger.logger.debug(f"  Average time per text: {avg_time:.4f} seconds")
         
         return result
     

--- a/chapter3/dense-embedding/test_empty_batch_encode.py
+++ b/chapter3/dense-embedding/test_empty_batch_encode.py
@@ -1,0 +1,34 @@
+"""
+Test suite locking out ZeroDivisionError in EmbeddingService.encode_batch
+when an empty texts list is provided.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+# Mock third-party dependencies before importing embedding_service
+sys.modules['FlagEmbedding'] = MagicMock()
+sys.modules['colorlog'] = MagicMock()
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+from embedding_service import EmbeddingService
+
+
+def test_encode_batch_empty_texts_logger_zero_division():
+    """
+    Ensure encode_batch with an empty list of texts does not raise ZeroDivisionError
+    during logging.
+    """
+    service = EmbeddingService.__new__(EmbeddingService)
+    mock_logger = MagicMock()
+    service.logger = mock_logger
+    service.model = MagicMock()
+    service.model.encode.return_value = {
+        'dense_vecs': MagicMock(shape=(0, 768))
+    }
+
+    result = service.encode_batch([])
+    assert result['num_texts'] == 0
+    assert result['dimension'] == 768


### PR DESCRIPTION
In `chapter3/dense-embedding/embedding_service.py`, calling `encode_batch` with an empty `texts` list raised a `ZeroDivisionError` during debug logging when computing `total_chars / len(texts)` and `encoding_time / len(texts)`.

This fix guards both average text length and average encoding time calculations with `if texts else 0.0`. Includes regression tests in `chapter3/dense-embedding/test_empty_batch_encode.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复批量编码空文本列表时可能发生的除零错误。
  - 空输入现在可正常返回，并正确报告文本数量为 0 及向量维度。

- **Tests**
  - 新增空批次编码场景的测试，确保相关处理稳定可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->