### PR TITLE
fix(prompt-engineering): avoid ZeroDivisionError when display_metrics receives empty results

### DIFF
--- a/chapter2/prompt-engineering/tau_bench/run.py
+++ b/chapter2/prompt-engineering/tau_bench/run.py
@@ -178,6 +178,10 @@ def agent_factory(
 
 
 def display_metrics(results: List[EnvRunResult]) -> None:
+    if not results:
+        print("No results to display metrics for.")
+        return
+
     def is_successful(reward: float) -> bool:
         return (1 - 1e-6) <= reward <= (1 + 1e-6)
 

--- a/chapter2/prompt-engineering/test_tau_bench_empty_results.py
+++ b/chapter2/prompt-engineering/test_tau_bench_empty_results.py
@@ -1,0 +1,14 @@
+"""
+display_metrics must handle empty results list without raising ZeroDivisionError.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "tau_bench"))
+
+from run import display_metrics
+
+
+def test_display_metrics_empty_results():
+    """Ensure display_metrics gracefully handles empty results list."""
+    display_metrics([])


### PR DESCRIPTION
When display_metrics receives an empty results list, calculating average reward raises ZeroDivisionError. Add an early check returning when results is empty.