### PR TITLE
fix(context): normalize currency codes with dollar suffix like US$ or AU$

### DIFF
--- a/chapter1/context/agent.py
+++ b/chapter1/context/agent.py
@@ -180,8 +180,6 @@ class ToolRegistry:
                 }
                 if c in symbols:
                     return symbols[c]
-                if c.startswith("S$"):
-                    return "SGD"
                 if c.endswith("$"):
                     prefix = c[:-1].strip()
                     if prefix in exchange_rates:

--- a/chapter1/context/agent.py
+++ b/chapter1/context/agent.py
@@ -143,16 +143,6 @@ class ToolRegistry:
             Dictionary with conversion result
         """
         try:
-            # Normalize currency codes (handle S$ / $ notation). Must be
-            # unconditional: gated on startswith("S$"), the "$" -> USD
-            # replacement could never fire (no "$" survives the S$ replace).
-            from_currency = from_currency.upper().replace("S$", "SGD").replace("$", "USD")
-            to_currency = to_currency.upper().replace("S$", "SGD").replace("$", "USD")
-            
-            logger.info(f"Converting {amount} {from_currency} to {to_currency}")
-            
-            # For demonstration, using fixed rates (in production, use a real API)
-            # These are example rates - you would normally fetch from an API
             exchange_rates = {
                 "USD": 1.0,
                 "EUR": 0.92,
@@ -165,6 +155,49 @@ class ToolRegistry:
                 "INR": 83.12,
                 "SGD": 1.34
             }
+
+            def _normalize_code(code: str) -> str:
+                if not isinstance(code, str):
+                    return str(code or "")
+                c = code.strip().upper()
+                symbols = {
+                    "$": "USD",
+                    "US$": "USD",
+                    "U.S.$": "USD",
+                    "USD$": "USD",
+                    "S$": "SGD",
+                    "SG$": "SGD",
+                    "SGD$": "SGD",
+                    "A$": "AUD",
+                    "AU$": "AUD",
+                    "AUD$": "AUD",
+                    "C$": "CAD",
+                    "CA$": "CAD",
+                    "CAD$": "CAD",
+                    "€": "EUR",
+                    "£": "GBP",
+                    "₹": "INR",
+                }
+                if c in symbols:
+                    return symbols[c]
+                if c.startswith("S$"):
+                    return "SGD"
+                if c.endswith("$"):
+                    prefix = c[:-1].strip()
+                    if prefix in exchange_rates:
+                        return prefix
+                    if prefix in ("US", "U.S."):
+                        return "USD"
+                    if prefix in ("AU", "A"):
+                        return "AUD"
+                    if prefix in ("CA", "C"):
+                        return "CAD"
+                return c
+
+            from_currency = _normalize_code(from_currency)
+            to_currency = _normalize_code(to_currency)
+            
+            logger.info(f"Converting {amount} {from_currency} to {to_currency}")
             
             if from_currency not in exchange_rates or to_currency not in exchange_rates:
                 return {"error": f"Unsupported currency: {from_currency} or {to_currency}"}

--- a/chapter1/context/test_agent.py
+++ b/chapter1/context/test_agent.py
@@ -40,6 +40,23 @@ class TestToolRegistry(unittest.TestCase):
         self.assertIn("exchange_rate", result)
         self.assertGreater(result["converted_amount"], 0)
         
+        # Currency symbol normalization (US$, S$, A$, C$, $)
+        result_us = tools.convert_currency(100, "US$", "EUR")
+        self.assertEqual(result_us["from_currency"], "USD")
+        self.assertEqual(result_us["converted_amount"], 92.0)
+
+        result_s = tools.convert_currency(100, "S$", "USD")
+        self.assertEqual(result_s["from_currency"], "SGD")
+        self.assertIn("converted_amount", result_s)
+
+        result_a = tools.convert_currency(100, "A$", "USD")
+        self.assertEqual(result_a["from_currency"], "AUD")
+        self.assertIn("converted_amount", result_a)
+
+        result_c = tools.convert_currency(100, "C$", "USD")
+        self.assertEqual(result_c["from_currency"], "CAD")
+        self.assertIn("converted_amount", result_c)
+
         # Invalid currency
         result = tools.convert_currency(100, "XXX", "YYY")
         self.assertIn("error", result)

--- a/chapter1/context/test_agent.py
+++ b/chapter1/context/test_agent.py
@@ -60,6 +60,8 @@ class TestToolRegistry(unittest.TestCase):
         # Invalid currency
         result = tools.convert_currency(100, "XXX", "YYY")
         self.assertIn("error", result)
+        result_invalid_s = tools.convert_currency(100, "S$INVALID", "USD")
+        self.assertIn("error", result_invalid_s)
     
     def test_pdf_parser_structure(self):
         """Test PDF parser structure (without actual PDF)"""


### PR DESCRIPTION
ToolRegistry.convert_currency raised KeyError when currency codes contained dollar suffixes like US$ or AU$.

Normalize prefixed dollar currency codes before looking up conversion rates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 货币转换支持更多货币符号和常见写法，包括美元、新加坡元、澳元、加元、欧元、英镑及卢比等。
  * 自动规范化货币输入格式，提升不同符号和代码组合下的转换准确性。

* **测试**
  * 增加多种货币符号转换场景的验证，确保货币代码和转换结果正确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->