### PR TITLE
fix(agentic-rag): avoid ZeroDivisionError when expected_keywords or expected_analysis is empty

### DIFF
--- a/chapter3/agentic-rag/evaluation/evaluate.py
+++ b/chapter3/agentic-rag/evaluation/evaluate.py
@@ -55,7 +55,7 @@ class RAGEvaluator:
                 else:
                     keywords_missing.append(keyword)
             
-            evaluation["metrics"]["keyword_recall"] = len(keywords_found) / len(test_case["expected_keywords"])
+            evaluation["metrics"]["keyword_recall"] = len(keywords_found) / len(test_case["expected_keywords"]) if test_case["expected_keywords"] else 1.0
             evaluation["metrics"]["keywords_found"] = keywords_found
             evaluation["metrics"]["keywords_missing"] = keywords_missing
         
@@ -70,7 +70,7 @@ class RAGEvaluator:
                 else:
                     analysis_missing.append(point)
             
-            evaluation["metrics"]["analysis_recall"] = len(analysis_found) / len(test_case["expected_analysis"])
+            evaluation["metrics"]["analysis_recall"] = len(analysis_found) / len(test_case["expected_analysis"]) if test_case["expected_analysis"] else 1.0
             evaluation["metrics"]["analysis_found"] = analysis_found
             evaluation["metrics"]["analysis_missing"] = analysis_missing
         

--- a/chapter3/agentic-rag/evaluation/test_evaluate_empty_expected.py
+++ b/chapter3/agentic-rag/evaluation/test_evaluate_empty_expected.py
@@ -1,0 +1,39 @@
+"""
+Test suite locking out ZeroDivisionError in RAGEvaluator.evaluate_response
+when test_case contains empty expected_keywords or expected_analysis lists.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+from evaluate import RAGEvaluator
+
+
+def test_evaluate_response_empty_expected_keywords():
+    """
+    Ensure evaluate_response gracefully handles empty expected_keywords without raising ZeroDivisionError.
+    """
+    evaluator = RAGEvaluator.__new__(RAGEvaluator)
+    test_case = {
+        "id": "tc1",
+        "question": "Sample query?",
+        "expected_keywords": []
+    }
+    result = evaluator.evaluate_response("Sample answer", test_case)
+    assert result["metrics"]["keyword_recall"] == 1.0
+
+
+def test_evaluate_response_empty_expected_analysis():
+    """
+    Ensure evaluate_response gracefully handles empty expected_analysis without raising ZeroDivisionError.
+    """
+    evaluator = RAGEvaluator.__new__(RAGEvaluator)
+    test_case = {
+        "id": "tc2",
+        "question": "Sample query?",
+        "expected_analysis": []
+    }
+    result = evaluator.evaluate_response("Sample answer", test_case)
+    assert result["metrics"]["analysis_recall"] == 1.0


### PR DESCRIPTION
In `chapter3/agentic-rag/evaluation/evaluate.py`, `evaluate_response` raised a `ZeroDivisionError` when `expected_keywords` or `expected_analysis` in a test case was an empty list.

This fix guards keyword and analysis recall calculations with `if test_case["expected_keywords"] else 1.0` and `if test_case["expected_analysis"] else 1.0`. Includes regression tests in `chapter3/agentic-rag/evaluation/test_evaluate_empty_expected.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复评估指标在期望关键词或分析项为空时可能发生除零错误的问题。
  * 空列表场景下，相应的召回率将正确返回 1.0。

* **Tests**
  * 新增测试，覆盖空关键词和空分析项的评估结果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->