### PR TITLE
fix(model-benchmark): format None uptime and success_rate as dash in markdown report

### DIFF
--- a/chapter6/model-benchmark/analysis.py
+++ b/chapter6/model-benchmark/analysis.py
@@ -749,6 +749,12 @@ def fmt(value: Any, digits: int = 3) -> str:
     return str(value)
 
 
+def fmt_pct(value: float | None, digits: int = 1) -> str:
+    if value is None:
+        return "—"
+    return f"{value:.{digits}%}"
+
+
 def markdown(report: dict[str, Any]) -> str:
     lines = [
         f"# Experiment 6-8 campaign: `{report['campaign_id']}`",
@@ -765,12 +771,12 @@ def markdown(report: dict[str, Any]) -> str:
         ttft, e2e = row["ttft_s"], row["e2e_s"]
         lines.append(
             f"| {row['provider']} | {row['target_context_tokens']} | {row['target_output_tokens']} | "
-            f"{row['requests']} | {row['success_rate']:.1%} | "
+            f"{row['requests']} | {fmt_pct(row['success_rate'], 1)} | "
             f"{fmt(ttft['p50'])}/{fmt(ttft['p95'])}/{fmt(ttft['p99'])} | "
             f"{fmt(e2e['p50'])}/{fmt(e2e['p95'])}/{fmt(e2e['p99'])} | "
             f"{fmt(row['input_prefill_throughput_tokens_s']['p50'], 1)} | "
             f"{fmt(row['output_throughput_tokens_s']['p50'], 1)} | "
-            f"{row['output_length_attainment_rate']:.1%} | "
+            f"{fmt_pct(row['output_length_attainment_rate'], 1)} | "
             f"{fmt(row['reasoning_tokens']['p50'], 1)} | "
             f"{fmt(row['thinking_ttft_s']['p50'])} |"
         )
@@ -781,7 +787,7 @@ def markdown(report: dict[str, Any]) -> str:
     ])
     for row in report["availability"]:
         lines.append(
-            f"| {row['provider']} | {row['probes']} | {row['uptime']:.2%} | "
+            f"| {row['provider']} | {row['probes']} | {fmt_pct(row['uptime'], 2)} | "
             f"{row['outage_count']} | {fmt(row['mttr_s'])} | "
             f"{row['longest_continuous_availability_s'] / 3600:.2f} |"
         )
@@ -792,7 +798,7 @@ def markdown(report: dict[str, Any]) -> str:
     ])
     for row in report["rate_limits"]:
         lines.append(
-            f"| {row['provider']} | {row['concurrency']} | {row['success_rate']:.1%} | "
+            f"| {row['provider']} | {row['concurrency']} | {fmt_pct(row['success_rate'], 1)} | "
             f"{fmt(row['measured_rpm'], 1)} | {fmt(row['measured_input_tpm'], 1)} | "
             f"{fmt(row['measured_output_tpm'], 1)} |"
         )

--- a/chapter6/model-benchmark/test_campaign.py
+++ b/chapter6/model-benchmark/test_campaign.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
-from analysis import availability_summary, completion_audit, percentile, summarize_workloads
+from analysis import availability_summary, completion_audit, markdown, percentile, summarize_workloads
 from campaign import (
     CampaignStore,
     Observation,
@@ -360,3 +360,54 @@ def test_non_usd_pricing_requires_dated_fx_for_comparable_cost():
         status="verified_with_fx",
     )
     assert converted.usd_conversion_complete is True
+
+
+def test_markdown_tolerates_null_percentage_fields() -> None:
+    report = {
+        "campaign_id": "exp6-8-test",
+        "observation_count": 0,
+        "completion_audit": {"official_complete": False},
+        "workload": [
+            {
+                "provider": "openai",
+                "target_context_tokens": 8192,
+                "target_output_tokens": 512,
+                "requests": 0,
+                "success_rate": None,
+                "ttft_s": {"p50": None, "p95": None, "p99": None},
+                "e2e_s": {"p50": None, "p95": None, "p99": None},
+                "input_prefill_throughput_tokens_s": {"p50": None},
+                "output_throughput_tokens_s": {"p50": None},
+                "output_length_attainment_rate": None,
+                "reasoning_tokens": {"p50": None},
+                "thinking_ttft_s": {"p50": None},
+            }
+        ],
+        "availability": [
+            {
+                "provider": "openai",
+                "probes": 0,
+                "uptime": None,
+                "outage_count": 0,
+                "mttr_s": None,
+                "longest_continuous_availability_s": 0.0,
+            }
+        ],
+        "rate_limits": [
+            {
+                "provider": "openai",
+                "concurrency": 1,
+                "success_rate": None,
+                "measured_rpm": None,
+                "measured_input_tpm": None,
+                "measured_output_tpm": None,
+            }
+        ],
+        "costs": [],
+        "external_benchmark_comparison": [],
+    }
+
+    result = markdown(report)
+    assert "| openai | 8192 | 512 | 0 | — | —/—/— | —/—/— | — | — | — | — | — |" in result
+    assert "| openai | 0 | — | 0 | — | 0.00 |" in result
+    assert "| openai | 1 | — | — | — | — |" in result


### PR DESCRIPTION
Generating markdown reports raised TypeError when uptime or success_rate was None.

Format None metric values as dashes in generated markdown tables.