### PR TITLE
fix(async-agent): improve save_checkpoint directory creation and handle null tasks in load_checkpoint

### DIFF
--- a/chapter4/async-agent/runtime.py
+++ b/chapter4/async-agent/runtime.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import json
+import os
 import time
 from typing import Optional
 
@@ -383,6 +384,9 @@ class AgentRuntime:
     def save_checkpoint(self, path: str) -> str:
         """把当前状态写入检查点文件（JSON），返回文件路径。"""
         data = self.snapshot()
+        dirname = os.path.dirname(path)
+        if dirname:
+            os.makedirs(dirname, exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
         self.log("STATE", f"已保存检查点 -> {path}"
@@ -396,5 +400,5 @@ class AgentRuntime:
         self.trajectory = [Event.from_dict(d) for d in data.get("trajectory", [])]
         self.tasks.restore(data.get("tasks", []))
         self.log("STATE", f"已从检查点恢复 <- {path}"
-                          f"（{len(self.trajectory)} 条轨迹事件，{len(data.get('tasks', []))} 个任务）")
+                          f"（{len(self.trajectory)} 条轨迹事件，{len(data.get('tasks') or [])} 个任务）")
         return data

--- a/chapter4/async-agent/runtime.py
+++ b/chapter4/async-agent/runtime.py
@@ -397,8 +397,10 @@ class AgentRuntime:
         """从检查点文件恢复轨迹与任务状态（原地覆盖当前状态）。"""
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
-        self.trajectory = [Event.from_dict(d) for d in data.get("trajectory", [])]
-        self.tasks.restore(data.get("tasks", []))
+        trajectory = data.get("trajectory") or []
+        tasks = data.get("tasks") or []
+        self.trajectory = [Event.from_dict(d) for d in trajectory]
+        self.tasks.restore(tasks)
         self.log("STATE", f"已从检查点恢复 <- {path}"
-                          f"（{len(self.trajectory)} 条轨迹事件，{len(data.get('tasks') or [])} 个任务）")
+                          f"（{len(self.trajectory)} 条轨迹事件，{len(tasks)} 个任务）")
         return data

--- a/chapter4/async-agent/test_checkpoint_robustness.py
+++ b/chapter4/async-agent/test_checkpoint_robustness.py
@@ -1,6 +1,6 @@
 """
 Test suite locking out TypeError and FileNotFoundError in AgentRuntime checkpointing
-when tasks is None or destination directory doesn't exist.
+when tasks is None, trajectory is None, or destination directory doesn't exist.
 """
 
 import json
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 from runtime import AgentRuntime
+from tasks import TaskManager
 
 
 def test_save_checkpoint_creates_nested_directories():
@@ -30,19 +31,23 @@ def test_save_checkpoint_creates_nested_directories():
         assert os.path.exists(target_path)
 
 
-def test_load_checkpoint_handles_null_tasks():
+def test_load_checkpoint_handles_null_tasks_and_trajectory():
     """
-    Ensure load_checkpoint logs task counts without TypeError when tasks key is None.
+    Ensure load_checkpoint gracefully handles JSON containing "tasks": null and
+    "trajectory": null with a real TaskManager without raising TypeError.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         target_path = os.path.join(tmpdir, "checkpoint.json")
         with open(target_path, "w", encoding="utf-8") as f:
-            json.dump({'trajectory': [], 'tasks': None}, f)
+            json.dump({'trajectory': None, 'tasks': None}, f)
 
         runtime = AgentRuntime.__new__(AgentRuntime)
-        runtime.tasks = MagicMock()
+        runtime.tasks = TaskManager(on_complete=MagicMock(), log=MagicMock())
         runtime.log = MagicMock()
 
         data = runtime.load_checkpoint(target_path)
         assert data['tasks'] is None
+        assert data['trajectory'] is None
+        assert len(runtime.trajectory) == 0
+        assert len(runtime.tasks._tasks) == 0
         runtime.log.assert_called_once()

--- a/chapter4/async-agent/test_checkpoint_robustness.py
+++ b/chapter4/async-agent/test_checkpoint_robustness.py
@@ -1,0 +1,48 @@
+"""
+Test suite locking out TypeError and FileNotFoundError in AgentRuntime checkpointing
+when tasks is None or destination directory doesn't exist.
+"""
+
+import json
+import os
+import sys
+import tempfile
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+from runtime import AgentRuntime
+
+
+def test_save_checkpoint_creates_nested_directories():
+    """
+    Ensure save_checkpoint automatically creates parent directories when saving.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        runtime = AgentRuntime.__new__(AgentRuntime)
+        runtime.snapshot = MagicMock(return_value={'trajectory': [], 'tasks': []})
+        runtime.log = MagicMock()
+        
+        target_path = os.path.join(tmpdir, "nested", "sub", "checkpoint.json")
+        result_path = runtime.save_checkpoint(target_path)
+        
+        assert result_path == target_path
+        assert os.path.exists(target_path)
+
+
+def test_load_checkpoint_handles_null_tasks():
+    """
+    Ensure load_checkpoint logs task counts without TypeError when tasks key is None.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        target_path = os.path.join(tmpdir, "checkpoint.json")
+        with open(target_path, "w", encoding="utf-8") as f:
+            json.dump({'trajectory': [], 'tasks': None}, f)
+
+        runtime = AgentRuntime.__new__(AgentRuntime)
+        runtime.tasks = MagicMock()
+        runtime.log = MagicMock()
+
+        data = runtime.load_checkpoint(target_path)
+        assert data['tasks'] is None
+        runtime.log.assert_called_once()


### PR DESCRIPTION
In `chapter4/async-agent/runtime.py`, `save_checkpoint` raised `FileNotFoundError` when target parent directories did not exist, and `load_checkpoint` raised `TypeError` during log formatting when a checkpoint JSON had `"tasks": null`.

This fix automatically creates parent directories via `os.makedirs` and uses `len(data.get('tasks') or [])`. Includes regression tests in `chapter4/async-agent/test_checkpoint_robustness.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 保存检查点时会自动创建缺失的多级目录，避免写入失败。
  * 加载缺少或为空的任务、轨迹数据时可稳定恢复为空状态。

* **Tests**
  * 增加对嵌套目录创建及空检查点数据恢复场景的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->