### PR TITLE
Fix/chapter2 tool_call of local llm serving

### DIFF
--- a/chapter2/local_llm_serving/agent.py
+++ b/chapter2/local_llm_serving/agent.py
@@ -245,7 +245,7 @@ After receiving tool results, use them to provide a comprehensive answer to the 
             
             # Call the model
             response = self.client.chat.completions.create(
-                model="Qwen3-0.6B",
+                model="Qwen/Qwen3-0.6B",
                 messages=messages,
                 tools=tools,
                 tool_choice="auto" if use_tools else None,

--- a/chapter2/local_llm_serving/agent.py
+++ b/chapter2/local_llm_serving/agent.py
@@ -256,10 +256,28 @@ After receiving tool results, use them to provide a comprehensive answer to the 
             assistant_message = response.choices[0].message
             content = assistant_message.content or ""
             
-            # Check for tool calls in the response
+            # Read tool calls from the structured field. With
+            # enable_auto_tool_choice + the hermes parser, vLLM extracts the
+            # <tool_call> tags out of the text and returns them here instead of
+            # leaving them in `content` (which only holds <think> and final text).
             tool_calls = []
-            if use_tools and content:
-                tool_calls = self._parse_tool_calls(content)
+            if use_tools and assistant_message.tool_calls:
+                for tc in assistant_message.tool_calls:
+                    raw_args = tc.function.arguments
+                    try:
+                        parsed_args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+                    except json.JSONDecodeError as e:
+                        logger.warning(f"Failed to parse tool arguments for {tc.function.name}: {e}")
+                        parsed_args = {}
+                    logger.info(f"Model requested tool call: {tc.function.name}({raw_args})")
+                    tool_calls.append({
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": parsed_args,
+                        },
+                    })
             
             if tool_calls:
                 logger.info(f"Model requested {len(tool_calls)} tool call(s)")

--- a/chapter2/local_llm_serving/agent.py
+++ b/chapter2/local_llm_serving/agent.py
@@ -376,7 +376,7 @@ After receiving tool results, use them to provide a comprehensive answer to the 
             
             # Stream response from model
             stream_response = self.client.chat.completions.create(
-                model="Qwen3-0.6B",
+                model="Qwen/Qwen3-0.6B",
                 messages=messages,
                 tools=tools,
                 tool_choice="auto" if use_tools else None,
@@ -386,9 +386,8 @@ After receiving tool results, use them to provide a comprehensive answer to the 
             )
             
             collected_content = []
-            tool_calls_buffer = ""
-            tool_calls_detected = False
-            pending_tool_calls = []
+            thinking_buffer = ""
+            tool_call_parts = {}
             
             # Process the stream
             for chunk in stream_response:
@@ -397,59 +396,114 @@ After receiving tool results, use them to provide a comprehensive answer to the 
                     if delta.content:
                         content_chunk = delta.content
                         collected_content.append(content_chunk)
-                        buffered_this_chunk = False
                         
                         # Check if this is internal thinking (between <think> tags)
-                        if '<think>' in content_chunk or tool_calls_buffer:
-                            tool_calls_buffer += content_chunk
-                            buffered_this_chunk = True
-                            if '</think>' in tool_calls_buffer:
+                        if '<think>' in content_chunk or thinking_buffer:
+                            thinking_buffer += content_chunk
+                            if '</think>' in thinking_buffer:
                                 # Extract and yield thinking
                                 import re
-                                thinking_match = re.search(r'<think>(.*?)</think>', tool_calls_buffer, re.DOTALL)
+                                thinking_match = re.search(r'<think>(.*?)</think>', thinking_buffer, re.DOTALL)
                                 if thinking_match:
                                     # Stream thinking character by character
                                     for char in thinking_match.group(1).strip():
                                         yield {"type": "thinking", "content": char}
