### PR TITLE
fix(code-for-math): handle empty rows in paired_statistics without ZeroDivisionError

### DIFF
--- a/chapter5/code-for-math/demo.py
+++ b/chapter5/code-for-math/demo.py
@@ -474,9 +474,9 @@ def paired_statistics(rows):
     n = len(rows)
     cot_ok = sum(r["cot_ok"] for r in rows)
     code_ok = sum(r["code_ok"] for r in rows)
-    cot_accuracy = cot_ok / n
-    code_accuracy = code_ok / n
-    library_rate = sum(r["used_math_library"] for r in rows) / n
+    cot_accuracy = cot_ok / n if n > 0 else 0.0
+    code_accuracy = code_ok / n if n > 0 else 0.0
+    library_rate = sum(r["used_math_library"] for r in rows) / n if n > 0 else 0.0
     return {
         "test": "two-sided exact McNemar/binomial test on discordant pairs",
         "n": n,

--- a/chapter5/code-for-math/test_campaign.py
+++ b/chapter5/code-for-math/test_campaign.py
@@ -64,3 +64,11 @@ def test_completion_requires_exact_30_task_two_arm_evidence():
     result = campaign_completion(rows, "both", manifest)
     assert result["status"] == "incomplete"
     assert result["checks"]["every_code_trajectory_called_real_sandbox"] is False
+
+
+def test_paired_statistics_empty_rows():
+    result = paired_statistics([])
+    assert result["n"] == 0
+    assert result["cot_accuracy"] == 0.0
+    assert result["code_accuracy"] == 0.0
+    assert result["math_library_use_rate"] == 0.0


### PR DESCRIPTION
paired_statistics raised ZeroDivisionError when passed an empty list of sample rows.

Return zeroed statistics when sample rows are empty.