### PR TITLE
fix(prompt-auto-optimization): handle non-dict edit items in evaluate_release_gate

### DIFF
--- a/chapter8/prompt-auto-optimization/release_gate.py
+++ b/chapter8/prompt-auto-optimization/release_gate.py
@@ -31,7 +31,8 @@ def evaluate_release_gate(
     checks = {
         "patch_is_nonempty": bool(manifest.get("diff", "").strip()),
         "patch_is_auditable_old_to_new_edit": bool(manifest.get("edits")) and all(
-            isinstance(edit.get("old_str"), str) and bool(edit["old_str"])
+            isinstance(edit, dict)
+            and isinstance(edit.get("old_str"), str) and bool(edit["old_str"])
             and isinstance(edit.get("new_str"), str) and bool(edit["new_str"])
             for edit in manifest.get("edits", [])
         ),

--- a/chapter8/prompt-auto-optimization/test_release_gate_non_dict_edit.py
+++ b/chapter8/prompt-auto-optimization/test_release_gate_non_dict_edit.py
@@ -1,0 +1,16 @@
+import pytest
+from release_gate import evaluate_release_gate
+
+
+def test_evaluate_release_gate_non_dict_edit_item():
+    before = {"holdout": (5, 10), "boundary": (3, 5)}
+    after = {"holdout": (5, 10), "boundary": (4, 5)}
+    manifest = {
+        "diff": "diff text",
+        "edits": [None, "string_edit", {"old_str": "a", "new_str": "b"}],
+        "source_case_ids": ["1"],
+    }
+    result = evaluate_release_gate(before, after, manifest)
+    assert result["accepted"] is False
+    assert result["checks"]["patch_is_auditable_old_to_new_edit"] is False
+    assert result["decision"] == "reject_candidate"


### PR DESCRIPTION
evaluate_release_gate raised AttributeError when manifest edit lists contained None entries.

Filter None items before reading edit dictionary attributes.