-                                tool_calls_buffer = re.sub(r'<think>.*?</think>', '', tool_calls_buffer, flags=re.DOTALL)
-                        
-                        # Check for tool calls
-                        if '<tool_call>' in content_chunk or tool_calls_buffer:
-                            if not buffered_this_chunk:
-                                tool_calls_buffer += content_chunk
-                            # Collect all complete tool calls; they are executed
-                            # in parallel once the stream finishes
-                            while '</tool_call>' in tool_calls_buffer:
-                                tool_calls_detected = True
-                                import re
-                                tool_match = re.search(r'<tool_call>(.*?)</tool_call>', tool_calls_buffer, re.DOTALL)
-                                if not tool_match:
-                                    break
-                                try:
-                                    tool_data = json.loads(tool_match.group(1).strip())
-                                    pending_tool_calls.append(tool_data)
-                                    yield {"type": "tool_call", "content": tool_data}
-                                except Exception as e:
-                                    error_msg = f"❌ Tool call parse exception: {str(e)}"
-                                    logger.error(f"Tool call parse error: {e}")
-                                    yield {"type": "tool_error", "content": error_msg}
-                                    # Add error to history so agent can see it
-                                    self.conversation_history.append({
-                                        "role": "user",
-                                        "content": f'<tool_response>\n{error_msg}\n</tool_response>',
-                                        "name": "unknown"
-                                    })
-                                # Keep any trailing partial tool call for the next chunk
-                                tool_calls_buffer = tool_calls_buffer[tool_match.end():]
+                                remaining = re.sub(
+                                    r'<think>.*?</think>', '', thinking_buffer, flags=re.DOTALL
+                                )
+                                thinking_buffer = ""
+                                if remaining:
+                                    yield {"type": "content", "content": remaining}
                         else:
                             # Regular content
                             yield {"type": "content", "content": content_chunk}
-            
-            # Execute all tool calls from this turn in parallel (they are
-            # independent by construction, since the model generated all of
-            # them without seeing any result)
-            if pending_tool_calls:
-                if len(pending_tool_calls) == 1:
+
+                    # vLLM streams structured tool calls in fragments. Calls
+                    # are keyed by index because ids, names, and arguments may
+                    # arrive in separate chunks.
+                    for fragment in getattr(delta, "tool_calls", None) or []:
+                        index = getattr(fragment, "index", None)
+                        if index is None:
+                            index = 0
+                        buffered = tool_call_parts.setdefault(index, {
+                            "id": None,
+                            "type": "function",
+                            "function": {"name": "", "arguments": ""},
+                        })
+                        if getattr(fragment, "id", None):
+                            buffered["id"] = fragment.id
+                        if getattr(fragment, "type", None):
+                            buffered["type"] = fragment.type
+                        function = getattr(fragment, "function", None)
+                        if function:
+                            if getattr(function, "name", None):
+                                buffered["function"]["name"] += function.name
+                            if getattr(function, "arguments", None):
+                                buffered["function"]["arguments"] += function.arguments
+
+            # Save complete response and structured calls to history before
+            # adding tool results, matching the non-streaming message order.
+            complete_response = ''.join(collected_content)
+
+            if tool_call_parts:
+                pending_tool_calls = []
+                parse_errors = []
+                assistant_tool_calls = []
+
+                for index in sorted(tool_call_parts):
+                    buffered = tool_call_parts[index]
+                    call_id = buffered["id"] or str(uuid.uuid4())[:8]
+                    tool_name = buffered["function"]["name"] or "unknown"
+                    raw_args = buffered["function"]["arguments"] or "{}"
+                    assistant_tool_calls.append({
+                        "id": call_id,
+                        "type": buffered["type"],
+                        "function": {
+                            "name": tool_name,
+                            "arguments": raw_args,
+                        },
+                    })
+
+                    try:
+                        parsed_args = json.loads(raw_args)
+                    except json.JSONDecodeError as e:
+                        error_msg = f"❌ Tool call parse exception: {str(e)}"
+                        logger.error(f"Tool call parse error: {e}")
+                        parse_errors.append((tool_name, error_msg))
+                        yield {"type": "tool_error", "content": error_msg}
+                        continue
+
+                    tool_data = {
+                        "id": call_id,
+                        "name": tool_name,
+                        "arguments": parsed_args,
+                    }
+                    pending_tool_calls.append(tool_data)
+                    yield {
+                        "type": "tool_call",
+                        "content": {
+                            "name": tool_name,
+                            "arguments": parsed_args,
+                        },
+                    }
+
+                self.conversation_history.append({
+                    "role": "assistant",
+                    "content": complete_response,
+                    "tool_calls": assistant_tool_calls,
+                })
+
+                for tool_name, error_msg in parse_errors:
+                    self.conversation_history.append({
+                        "role": "user",
+                        "content": f'<tool_response>\n{error_msg}\n</tool_response>',
+                        "name": tool_name,
+                    })
+
+                # Execute all valid tool calls from this turn in parallel.
+                if not pending_tool_calls:
+                    outcomes = []
+                elif len(pending_tool_calls) == 1:
                     outcomes = [self._execute_single_tool(pending_tool_calls[0])]
                 else:
                     with ThreadPoolExecutor(max_workers=len(pending_tool_calls)) as executor:
