### PR TITLE
fix(trajectory-verifier): prevent ZeroDivisionError when dimensions is empty in TrajectoryVerifier

### DIFF
--- a/chapter8/trajectory-verifier/test_empty_dimensions_score.py
+++ b/chapter8/trajectory-verifier/test_empty_dimensions_score.py
@@ -1,0 +1,17 @@
+"""
+TrajectoryVerifier.evaluate must handle empty dimensions list without raising ZeroDivisionError.
+"""
+from unittest.mock import MagicMock
+from verifier import TrajectoryVerifier
+
+
+def test_trajectory_verifier_handles_empty_dimensions():
+    verifier = TrajectoryVerifier()
+    verifier.result_verifier.evaluate = MagicMock(return_value=[])
+    verifier.process_verifier.evaluate = MagicMock(return_value=[])
+    verifier.quality_judge.evaluate = MagicMock(return_value=[])
+
+    report = verifier.evaluate({"id": "traj-empty"})
+    assert report["overall_score"] == 0.0
+    assert report["critical_failures"] == []
+    assert report["release_recommendation"] == "review_or_accept"

--- a/chapter8/trajectory-verifier/verifier.py
+++ b/chapter8/trajectory-verifier/verifier.py
@@ -222,7 +222,7 @@ class TrajectoryVerifier:
         ]
         return {
             "trajectory_id": trajectory.get("id"),
-            "overall_score": round(sum(scores) / len(scores), 3),
+            "overall_score": round(sum(scores) / len(scores), 3) if scores else 0.0,
             "release_recommendation": "reject" if critical_failures else "review_or_accept",
             "critical_failures": critical_failures,
             "dimensions": [asdict(item) for item in dimensions],


### PR DESCRIPTION
TrajectoryVerifier.evaluate raises ZeroDivisionError when custom verifiers or judges return an empty dimensions list because sum(scores) / len(scores) divides by zero. Fallback to 0.0 when scores is empty.