### PR TITLE
fix(async-agent): handle null receipt fields in TaskManager.restore

### DIFF
--- a/chapter4/async-agent/events.py
+++ b/chapter4/async-agent/events.py
@@ -82,8 +82,10 @@ class Event:
     @classmethod
     def from_dict(cls, d: dict) -> "Event":
         """从检查点字典还原事件对象。"""
+        raw_ts = d.get("ts")
         return cls(
-            type=d["type"], message=d.get("message"), label=d.get("label", ""),
+            type=d["type"], message=d.get("message"),
+            label=d.get("label") or "",
             task_id=d.get("task_id"), urgency=d.get("urgency"),
-            ts=d.get("ts", time.time()),
+            ts=raw_ts if raw_ts is not None else time.time(),
         )

--- a/chapter4/async-agent/tasks.py
+++ b/chapter4/async-agent/tasks.py
@@ -265,14 +265,15 @@ class TaskManager:
     def restore(self, records: list[dict]) -> None:
         for record in records:
             status = "suspended" if record["status"] == "running" else record["status"]
+            receipt = record.get("executable_receipt")
             state = TaskState(
                 task_id=record["task_id"], command=record["command"],
                 rate=record["rate"], progress=record["progress"], status=status,
-                result=record.get("result", ""), pid=record.get("pid"),
+                result=record.get("result") or "", pid=record.get("pid"),
                 returncode=record.get("returncode"),
                 started_at=record.get("started_at"), completed_at=record.get("completed_at"),
                 stdout_sha256=record.get("stdout_sha256"),
-                executable_receipt=record.get("executable_receipt", {}),
+                executable_receipt=receipt if isinstance(receipt, dict) else {},
             )
             self._tasks[state.task_id] = state
             try:

--- a/chapter4/async-agent/test_checkpoint_robustness.py
+++ b/chapter4/async-agent/test_checkpoint_robustness.py
@@ -51,3 +51,51 @@ def test_load_checkpoint_handles_null_tasks_and_trajectory():
         assert len(runtime.trajectory) == 0
         assert len(runtime.tasks._tasks) == 0
         runtime.log.assert_called_once()
+
+def test_load_checkpoint_handles_null_task_fields_and_event_fields():
+    """
+    Ensure load_checkpoint gracefully handles JSON containing null fields in
+    task records and trajectory events without setting None for non-optional attributes.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        target_path = os.path.join(tmpdir, "checkpoint.json")
+        checkpoint_data = {
+            'trajectory': [
+                {
+                    'type': 'user.input',
+                    'message': {'role': 'user', 'content': 'hello'},
+                    'label': None,
+                    'ts': None,
+                }
+            ],
+            'tasks': [
+                {
+                    'task_id': 'T1',
+                    'command': 'python analyze_logs.py',
+                    'rate': 50.0,
+                    'progress': 100.0,
+                    'status': 'completed',
+                    'result': None,
+                    'executable_receipt': None,
+                }
+            ]
+        }
+        with open(target_path, "w", encoding="utf-8") as f:
+            json.dump(checkpoint_data, f)
+
+        runtime = AgentRuntime.__new__(AgentRuntime)
+        runtime.tasks = TaskManager(on_complete=MagicMock(), log=MagicMock())
+        runtime.log = MagicMock()
+
+        runtime.load_checkpoint(target_path)
+
+        ev = runtime.trajectory[0]
+        assert isinstance(ev.label, str)
+        assert ev.label == ""
+        assert isinstance(ev.ts, float)
+
+        st = runtime.tasks.query('T1')
+        assert isinstance(st.result, str)
+        assert st.result == ""
+        assert isinstance(st.executable_receipt, dict)
+        assert st.executable_receipt == {}


### PR DESCRIPTION
TaskManager.restore raised AttributeError when checkpoint records contained null executable_receipt fields.

Safely fallback null receipt fields to empty records during state restoration.