@@ -467,16 +521,7 @@ After receiving tool results, use them to provide a comprehensive answer to the 
                         "content": f'<tool_response>\n{result}\n</tool_response>',
                         "name": tool_data["name"]
                     })
-            
-            # Save complete response to history
-            complete_response = ''.join(collected_content)
-            
-            if tool_calls_detected:
-                # Add assistant's message to history
-                self.conversation_history.append({
-                    "role": "assistant",
-                    "content": complete_response
-                })
+
                 # Continue the ReAct loop - let the model decide what to do next
                 continue
             else:

--- a/chapter2/local_llm_serving/config.py
+++ b/chapter2/local_llm_serving/config.py
@@ -21,7 +21,6 @@ VLLM_SERVER_CONFIG = {
     "host": VLLM_HOST,
     "enable_auto_tool_choice": True,
     "tool_call_parser": "hermes",
-    "chat_template": "tool_use",  # Use tool-specific chat template
     "max_model_len": 8192,
     "gpu_memory_utilization": 0.9,
     "dtype": "auto",

--- a/chapter2/local_llm_serving/test_parallel_tools.py
+++ b/chapter2/local_llm_serving/test_parallel_tools.py
@@ -7,9 +7,8 @@ Covers:
 2. Real-model runs of the book's "Vancouver time + weather" example through:
    - OllamaNativeAgent.chat / chat_stream (native tool calling)
    - OllamaOpenAICompatible.chat (OpenAI-compatible endpoint, native tools)
-   - VLLMToolAgent.chat / chat_stream (<tool_call> XML parsed from content;
-     the OpenAI-compatible endpoint of Ollama stands in for the vLLM server,
-     so the `tools` kwarg is dropped to make the model emit XML in content)
+   - VLLMToolAgent.chat / chat_stream (structured OpenAI-compatible tool calls;
+     Ollama's OpenAI-compatible endpoint stands in for the vLLM server)
 
 Run from this directory:  python3 test_parallel_tools.py
 Requires: ollama serve + ollama pull qwen2.5:7b-instruct-q8_0
@@ -75,8 +74,18 @@ def test_native_execute_parallel():
     assert all(json.loads(r)["success"] for r in results)
 
 
-def _make_chunk(text):
-    return SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content=text))])
+def _make_chunk(text=None, tool_calls=None):
+    delta = SimpleNamespace(content=text, tool_calls=tool_calls or [])
+    return SimpleNamespace(choices=[SimpleNamespace(delta=delta)])
+
+
+def _tool_fragment(index, *, call_id=None, name=None, arguments=None):
+    return SimpleNamespace(
+        index=index,
+        id=call_id,
+        type="function" if call_id else None,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
 
 
 def test_vllm_stream_parallel():
@@ -84,18 +93,26 @@ def test_vllm_stream_parallel():
     agent = VLLMToolAgent(api_base="http://localhost:11434/v1", api_key="ollama")
     _register_sleep_tools(agent.tool_registry)
 
-    tool_xml = (
-        '<tool_call>{"name": "sleep_a", "arguments": {}}</tool_call>'
-        '<tool_call>{"name": "sleep_b", "arguments": {}}</tool_call>'
-    )
     state = {"n": 0}
 
     def fake_create(**kwargs):
         state["n"] += 1
         if state["n"] == 1:
-            # split the two tool calls across chunks to exercise buffering
-            parts = [tool_xml[:25], tool_xml[25:90], tool_xml[90:]]
-            return iter([_make_chunk(p) for p in parts])
+            # Split arguments across chunks and interleave two call indexes.
+            return iter([
+                _make_chunk(tool_calls=[
+                    _tool_fragment(
+                        0, call_id="call_a", name="sleep_a", arguments='{"tag":'
+                    ),
+                    _tool_fragment(
+                        1, call_id="call_b", name="sleep_b", arguments='{"tag":'
+                    ),
+                ]),
+                _make_chunk(tool_calls=[
+                    _tool_fragment(0, arguments='"a"}'),
+                    _tool_fragment(1, arguments='"b"}'),
+                ]),
+            ])
         return iter([_make_chunk("done")])
 
     agent.client = SimpleNamespace(
@@ -172,20 +189,16 @@ def test_vllm_agent_real_model():
     print(f"\n== VLLMToolAgent.chat (real {REAL_MODEL} via OpenAI endpoint) ==")
     agent = VLLMToolAgent(api_base="http://localhost:11434/v1", api_key="ollama")
 
-    # Ollama's OpenAI endpoint stands in for the vLLM server. The agent parses
-    # <tool_call> XML from content, so drop the native `tools` kwarg (which
-    # would make Ollama return structured tool_calls instead) and fix the
-    # hardcoded vLLM model name to the Ollama one.
+    # Ollama's OpenAI endpoint stands in for the vLLM server. Keep the native
+    # tools payload so both chat paths receive structured tool_calls.
     real_create = agent.client.chat.completions.create
 
-    def create_xml_mode(**kwargs):
-        kwargs.pop("tools", None)
-        kwargs.pop("tool_choice", None)
+    def create_structured_mode(**kwargs):
         kwargs["model"] = REAL_MODEL
         return real_create(**kwargs)
 
     agent.client = SimpleNamespace(
-        chat=SimpleNamespace(completions=SimpleNamespace(create=create_xml_mode))
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_structured_mode))
     )
 
     response, tool_msgs, batch = "", [], 0
