### PR TITLE
fix: 修复 evaluation 模式查看 memory 崩溃

### DIFF
--- a/chapter3/user-memory/main.py
+++ b/chapter3/user-memory/main.py
@@ -683,12 +683,7 @@ def run_evaluation_mode(user_id: str, memory_mode: MemoryMode, verbose: bool = T
             # View current memory
             print("\n📄 Current Memory State:")
             print("-"*60)
-            memories = processor.get_current_memories()
-            if memories:
-                for mem in memories:
-                    print(f"  • {mem}")
-            else:
-                print("  (No memories stored)")
+            print(processor.memory_manager.get_context_string())
                 
         elif choice == "3":
             # Clear memory

--- a/chapter3/user-memory/test_evaluation_memory_view.py
+++ b/chapter3/user-memory/test_evaluation_memory_view.py
@@ -1,0 +1,53 @@
+"""Regression coverage for evaluation menu memory display."""
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import main
+from config import MemoryMode
+
+
+def test_evaluation_option_two_prints_memory_manager_context(monkeypatch, capsys):
+    class FakeTestSuite:
+        test_cases = [object()]
+
+    class FakeFramework:
+        def __init__(self):
+            self.test_suite = FakeTestSuite()
+
+    fake_framework_module = types.SimpleNamespace(UserMemoryEvaluationFramework=FakeFramework)
+    monkeypatch.setitem(sys.modules, "models", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "evaluator", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "framework", fake_framework_module)
+
+    class FakeMemoryManager:
+        def get_context_string(self):
+            return "User Memory Notes:\n\nNote 1: Prefers Python"
+
+    class FakeConversationHistory:
+        def __init__(self):
+            self.conversations = []
+
+    class FakeAgent:
+        def __init__(self, *args, **kwargs):
+            self.memory_manager = FakeMemoryManager()
+            self.conversation_history = FakeConversationHistory()
+            self.conversation = []
+
+    class FakeProcessor:
+        def __init__(self, *args, **kwargs):
+            self.memory_manager = FakeMemoryManager()
+
+    inputs = iter(["2", "4"])
+    monkeypatch.setattr(main.Config, "get_api_key", lambda provider: "test-key")
+    monkeypatch.setattr(main, "ConversationalAgent", FakeAgent)
+    monkeypatch.setattr(main, "BackgroundMemoryProcessor", FakeProcessor)
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+
+    main.run_evaluation_mode("default_user", MemoryMode.NOTES, provider="moonshot", model="test-model")
+
+    output = capsys.readouterr().out
+    assert "Current Memory State" in output
+    assert "Note 1: Prefers Python" in output

--- a/chapter3/user-memory/test_evaluation_memory_view.py
+++ b/chapter3/user-memory/test_evaluation_memory_view.py
@@ -1,15 +1,15 @@
 """Regression coverage for evaluation menu memory display."""
-import os
-import sys
+import builtins
 import types
-
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-
-import main
-from config import MemoryMode
+from pathlib import Path
 
 
 def test_evaluation_option_two_prints_memory_manager_context(monkeypatch, capsys):
+    monkeypatch.syspath_prepend(str(Path(__file__).parent))
+
+    import main
+    from config import MemoryMode
+
     class FakeTestSuite:
         test_cases = [object()]
 
@@ -17,10 +17,20 @@ def test_evaluation_option_two_prints_memory_manager_context(monkeypatch, capsys
         def __init__(self):
             self.test_suite = FakeTestSuite()
 
-    fake_framework_module = types.SimpleNamespace(UserMemoryEvaluationFramework=FakeFramework)
-    monkeypatch.setitem(sys.modules, "models", types.SimpleNamespace())
-    monkeypatch.setitem(sys.modules, "evaluator", types.SimpleNamespace())
-    monkeypatch.setitem(sys.modules, "framework", fake_framework_module)
+    fake_evaluation_modules = {
+        "config": types.SimpleNamespace(),
+        "models": types.SimpleNamespace(),
+        "evaluator": types.SimpleNamespace(),
+        "framework": types.SimpleNamespace(UserMemoryEvaluationFramework=FakeFramework),
+    }
+    real_import = builtins.__import__
+
+    def import_fake_evaluation_module(name, globals=None, locals=None, fromlist=(), level=0):
+        if level == 0 and name in fake_evaluation_modules:
+            return fake_evaluation_modules[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_fake_evaluation_module)
 
     class FakeMemoryManager:
         def get_context_string(self):


### PR DESCRIPTION
## 问题

在 `chapter3/user-memory` 中运行 evaluation 模式时，选择菜单项 `2. View current memory state` 会崩溃：

```text
AttributeError: 'BackgroundMemoryProcessor' object has no attribute 'get_current_memories'
```

原因是 `main.py` 调用了 `processor.get_current_memories()`，但 `BackgroundMemoryProcessor` 没有这个方法。

## 修改

将菜单项 2 改为直接使用已有的 memory manager 接口：

```python
print(processor.memory_manager.get_context_string())
```

并新增回归测试覆盖该菜单项。

## 验证

```bash
python -m pytest test_evaluation_memory_view.py -q
```

结果：

```text
1 passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 优化评测模式中“查看当前记忆”的展示方式，改为以当前记忆上下文字符串形式输出，信息更完整。
* **测试**
  * 新增回归测试，覆盖评测菜单选择“2”后输出包含当前记忆上下文（含指定注释内容）的场景，并验证后续退出/切换流程下的输出表现。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->