### PR TITLE
fix(user-memory): scope raw history to current session

### DIFF
--- a/chapter3/user-memory/conversational_agent.py
+++ b/chapter3/user-memory/conversational_agent.py
@@ -170,17 +170,21 @@ You MUST analyze the context, user's questions and memories in detail, and provi
             context_parts.append(memory_str)
             context_parts.append("")
         
-        # Add ALL conversation history
+        # Keep raw conversation turns scoped to the active session. Persisted
+        # turns from earlier sessions are input to the background memory
+        # processor, but the conversational agent should learn about those
+        # sessions only through the structured long-term memory above.
         if self.conversation_history:
-            # Get ALL conversation history, not just recent
-            all_conversations = self.conversation_history.conversations if hasattr(self.conversation_history, 'conversations') else []
+            session_turns = self.conversation_history.get_session_turns(
+                self.session_id
+            )
             
-            if all_conversations:
-                context_parts.append("=== FULL CONVERSATION HISTORY ===")
-                context_parts.append(f"Total conversations: {len(all_conversations)}")
+            if session_turns:
+                context_parts.append("=== CURRENT SESSION HISTORY ===")
+                context_parts.append(f"Total turns: {len(session_turns)}")
                 context_parts.append("")
                 
-                for turn in all_conversations:
+                for turn in session_turns:
                     context_parts.append(f"[Session: {turn.session_id}, Turn {turn.turn_number}, Time: {turn.timestamp}]")
                     context_parts.append(f"User: {turn.user_message}")
                     context_parts.append(f"Assistant: {turn.assistant_message}")

--- a/chapter3/user-memory/test_session_scoped_history.py
+++ b/chapter3/user-memory/test_session_scoped_history.py
@@ -1,0 +1,81 @@
+"""Regression tests for issue #493's cross-session history leak."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from conversational_agent import ConversationConfig, ConversationalAgent
+from conversation_history import ConversationHistory, ConversationTurn
+
+
+class StubMemoryManager:
+    def __init__(self, context: str):
+        self.context = context
+        self.load_count = 0
+
+    def load_memory(self):
+        self.load_count += 1
+
+    def get_context_string(self) -> str:
+        return self.context
+
+
+def make_agent(history: ConversationHistory, session_id: str):
+    """Build the prompt-only portion of an agent without an API client."""
+    agent = ConversationalAgent.__new__(ConversationalAgent)
+    agent.config = ConversationConfig()
+    agent.memory_manager = StubMemoryManager("Preferred editor: VS Code")
+    agent.conversation_history = history
+    agent.session_id = session_id
+    return agent
+
+
+def test_memory_context_excludes_raw_turns_from_previous_sessions():
+    history = ConversationHistory.__new__(ConversationHistory)
+    history.conversations = [
+        ConversationTurn(
+            "session-old",
+            "My private detail from the old session",
+            "I will remember that detail",
+            "2026-07-28T10:00:00",
+            1,
+        ),
+        ConversationTurn(
+            "session-current",
+            "What did we discuss in this session?",
+            "We discussed the current task",
+            "2026-07-29T10:00:00",
+            2,
+        ),
+    ]
+    agent = make_agent(history, "session-current")
+
+    context = agent._get_memory_context()
+
+    assert "Preferred editor: VS Code" in context
+    assert "=== CURRENT SESSION HISTORY ===" in context
+    assert "What did we discuss in this session?" in context
+    assert "My private detail from the old session" not in context
+    assert "session-old" not in context
+
+
+def test_new_session_uses_structured_memory_without_old_raw_history():
+    history = ConversationHistory.__new__(ConversationHistory)
+    history.conversations = [
+        ConversationTurn(
+            "session-old",
+            "I work at TechCorp",
+            "Thanks for sharing",
+            "2026-07-28T10:00:00",
+            1,
+        )
+    ]
+    agent = make_agent(history, "session-new")
+
+    context = agent._get_memory_context()
+
+    assert "Preferred editor: VS Code" in context
+    assert "I work at TechCorp" not in context
+    assert "CURRENT SESSION HISTORY" not in context
+    assert agent.memory_manager.load_count == 1


### PR DESCRIPTION
## Summary

- Filter persisted raw conversation turns by the active session before adding them to the conversational agent prompt.
- Preserve structured long-term memory across sessions and retain normal current-session context.
- Add regression coverage for both active-session continuity and new-session isolation.

## Testing

- python -m pytest chapter3/user-memory -q (9 passed)
- python -m compileall -q chapter3/user-memory/conversational_agent.py chapter3/user-memory/test_session_scoped_history.py

Fixes #493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 会话记忆上下文现仅包含当前会话的对话历史，避免混入其他会话的原始内容。
  - 保留长期用户记忆，并在当前会话存在历史记录时展示结构化的会话信息。
  - 新会话不会显示旧会话的原始对话内容。

- **Tests**
  - 新增回归测试，验证跨会话内容隔离、当前会话历史展示及长期记忆加载行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->