### PR TITLE
fix(perception-tools): clamp negative top_k in search_knowledge_base

### DIFF
--- a/chapter4/perception-tools/src/search_tools.py
+++ b/chapter4/perception-tools/src/search_tools.py
@@ -370,7 +370,7 @@ async def search_knowledge_base(
         
         # Sort by relevance and limit
         results.sort(key=lambda x: x["relevance"], reverse=True)
-        results = results[:top_k]
+        results = results[:max(0, top_k)]
         
         logging.info(f"✅ Found {len(results)} results")
         

--- a/chapter4/perception-tools/test_search_kb_negative_top_k.py
+++ b/chapter4/perception-tools/test_search_kb_negative_top_k.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+import pytest
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+from search_tools import search_knowledge_base
+
+
+@pytest.mark.asyncio
+async def test_search_knowledge_base_negative_top_k(tmp_path: Path):
+    (tmp_path / "doc1.txt").write_text("test content one", encoding="utf-8")
+    (tmp_path / "doc2.txt").write_text("test content two", encoding="utf-8")
+
+    res = await search_knowledge_base("test", str(tmp_path), top_k=-1)
+    payload = json.loads(res.text)
+    assert payload["success"] is True
+    assert payload["message"]["total_found"] == 0
+    assert payload["message"]["results"] == []


### PR DESCRIPTION
Passing a negative top_k parameter to search_knowledge_base inverted list slice offsets.

Clamp top_k to non-negative values before slicing search results.