### PR TITLE
fix(context-compression): handle null page content in search_web

### DIFF
--- a/chapter2/context-compression/test_web_tools_null_content.py
+++ b/chapter2/context-compression/test_web_tools_null_content.py
@@ -1,0 +1,38 @@
+"""
+Test suite locking out TypeError in WebTools.search_web
+when fetch_webpage returns a dictionary containing 'content': None.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.modules['html2text'] = MagicMock()
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+from web_tools import WebTools
+
+
+def test_search_web_handles_null_page_content():
+    """
+    Ensure search_web calculates content_length correctly when page_content['content'] is None.
+    """
+    tool = WebTools.__new__(WebTools)
+    tool.serper_api_key = "dummy"
+    tool.fetch_webpage = MagicMock(return_value={'content': None, 'success': True})
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        'organic': [
+            {'title': 'Example', 'link': 'http://example.com', 'snippet': 'Test snippet'}
+        ]
+    }
+    
+    import requests
+    requests.post = MagicMock(return_value=mock_resp)
+
+    res = tool.search_web("test query", num_results=1)
+    assert res['num_results'] == 1
+    assert res['results'][0]['content_length'] == 0

--- a/chapter2/context-compression/web_tools.py
+++ b/chapter2/context-compression/web_tools.py
@@ -91,7 +91,7 @@ class WebTools:
                         'url': url,
                         'snippet': result.get('snippet', ''),
                         'content': page_content.get('content', ''),
-                        'content_length': len(page_content.get('content', '')),
+                        'content_length': len(page_content.get('content') or ''),
                         'fetch_success': page_content.get('success', False)
                     })
                     


### PR DESCRIPTION
In `chapter2/context-compression/web_tools.py`, `search_web` raised a `TypeError` when `fetch_webpage` returned `'content': None`.

This fix updates `len(page_content.get('content', ''))` to `len(page_content.get('content') or '')` to handle `None` gracefully. Includes regression tests in `chapter2/context-compression/test_web_tools_null_content.py`.