### PR TITLE
fix(elo-leaderboard): prevent ZeroDivisionError in benchmark summary calculations

### DIFF
--- a/chapter6/elo-leaderboard/benchmark.py
+++ b/chapter6/elo-leaderboard/benchmark.py
@@ -115,10 +115,11 @@ def main():
     print(f"\nBasic Implementation:     {time_basic:8.2f} seconds")
     print(f"Optimized Implementation: {time_optimized:8.2f} seconds")
     print(f"\nSpeedup: {speedup:.1f}x faster")
-    print(f"Time saved: {time_basic - time_optimized:.2f} seconds ({(1-time_optimized/time_basic)*100:.1f}% reduction)")
+    pct_reduction = (1 - time_optimized / time_basic) * 100 if time_basic > 0 else 0.0
+    print(f"Time saved: {time_basic - time_optimized:.2f} seconds ({pct_reduction:.1f}% reduction)")
     
     # Extrapolate to full dataset
-    if len(df_sample) < len(df_filtered):
+    if len(df_sample) > 0 and len(df_sample) < len(df_filtered):
         full_time_basic = time_basic * (len(df_filtered) / len(df_sample))
         full_time_optimized = time_optimized * (len(df_filtered) / len(df_sample))
         

--- a/chapter6/elo-leaderboard/test_benchmark_zero_div.py
+++ b/chapter6/elo-leaderboard/test_benchmark_zero_div.py
@@ -1,0 +1,29 @@
+"""
+Test suite locking out ZeroDivisionError in benchmark summary print logic
+when time_basic is 0.0 or df_sample is empty.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+
+def test_benchmark_pct_reduction_zero_division():
+    """
+    Ensure zero time_basic does not raise ZeroDivisionError during benchmark calculation.
+    """
+    time_basic = 0.0
+    time_optimized = 0.0
+    pct_reduction = (1 - time_optimized / time_basic) * 100 if time_basic > 0 else 0.0
+    assert pct_reduction == 0.0
+
+
+def test_benchmark_extrapolation_zero_sample():
+    """
+    Ensure empty df_sample does not raise ZeroDivisionError during extrapolation check.
+    """
+    df_sample = []
+    df_filtered = [1, 2, 3]
+    should_extrapolate = len(df_sample) > 0 and len(df_sample) < len(df_filtered)
+    assert not should_extrapolate


### PR DESCRIPTION
In `chapter6/elo-leaderboard/benchmark.py`, computing percentage time reduction raised a `ZeroDivisionError` when `time_basic` was `0.0`, and dataset extrapolation raised a `ZeroDivisionError` when `df_sample` was empty.

This fix adds non-zero checks to both calculations. Includes regression tests in `chapter6/elo-leaderboard/test_benchmark_zero_div.py`.