### PR TITLE
fix(context-compression): tolerate null content in _no_compression search results

### DIFF
--- a/chapter2/context-compression/compression_strategies.py
+++ b/chapter2/context-compression/compression_strategies.py
@@ -246,7 +246,7 @@ Full Content:
 ========================
 """
             all_content.append(content)
-            total_length += len(result.get('content', ''))
+            total_length += len(result.get('content') or '')
         
         full_content = "\n\n".join(all_content)
         

--- a/chapter2/context-compression/test_null_content_compression.py
+++ b/chapter2/context-compression/test_null_content_compression.py
@@ -1,0 +1,26 @@
+"""
+Test suite locking out TypeError in ContextCompressor._no_compression
+when a search result dictionary contains 'content': None.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+from compression_strategies import ContextCompressor
+
+
+def test_no_compression_handles_null_content():
+    """
+    Ensure _no_compression does not raise TypeError when result['content'] is None.
+    """
+    compressor = ContextCompressor.__new__(ContextCompressor)
+    search_results = {
+        'results': [
+            {'title': 'Test', 'url': 'http://example.com', 'snippet': 'snippet', 'content': None}
+        ]
+    }
+    compressed = compressor._no_compression(search_results)
+    assert compressed.original_length == 0
+    assert "Full Content:" in compressed.content


### PR DESCRIPTION
In `chapter2/context-compression/compression_strategies.py`, `_no_compression` raised a `TypeError` when a search result dictionary contained `'content': None`.

This fix updates `result.get('content', '')` to `result.get('content') or ''` so `None` safely defaults to an empty string. Includes regression tests in `chapter2/context-compression/test_null_content_compression.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复搜索结果内容为空时的处理问题，避免因空值导致错误。
  * 无内容的结果现在可正常完成上下文压缩，并正确计算内容长度。

* **测试**
  * 新增针对空内容搜索结果的覆盖测试，确保相关场景稳定运行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->