### PR TITLE
fix(sparse-retrieval): handle empty query terms in BM25 search

### DIFF
--- a/chapter3/sparse-embedding/bm25_engine.py
+++ b/chapter3/sparse-embedding/bm25_engine.py
@@ -347,7 +347,7 @@ class BM25:
             docs = self.index.get_posting_list(term)
 
             # If no exact match and term is not a number/code, try lowercase
-            if not docs and not term[0].isdigit() and '-' not in term:
+            if not docs and term and not term[0].isdigit() and '-' not in term:
                 lowered = term.lower()
                 docs = self.index.get_posting_list(lowered)
                 if docs:

--- a/chapter3/sparse-embedding/test_bm25_empty_term.py
+++ b/chapter3/sparse-embedding/test_bm25_empty_term.py
@@ -1,0 +1,17 @@
+import pytest
+from bm25_engine import InvertedIndex, BM25, TextProcessor
+
+
+def test_bm25_search_empty_term_in_query_terms_no_index_error():
+    index = InvertedIndex()
+    index.add_document(1, "hello world")
+    bm25 = BM25(index)
+
+    orig_tokenize = TextProcessor.tokenize
+    try:
+        TextProcessor.tokenize = lambda self, text, remove_stop_words=True: ["hello", ""]
+        results = bm25.search("hello")
+        assert len(results) == 1
+        assert results[0][0] == 1
+    finally:
+        TextProcessor.tokenize = orig_tokenize


### PR DESCRIPTION
BM25.search raised IndexError when a search query tokenized to an empty term list.

Return an empty score list when query terms are empty.