### PR TITLE
fix(intuitor): preserve negative sign in currency and fraction normalization

### DIFF
--- a/chapter7/Intuitor/evaluate_from_cache.py
+++ b/chapter7/Intuitor/evaluate_from_cache.py
@@ -81,13 +81,14 @@ def normalize_number(text: str) -> Optional[str]:
     text = str(text)
 
     # Evaluate \frac{a}{b} before brace stripping (else "\frac{6}{2}" becomes "frac62").
-    frac = re.search(r'\\(?:d)?frac\s*\{([^{}]+)\}\s*\{([^{}]+)\}', text)
+    frac = re.search(r'(-)?\s*\\(?:d)?frac\s*\{([^{}]+)\}\s*\{([^{}]+)\}', text)
     if frac:
         try:
-            num = float(frac.group(1).replace(",", "").strip())
-            den = float(frac.group(2).replace(",", "").strip())
+            sign = -1.0 if frac.group(1) else 1.0
+            num = float(frac.group(2).replace(",", "").replace("$", "").replace("\\$", "").strip())
+            den = float(frac.group(3).replace(",", "").replace("$", "").replace("\\$", "").strip())
             if den != 0:
-                return _format_normalized_number(num / den)
+                return _format_normalized_number(sign * (num / den))
         except ValueError:
             pass
 
@@ -102,7 +103,9 @@ def normalize_number(text: str) -> Optional[str]:
         except ValueError:
             pass
     
-    # 去除 LaTeX 符号
+    # 去除 LaTeX 及货币符号
+    text = text.replace("\\$", "")
+    text = text.replace("$", "")
     text = text.replace("\\,", "")
     text = text.replace("\\text", "")
     text = text.replace("{", "").replace("}", "")

--- a/chapter7/Intuitor/test_normalize_negative_currency.py
+++ b/chapter7/Intuitor/test_normalize_negative_currency.py
@@ -1,0 +1,20 @@
+"""Regression: negative currency formats and negative fractions must preserve negative sign."""
+
+from evaluate_from_cache import extract_and_normalize_answer, normalize_number
+
+
+def test_negative_dollar_amount():
+    assert normalize_number("-$42") == "-42"
+
+
+def test_negative_latex_dollar_amount():
+    assert normalize_number(r"-\$42") == "-42"
+
+
+def test_boxed_negative_dollar_amount():
+    assert extract_and_normalize_answer(r"\boxed{-\$42}") == "-42"
+
+
+def test_negative_latex_frac():
+    assert normalize_number(r"-\frac{6}{2}") == "-3"
+    assert normalize_number(r"-\dfrac{6}{2}") == "-3"


### PR DESCRIPTION
normalize_number stripped leading negative signs when parsing formatted currency strings.

Preserve negative sign prefixes during number normalization.