### PR TITLE
fix(prompt-engineering): fix dict hash collisions in hash_item

### DIFF
--- a/chapter2/prompt-engineering/tau_bench/model_utils/api/cache.py
+++ b/chapter2/prompt-engineering/tau_bench/model_utils/api/cache.py
@@ -46,18 +46,10 @@ def enable_cache():
 
 def hash_item(item: Any) -> Any:
     if isinstance(item, dict):
-        entries = ((hash_item(key), hash_item(value)) for key, value in item.items())
         return (
             "dict",
-            tuple(
-                sorted(
-                    entries,
-                    key=lambda entry: (
-                        type(entry[0]).__module__,
-                        type(entry[0]).__qualname__,
-                        repr(entry[0]),
-                    ),
-                )
+            frozenset(
+                (hash_item(key), hash_item(value)) for key, value in item.items()
             ),
         )
     elif isinstance(item, list):
@@ -65,12 +57,7 @@ def hash_item(item: Any) -> Any:
     elif isinstance(item, set):
         return (
             "set",
-            tuple(
-                sorted(
-                    (hash_item(x) for x in item),
-                    key=lambda x: (type(x).__module__, type(x).__qualname__, repr(x)),
-                )
-            ),
+            frozenset(hash_item(x) for x in item),
         )
     elif isinstance(item, tuple):
         return ("tuple", tuple(hash_item(x) for x in item))

--- a/chapter2/prompt-engineering/tau_bench/model_utils/api/cache.py
+++ b/chapter2/prompt-engineering/tau_bench/model_utils/api/cache.py
@@ -29,18 +29,18 @@ def enable_cache():
         USE_CACHE = True
 
 
-def hash_item(item: Any) -> int:
+def hash_item(item: Any) -> Any:
     if isinstance(item, dict):
-        return hash(tuple((k, hash_item(v)) for k, v in sorted(item.items())))
+        return tuple((k, hash_item(v)) for k, v in sorted(item.items()))
     elif isinstance(item, list):
-        return hash(tuple([hash_item(x) for x in item]))
+        return tuple(hash_item(x) for x in item)
     elif isinstance(item, set):
-        return hash(frozenset([hash_item(x) for x in item]))
+        return tuple(sorted((hash_item(x) for x in item), key=lambda x: str(x)))
     elif isinstance(item, tuple):
-        return hash(tuple([hash_item(x) for x in item]))
+        return tuple(hash_item(x) for x in item)
     elif isinstance(item, BaseModel):
-        return hash_item(item.model_json_schema())
-    return hash(item)
+        return hash_item(item.model_dump() if hasattr(item, "model_dump") else item.dict())
+    return item
 
 
 def hash_func_call(func: Callable[..., Any], args: tuple[Any], kwargs: dict[str, Any]) -> str:

--- a/chapter2/prompt-engineering/tau_bench/model_utils/api/cache.py
+++ b/chapter2/prompt-engineering/tau_bench/model_utils/api/cache.py
@@ -93,6 +93,7 @@ def hash_func_call(
     standardized_args = sorted(bound_args.arguments.items())
     return _CallableIdentity(func), hash_item(standardized_args)
 
+
 def cache_call_w_dedup(func: Callable[..., T]) -> Callable[..., T]:
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> T:

--- a/chapter2/prompt-engineering/tau_bench/model_utils/api/cache.py
+++ b/chapter2/prompt-engineering/tau_bench/model_utils/api/cache.py
@@ -31,15 +31,42 @@ def enable_cache():
 
 def hash_item(item: Any) -> Any:
     if isinstance(item, dict):
-        return tuple((k, hash_item(v)) for k, v in sorted(item.items()))
+        entries = ((hash_item(key), hash_item(value)) for key, value in item.items())
+        return (
+            "dict",
+            tuple(
+                sorted(
+                    entries,
+                    key=lambda entry: (
+                        type(entry[0]).__module__,
+                        type(entry[0]).__qualname__,
+                        repr(entry[0]),
+                    ),
+                )
+            ),
+        )
     elif isinstance(item, list):
-        return tuple(hash_item(x) for x in item)
+        return ("list", tuple(hash_item(x) for x in item))
     elif isinstance(item, set):
-        return tuple(sorted((hash_item(x) for x in item), key=lambda x: str(x)))
+        return (
+            "set",
+            tuple(
+                sorted(
+                    (hash_item(x) for x in item),
+                    key=lambda x: (type(x).__module__, type(x).__qualname__, repr(x)),
+                )
+            ),
+        )
     elif isinstance(item, tuple):
-        return tuple(hash_item(x) for x in item)
+        return ("tuple", tuple(hash_item(x) for x in item))
     elif isinstance(item, BaseModel):
-        return hash_item(item.model_dump() if hasattr(item, "model_dump") else item.dict())
+        values = item.model_dump() if hasattr(item, "model_dump") else item.dict()
+        return (
+            "model",
+            type(item).__module__,
+            type(item).__qualname__,
+            hash_item(values),
+        )
     return item
 
 
@@ -48,7 +75,7 @@ def hash_func_call(func: Callable[..., Any], args: tuple[Any], kwargs: dict[str,
     bound_args.apply_defaults()
     standardized_args = sorted(bound_args.arguments.items())
     arg_hash = hash_item(standardized_args)
-    hashed_func = getattr(func, "__qualname__", getattr(func, "__name__", str(func)))
+    hashed_func = id(func)
     call = (hashed_func, arg_hash)
     return hashlib.md5(str(call).encode()).hexdigest()
 

--- a/chapter2/prompt-engineering/tau_bench/model_utils/api/cache.py
+++ b/chapter2/prompt-engineering/tau_bench/model_utils/api/cache.py
@@ -48,10 +48,9 @@ def hash_func_call(func: Callable[..., Any], args: tuple[Any], kwargs: dict[str,
     bound_args.apply_defaults()
     standardized_args = sorted(bound_args.arguments.items())
     arg_hash = hash_item(standardized_args)
-    hashed_func = id(func)
+    hashed_func = getattr(func, "__qualname__", getattr(func, "__name__", str(func)))
     call = (hashed_func, arg_hash)
     return hashlib.md5(str(call).encode()).hexdigest()
-
 
 def cache_call_w_dedup(func: Callable[..., T]) -> Callable[..., T]:
     @functools.wraps(func)

--- a/chapter2/prompt-engineering/tau_bench/model_utils/api/cache.py
+++ b/chapter2/prompt-engineering/tau_bench/model_utils/api/cache.py
@@ -1,5 +1,4 @@
 import functools
-import hashlib
 import inspect
 import threading
 from collections import defaultdict
@@ -10,9 +9,25 @@ from pydantic import BaseModel
 
 T = TypeVar("T")
 
+
+class _CallableIdentity:
+    __slots__ = ("func",)
+
+    def __init__(self, func: Callable[..., Any]):
+        self.func = func
+
+    def __hash__(self) -> int:
+        return id(self.func)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _CallableIdentity) and self.func is other.func
+
+
+CacheKey = tuple[_CallableIdentity, Any]
+
 USE_CACHE = True
 _USE_CACHE_LOCK = Lock()
-cache: dict[str, tuple[T, threading.Event]] = {}
+cache: dict[CacheKey, tuple[T, threading.Event]] = {}
 lock = threading.Lock()
 conditions = defaultdict(threading.Condition)
 
@@ -70,14 +85,13 @@ def hash_item(item: Any) -> Any:
     return item
 
 
-def hash_func_call(func: Callable[..., Any], args: tuple[Any], kwargs: dict[str, Any]) -> str:
+def hash_func_call(
+    func: Callable[..., Any], args: tuple[Any], kwargs: dict[str, Any]
+) -> CacheKey:
     bound_args = inspect.signature(func).bind(*args, **kwargs)
     bound_args.apply_defaults()
     standardized_args = sorted(bound_args.arguments.items())
-    arg_hash = hash_item(standardized_args)
-    hashed_func = id(func)
-    call = (hashed_func, arg_hash)
-    return hashlib.md5(str(call).encode()).hexdigest()
+    return _CallableIdentity(func), hash_item(standardized_args)
 
 def cache_call_w_dedup(func: Callable[..., T]) -> Callable[..., T]:
     @functools.wraps(func)

--- a/chapter2/prompt-engineering/tau_bench/model_utils/api/cache.py
+++ b/chapter2/prompt-engineering/tau_bench/model_utils/api/cache.py
@@ -31,7 +31,7 @@ def enable_cache():
 
 def hash_item(item: Any) -> int:
     if isinstance(item, dict):
-        return hash(tuple({k: hash_item(v) for k, v in sorted(item.items())}))
+        return hash(tuple((k, hash_item(v)) for k, v in sorted(item.items())))
     elif isinstance(item, list):
         return hash(tuple([hash_item(x) for x in item]))
     elif isinstance(item, set):

--- a/chapter2/prompt-engineering/test_hash_item_dict_collision.py
+++ b/chapter2/prompt-engineering/test_hash_item_dict_collision.py
@@ -69,3 +69,19 @@ def test_cache_distinguishes_same_named_function_instances():
 
     assert lookup_a(7) == ("a", 7)
     assert lookup_b(7) == ("b", 7)
+
+
+def test_cache_distinguishes_nan_dictionary_keys():
+    calls = 0
+
+    @cache_call_w_dedup
+    def lookup(value):
+        nonlocal calls
+        calls += 1
+        return calls, value
+
+    first_result = lookup({float("nan"): "value"})
+    second_result = lookup({float("nan"): "value"})
+
+    assert first_result[0] == 1
+    assert second_result[0] == 2

--- a/chapter2/prompt-engineering/test_hash_item_dict_collision.py
+++ b/chapter2/prompt-engineering/test_hash_item_dict_collision.py
@@ -7,6 +7,22 @@ from tau_bench.model_utils.api.cache import (
 )
 
 
+class SameReprKey:
+    """Hashable key whose representation intentionally carries no identity."""
+
+    def __init__(self, value):
+        self.value = value
+
+    def __hash__(self):
+        return 0
+
+    def __eq__(self, other):
+        return isinstance(other, SameReprKey) and self.value == other.value
+
+    def __repr__(self):
+        return "SameReprKey()"
+
+
 @pytest.fixture(autouse=True)
 def clear_cache():
     cache.clear()
@@ -42,6 +58,38 @@ def test_hash_item_dict_heterogeneous_keys_is_order_independent():
     dict1 = {1: "integer", "1": "string", (1,): "tuple"}
     dict2 = {(1,): "tuple", "1": "string", 1: "integer"}
     assert hash_item(dict1) == hash_item(dict2)
+
+
+def test_cache_dict_same_repr_keys_is_order_independent():
+    """Equal dictionaries deduplicate even when the key sort identities collide."""
+    calls = 0
+    first_key = SameReprKey("first")
+    second_key = SameReprKey("second")
+    dict1 = {first_key: 1, second_key: 2}
+    dict2 = {second_key: 2, first_key: 1}
+
+    @cache_call_w_dedup
+    def lookup(value):
+        nonlocal calls
+        calls += 1
+        return calls, value
+
+    assert dict1 == dict2
+    assert hash_item(dict1) == hash_item(dict2)
+    assert lookup(dict1)[0] == 1
+    assert lookup(dict2)[0] == 1
+    assert calls == 1
+
+
+def test_hash_item_set_same_repr_members_is_order_independent():
+    """Equal sets normalize identically when member sort identities collide."""
+    first = SameReprKey("first")
+    second = SameReprKey("second")
+    set1 = {first, second}
+    set2 = {second, first}
+
+    assert set1 == set2
+    assert hash_item(set1) == hash_item(set2)
 
 
 def test_hash_item_dict_distinguishes_heterogeneous_key_types():

--- a/chapter2/prompt-engineering/test_hash_item_dict_collision.py
+++ b/chapter2/prompt-engineering/test_hash_item_dict_collision.py
@@ -17,30 +17,35 @@ def clear_cache():
 
 
 def test_hash_item_dict_different_values():
+    """Different values under one key must not share a canonical identity."""
     dict1 = {"a": 1}
     dict2 = {"a": 2}
     assert hash_item(dict1) != hash_item(dict2)
 
 
 def test_hash_item_dict_different_key_value_pairs():
+    """Reassigning values across keys must change dictionary identity."""
     dict1 = {"a": 1, "b": 2}
     dict2 = {"a": 2, "b": 1}
     assert hash_item(dict1) != hash_item(dict2)
 
 
 def test_hash_item_dict_nested_different_values():
+    """Differences in recursively nested values must remain observable."""
     dict1 = {"a": {"items": [1, {"value": "first"}]}}
     dict2 = {"a": {"items": [1, {"value": "second"}]}}
     assert hash_item(dict1) != hash_item(dict2)
 
 
 def test_hash_item_dict_heterogeneous_keys_is_order_independent():
+    """Mixed key types must normalize independently of insertion order."""
     dict1 = {1: "integer", "1": "string", (1,): "tuple"}
     dict2 = {(1,): "tuple", "1": "string", 1: "integer"}
     assert hash_item(dict1) == hash_item(dict2)
 
 
 def test_hash_item_dict_distinguishes_heterogeneous_key_types():
+    """Textually similar keys of different types must not collide."""
     assert hash_item({1: "value"}) != hash_item({"1": "value"})
 
 
@@ -53,10 +58,12 @@ def test_hash_item_dict_distinguishes_heterogeneous_key_types():
     ],
 )
 def test_hash_item_preserves_container_type(item1, item2):
+    """List/tuple, set/tuple, and dict/tuple inputs must remain distinct."""
     assert hash_item(item1) != hash_item(item2)
 
 
 def test_cache_distinguishes_same_named_function_instances():
+    """Distinct same-named callables must never share cached results."""
     def make_lookup(prefix):
         @cache_call_w_dedup
         def lookup(value):
@@ -72,6 +79,7 @@ def test_cache_distinguishes_same_named_function_instances():
 
 
 def test_cache_distinguishes_nan_dictionary_keys():
+    """Unequal NaN keys with identical text must not share cached results."""
     calls = 0
 
     @cache_call_w_dedup

--- a/chapter2/prompt-engineering/test_hash_item_dict_collision.py
+++ b/chapter2/prompt-engineering/test_hash_item_dict_collision.py
@@ -1,5 +1,19 @@
 import pytest
-from tau_bench.model_utils.api.cache import hash_item
+from tau_bench.model_utils.api.cache import (
+    cache,
+    cache_call_w_dedup,
+    conditions,
+    hash_item,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache.clear()
+    conditions.clear()
+    yield
+    cache.clear()
+    conditions.clear()
 
 
 def test_hash_item_dict_different_values():
@@ -12,3 +26,46 @@ def test_hash_item_dict_different_key_value_pairs():
     dict1 = {"a": 1, "b": 2}
     dict2 = {"a": 2, "b": 1}
     assert hash_item(dict1) != hash_item(dict2)
+
+
+def test_hash_item_dict_nested_different_values():
+    dict1 = {"a": {"items": [1, {"value": "first"}]}}
+    dict2 = {"a": {"items": [1, {"value": "second"}]}}
+    assert hash_item(dict1) != hash_item(dict2)
+
+
+def test_hash_item_dict_heterogeneous_keys_is_order_independent():
+    dict1 = {1: "integer", "1": "string", (1,): "tuple"}
+    dict2 = {(1,): "tuple", "1": "string", 1: "integer"}
+    assert hash_item(dict1) == hash_item(dict2)
+
+
+def test_hash_item_dict_distinguishes_heterogeneous_key_types():
+    assert hash_item({1: "value"}) != hash_item({"1": "value"})
+
+
+@pytest.mark.parametrize(
+    ("item1", "item2"),
+    [
+        ([1, 2], (1, 2)),
+        ({1, 2}, (1, 2)),
+        ({"a": 1}, (("a", 1),)),
+    ],
+)
+def test_hash_item_preserves_container_type(item1, item2):
+    assert hash_item(item1) != hash_item(item2)
+
+
+def test_cache_distinguishes_same_named_function_instances():
+    def make_lookup(prefix):
+        @cache_call_w_dedup
+        def lookup(value):
+            return prefix, value
+
+        return lookup
+
+    lookup_a = make_lookup("a")
+    lookup_b = make_lookup("b")
+
+    assert lookup_a(7) == ("a", 7)
+    assert lookup_b(7) == ("b", 7)

--- a/chapter2/prompt-engineering/test_hash_item_dict_collision.py
+++ b/chapter2/prompt-engineering/test_hash_item_dict_collision.py
@@ -1,0 +1,14 @@
+import pytest
+from tau_bench.model_utils.api.cache import hash_item
+
+
+def test_hash_item_dict_different_values():
+    dict1 = {"a": 1}
+    dict2 = {"a": 2}
+    assert hash_item(dict1) != hash_item(dict2)
+
+
+def test_hash_item_dict_different_key_value_pairs():
+    dict1 = {"a": 1, "b": 2}
+    dict2 = {"a": 2, "b": 1}
+    assert hash_item(dict1) != hash_item(dict2)


### PR DESCRIPTION
Dict comprehension in hash_item hashed keys instead of key-value pairs, causing dictionaries with identical keys but different values to hash to the same value.

Include key-value tuples when recursively hashing dictionary items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进字典和集合等复杂数据的缓存键生成，降低因哈希碰撞、相同表示或特殊键值导致的错误缓存命中。
  * 强化函数调用缓存的区分逻辑，避免不同函数实例或不相等参数错误共享缓存结果。

* **Tests**
  * 新增哈希碰撞、嵌套容器、顺序无关性及特殊数值键的覆盖测试。
  * 扩展缓存隔离与去重场景验证，确保相似输入仍能正确区分。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->