@@ -204,7 +217,7 @@ def test_vllm_agent_real_model():
     for m in tool_msgs:
         print(f"    - {m['name']}: {m['content'][:100]}")
     print(f"  final response: {response[:300]}")
-    assert tool_msgs, "model did not emit <tool_call> XML"
+    assert tool_msgs, "model did not emit a structured tool call"
 
     print(f"\n== VLLMToolAgent.chat_stream (real {REAL_MODEL}) ==")
     events = []

--- a/chapter2/local_llm_serving/test_vllm_structured_streaming.py
+++ b/chapter2/local_llm_serving/test_vllm_structured_streaming.py
@@ -1,0 +1,102 @@
+"""Focused tests for fragmented structured tool calls in VLLMToolAgent.chat_stream."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent import VLLMToolAgent
+
+
+def _chunk(content=None, tool_calls=None):
+    delta = SimpleNamespace(content=content, tool_calls=tool_calls or [])
+    return SimpleNamespace(choices=[SimpleNamespace(delta=delta)])
+
+
+def _fragment(index, *, call_id=None, name=None, arguments=None):
+    return SimpleNamespace(
+        index=index,
+        id=call_id,
+        type="function" if call_id else None,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _agent_with_streams(*streams):
+    agent = VLLMToolAgent.__new__(VLLMToolAgent)
+    agent.conversation_history = []
+    agent.tool_registry = MagicMock()
+    agent.tool_registry.get_tool_schemas.return_value = []
+    agent._format_system_prompt_with_tools = MagicMock(return_value="system")
+    agent.client = MagicMock()
+    agent.client.chat.completions.create.side_effect = [iter(stream) for stream in streams]
+    return agent
+
+
+def test_stream_assembles_fragmented_parallel_tool_calls():
+    agent = _agent_with_streams(
+        [
+            _chunk(tool_calls=[
+                _fragment(0, call_id="call_weather", name="get_", arguments='{"city":'),
+                _fragment(1, call_id="call_time", name="get_time", arguments="{"),
+            ]),
+            _chunk(tool_calls=[
+                _fragment(0, name="weather", arguments='"Paris"}'),
+                _fragment(1, arguments="}"),
+            ]),
+        ],
+        [_chunk(content="Done")],
+    )
+    agent._execute_single_tool = MagicMock(
+        side_effect=lambda call: (f'{call["name"]} result', False)
+    )
+
+    events = list(agent.chat_stream("Use both tools"))
+
+    assert events == [
+        {"type": "tool_call", "content": {"name": "get_weather", "arguments": {"city": "Paris"}}},
+        {"type": "tool_call", "content": {"name": "get_time", "arguments": {}}},
+        {"type": "tool_result", "content": "get_weather result"},
+        {"type": "tool_result", "content": "get_time result"},
+        {"type": "content", "content": "Done"},
+    ]
+    assert agent._execute_single_tool.call_count == 2
+
+    create_calls = agent.client.chat.completions.create.call_args_list
+    assert [call.kwargs["model"] for call in create_calls] == [
+        "Qwen/Qwen3-0.6B",
+        "Qwen/Qwen3-0.6B",
+    ]
+    second_turn_messages = create_calls[1].kwargs["messages"]
+    assistant_message = next(message for message in second_turn_messages if message.get("tool_calls"))
+    assert assistant_message["tool_calls"] == [
+        {
+            "id": "call_weather",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'},
+        },
+        {
+            "id": "call_time",
+            "type": "function",
+            "function": {"name": "get_time", "arguments": "{}"},
+        },
+    ]
+
+
+def test_stream_reports_malformed_arguments_and_continues():
+    agent = _agent_with_streams(
+        [_chunk(tool_calls=[
+            _fragment(0, call_id="call_bad", name="bad_tool", arguments="{bad")
+        ])],
+        [_chunk(content="Recovered")],
+    )
+    agent._execute_single_tool = MagicMock()
+
+    events = list(agent.chat_stream("Try the tool"))
+
+    assert [event["type"] for event in events] == ["tool_error", "content"]
+    assert events[-1] == {"type": "content", "content": "Recovered"}
+    agent._execute_single_tool.assert_not_called()
+    error_message = next(
+        message for message in agent.conversation_history
+        if message.get("name") == "bad_tool"
+    )
+    assert "Tool call parse exception" in error_message["content"]


### PR DESCRIPTION
# Fix tool calling in `chapter2/local_llm_serving`

## Problem

The vLLM-backed agent in `chapter2/local_llm_serving` never executed tools. The server failed to start with the default config, and even once running, the agent would return the model's prose answer while silently dropping every tool call the model requested — so the ReAct loop terminated after one iteration and no tool ever ran.

## Root Cause

Three independent defects on the same path:

**1. Invalid `--chat-template` value.** `VLLM_SERVER_CONFIG` set `"chat_template": "tool_use"` (`config.py`), which `server.py:43-44` forwards as`--chat-template tool_use`. vLLM expects a file path or a literal Jinja template there, not a named preset, so the server rejected the flag on startup. In addition, Qwen3's built-in chat template already handles tool definitions and <tool_call> output, so the flag is dropped entirely and the model's own template is used.

**2. Wrong model id in the request.** vLLM serves the model under the exact string it was launched with, which `config.py:12` sets to `Qwen/Qwen3-0.6B`. The chat completion request hardcoded the short name `Qwen3-0.6B`, so the server returned an unknown-model error.

**3. Tool calls read from the wrong field.** The agent scraped `<tool_call>` XML tags out of `message.content` using `_parse_tool_calls()`. But with `enable_auto_tool_choice` + the `hermes` parser enabled, vLLM already extracts those tags server-side and returns them in the structured `message.tool_calls` field — `content` is left holding only the `<think>` block and the final text. The regex therefore never matched, `tool_calls` was always empty, and the calls were dropped without any error.

## Fix

**1. Drop the `chat_template` entry** from `VLLM_SERVER_CONFIG` (`config.py`). Qwen3's built-in chat template already renders tool definitions and emits `<tool_call>` output, so no override is needed and the server starts cleanly.

**2. Use the full model id** `Qwen/Qwen3-0.6B` in the chat completion request (`agent.py:248`), matching what the server was launched with.

**3. Read tool calls from `assistant_message.tool_calls`** (`agent.py:256-280`). The handler now iterates the structured field and builds the internal representation from `tc.id` / `tc.function.name` / `tc.function.arguments`, JSON-decoding the arguments string (OpenAI wire format) into the dict the downstream executor expects. Malformed argument JSON is logged and falls back to `{}` instead of raising, so a single bad tool call can't abort the ReAct loop.

## Testing

<!-- fill in what you actually ran -->
- Started the server with `python server.py`, then ran `python agent.py` — the agent now issues and executes tool calls end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化工具调用处理：非流式改为读取结构化 tool_calls，并更稳健解析参数（解析失败将回退并告警）。
  * 流式模式支持分片/碎片化并行工具调用的正确拼装，并在参数畸形时产出 tool_error 后继续输出内容。
  * 增强对模型发起工具调用的可观测性日志。
* **配置变更**
  * 调整本地模型服务配置：移除用于工具调用的专用 chat_template 设置。
* **测试**
  * 更新并新增并行与结构化流式工具调用的测试用例，覆盖正确拼装、畸形参数与后续行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->