### PR TITLE
fix(tts-quality-eval): tolerate null models in _resolve_gemini_model

### DIFF
--- a/chapter6/tts-quality-eval/pipeline.py
+++ b/chapter6/tts-quality-eval/pipeline.py
@@ -398,8 +398,9 @@ def _resolve_gemini_model(api_key: str) -> str:
     try:
         with urllib.request.urlopen(url, timeout=20) as r:
             data = json.loads(r.read())
-        names = [m["name"].split("/")[-1] for m in data.get("models", [])
-                 if "generateContent" in m.get("supportedGenerationMethods", [])]
+        models_list = data.get("models") or [] if isinstance(data, dict) else []
+        names = [(m.get("name") or "").split("/")[-1] for m in models_list
+                 if isinstance(m, dict) and "generateContent" in (m.get("supportedGenerationMethods") or [])]
         # 优先默认的 gemini-3.5-flash（已验证支持音频输入），再退到 pro / 旧 flash 系列。
         for want in (config.GEMINI_MODEL_DEFAULT, "gemini-3.5-flash",
                      "gemini-2.5-pro", "gemini-2.5-flash", "gemini-flash-latest"):

--- a/chapter6/tts-quality-eval/test_resolve_gemini_model_null.py
+++ b/chapter6/tts-quality-eval/test_resolve_gemini_model_null.py
@@ -1,0 +1,29 @@
+"""
+Test suite locking out TypeError in _resolve_gemini_model
+when API returns data with models: None or non-dict items.
+"""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+from pipeline import _resolve_gemini_model, config
+
+
+def test_resolve_gemini_model_handles_null_models():
+    """
+    Ensure _resolve_gemini_model returns default model without TypeError when models key is None.
+    """
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps({"models": None}).encode("utf-8")
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=None)
+
+    import urllib.request
+    urllib.request.urlopen = MagicMock(return_value=mock_resp)
+
+    res = _resolve_gemini_model("dummy_key")
+    assert res == config.GEMINI_MODEL_DEFAULT


### PR DESCRIPTION
In `chapter6/tts-quality-eval/pipeline.py`, `_resolve_gemini_model` raised a `TypeError` when the API response dictionary contained `"models": None`.

This fix ensures `data.get("models")` defaults to an empty list when `None`, and validates model dictionary items. Includes regression tests in `chapter6/tts-quality-eval/test_resolve_gemini_model_null.py`.