### PR TITLE
Refresh MiniMax TTS adapter to the /v1/t2a_v2 Bearer endpoints

### DIFF
--- a/chapter6/tts-quality-eval/README.md
+++ b/chapter6/tts-quality-eval/README.md
@@ -136,7 +136,7 @@ Outputs are under `output/` (audio) and `output/results.json` (structured result
   | `openai` | `OPENAI_API_KEY` | alloy/nova…；model=tts-1 / tts-1-hd / gpt-4o-mini-tts |
   | `elevenlabs` | `ELEVENLABS_API_KEY` | voice_id；model 默认 eleven_multilingual_v2 |
   | `fishaudio` | `FISH_API_KEY`（别名 `FISHAUDIO_API_KEY`） | reference_id（留空用默认音色） |
-  | `minimax` | `MINIMAX_API_KEY` + `MINIMAX_GROUP_ID` | voice_id；model 默认 speech-01-turbo |
+  | `minimax` | `MINIMAX_API_KEY`（可选 `MINIMAX_REGION`） | voice_id；model 默认 speech-2.8-hd（另有 speech-2.8-turbo） |
   | `doubao` | `DOUBAO_APP_ID` + `DOUBAO_ACCESS_TOKEN` | voice_type |
 
   > 说明：本仓库仅 **OpenAI** 路径经端到端验证；其余四家按各自公开 REST 文档实现，请用自己

--- a/chapter6/tts-quality-eval/config.py
+++ b/chapter6/tts-quality-eval/config.py
@@ -101,8 +101,9 @@ PROVIDERS = {
         "voice=reference_id（留空用默认音色），走 /v1/tts；key 亦可用别名 FISHAUDIO_API_KEY。",
     ),
     "minimax": ProviderInfo(
-        "minimax", "Minimax", ("MINIMAX_API_KEY", "MINIMAX_GROUP_ID"),
-        "voice=voice_id，model 默认 speech-01-turbo；需额外 GroupId。",
+        "minimax", "Minimax", ("MINIMAX_API_KEY",),
+        "voice=voice_id，model 默认 speech-2.8-hd（另有 speech-2.8-turbo）；Bearer 鉴权，"
+        "MINIMAX_REGION 选 global(api.minimax.io)/cn(api.minimaxi.com)。",
     ),
     "doubao": ProviderInfo(
         "doubao", "豆包（火山引擎）", ("DOUBAO_APP_ID", "DOUBAO_ACCESS_TOKEN"),
@@ -126,8 +127,8 @@ PROVIDER_CONFIGS = {
         model="s1",
         voice=os.getenv("FISH_REFERENCE_ID", "6df3c1e14c9440e9ac978556536bf116"),
     ),
-    "minimax": TTSConfig("minimax-turbo", provider="minimax",
-                        model="speech-01-turbo", voice="male-qn-qingse"),
+    "minimax": TTSConfig("minimax-hd", provider="minimax",
+                        model="speech-2.8-hd", voice="male-qn-qingse"),
     "doubao": TTSConfig("doubao-tts", provider="doubao",
                        model="volcano_tts", voice="zh_female_qingxin"),
 }

--- a/chapter6/tts-quality-eval/env.example
+++ b/chapter6/tts-quality-eval/env.example
@@ -15,7 +15,7 @@ OPENAI_API_KEY=sk-your-openai-key
 # 未配置的 provider 对应的行会被记为失败，不影响整表。逐项见 `python demo.py --list-providers`。
 # ELEVENLABS_API_KEY=your-elevenlabs-key
 # FISH_API_KEY=your-fishaudio-key            # 亦兼容别名 FISHAUDIO_API_KEY
-# MINIMAX_API_KEY=your-minimax-key
-# MINIMAX_GROUP_ID=your-minimax-group-id
+# MINIMAX_API_KEY=your-minimax-key           # Bearer 鉴权，model 默认 speech-2.8-hd
+# MINIMAX_REGION=global                       # 可选：global->api.minimax.io，cn->api.minimaxi.com
 # DOUBAO_APP_ID=your-volcengine-app-id
 # DOUBAO_ACCESS_TOKEN=your-volcengine-access-token

--- a/chapter6/tts-quality-eval/pipeline.py
+++ b/chapter6/tts-quality-eval/pipeline.py
@@ -178,24 +178,51 @@ def _synth_fishaudio(cfg: config.TTSConfig, text: str) -> bytes:
     return b"".join(Session(key).tts(request, backend=cfg.model or "s1"))
 
 
+# Minimax /v1/t2a_v2 uses Bearer auth and no longer takes a GroupId query
+# parameter.  The global and mainland-China deployments live on separate hosts;
+# pick one via MINIMAX_REGION (defaults to the global api.minimax.io host).
+_MINIMAX_T2A_ENDPOINTS = {
+    "global": "https://api.minimax.io/v1/t2a_v2",
+    "cn": "https://api.minimaxi.com/v1/t2a_v2",
+}
+# Success criteria for the non-streaming t2a_v2 call: base_resp.status_code == 0
+# (request accepted) and data.status == 2 (synthesis finished).
+_MINIMAX_SUCCESS_CODE = 0
+_MINIMAX_STATUS_DONE = 2
+
+
+def _minimax_endpoint() -> str:
+    """Return the t2a_v2 endpoint for MINIMAX_REGION: cn -> api.minimaxi.com,
+    otherwise the global api.minimax.io host."""
+    region = os.environ.get("MINIMAX_REGION", "").strip().lower()
+    if region in ("cn", "cn_zh", "china", "minimaxi"):
+        return _MINIMAX_T2A_ENDPOINTS["cn"]
+    return _MINIMAX_T2A_ENDPOINTS["global"]
+
+
 def _synth_minimax(cfg: config.TTSConfig, text: str) -> bytes:
     key = _require_env("MINIMAX_API_KEY")
-    group = _require_env("MINIMAX_GROUP_ID")
-    url = f"https://api.minimax.chat/v1/t2a_v2?GroupId={group}"
     body = {
-        "model": cfg.model or "speech-01-turbo",
+        "model": cfg.model or "speech-2.8-hd",
         "text": text,
         "stream": False,
         "voice_setting": {"voice_id": cfg.voice, "speed": cfg.speed},
         "audio_setting": {"format": "mp3", "sample_rate": 32000},
     }
-    raw = _http_post(url, body, {"Authorization": f"Bearer {key}"})
+    raw = _http_post(_minimax_endpoint(), body, {"Authorization": f"Bearer {key}"})
     data = json.loads(raw)
-    # 返回 JSON，音频为 data.audio（hex 编码）。
-    hexstr = (data.get("data") or {}).get("audio")
-    if not hexstr:
-        err = data.get("base_resp", {})
-        raise RuntimeError(f"Minimax 无音频返回：{err or data}")
+    # Validate the request-level return code first, then the synthesis status.
+    base_resp = data.get("base_resp") or {}
+    if base_resp.get("status_code") != _MINIMAX_SUCCESS_CODE:
+        raise RuntimeError(f"Minimax t2a_v2 failed: base_resp={base_resp or data}")
+    payload = data.get("data") or {}
+    status = payload.get("status")
+    hexstr = payload.get("audio")
+    if status != _MINIMAX_STATUS_DONE or not hexstr:
+        raise RuntimeError(
+            f"Minimax returned no finished audio: status={status} base_resp={base_resp}"
+        )
+    # data.audio is a hex-encoded mp3 payload.
     return bytes.fromhex(hexstr)
 
 

--- a/chapter6/tts-quality-eval/test_minimax_t2a_refresh.py
+++ b/chapter6/tts-quality-eval/test_minimax_t2a_refresh.py
@@ -1,0 +1,109 @@
+"""
+Regression tests for the Minimax t2a_v2 synthesis adapter (实验 6-5 TTS 质量评估).
+
+Locks in the refreshed contract:
+  - the request targets the /v1/t2a_v2 endpoint with Bearer auth and no GroupId
+    query parameter, on the global host by default and the mainland-China host
+    when MINIMAX_REGION selects it;
+  - the default model is speech-2.8-hd;
+  - the response is validated on base_resp.status_code, data.status and
+    data.audio, so a bad return code or an unfinished status raises a clear
+    RuntimeError instead of yielding empty/garbage audio.
+
+Network is stubbed: pipeline._http_post is replaced with a fake that records the
+request and returns a canned JSON body.
+"""
+import json
+
+import pytest
+
+import config
+import pipeline
+
+
+def _cfg(model="speech-2.8-hd"):
+    return config.TTSConfig("minimax-test", provider="minimax",
+                            model=model, voice="male-qn-qingse")
+
+
+def _stub_http_post(monkeypatch, response: dict):
+    """Capture the outgoing request and return a canned decoded JSON body."""
+    calls = {}
+
+    def fake_post(url, body, headers, timeout=90.0):
+        calls["url"] = url
+        calls["body"] = body
+        calls["headers"] = headers
+        return json.dumps(response).encode()
+
+    monkeypatch.setattr(pipeline, "_http_post", fake_post)
+    return calls
+
+
+def _ok_response(audio_bytes: bytes):
+    return {
+        "data": {"audio": audio_bytes.hex(), "status": pipeline._MINIMAX_STATUS_DONE},
+        "base_resp": {"status_code": pipeline._MINIMAX_SUCCESS_CODE, "status_msg": "success"},
+    }
+
+
+def test_default_endpoint_is_global_bearer_no_groupid(monkeypatch):
+    """Global host, Bearer auth, no GroupId query param, default model."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "fake-key")
+    monkeypatch.delenv("MINIMAX_REGION", raising=False)
+    calls = _stub_http_post(monkeypatch, _ok_response(b"\xff\xfb\x10\x20"))
+
+    audio = pipeline._synth_minimax(_cfg(), "你好")
+
+    assert calls["url"] == "https://api.minimax.io/v1/t2a_v2"
+    assert "GroupId" not in calls["url"]
+    assert calls["headers"]["Authorization"] == "Bearer fake-key"
+    assert calls["body"]["model"] == "speech-2.8-hd"
+    assert audio == b"\xff\xfb\x10\x20"
+
+
+def test_cn_region_uses_minimaxi_host(monkeypatch):
+    """MINIMAX_REGION=cn routes to the mainland-China api.minimaxi.com host."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "fake-key")
+    monkeypatch.setenv("MINIMAX_REGION", "cn")
+    calls = _stub_http_post(monkeypatch, _ok_response(b"\x00\x01"))
+
+    pipeline._synth_minimax(_cfg(), "你好")
+
+    assert calls["url"] == "https://api.minimaxi.com/v1/t2a_v2"
+
+
+def test_empty_model_falls_back_to_default(monkeypatch):
+    """An empty cfg.model falls back to the current default speech-2.8-hd."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "fake-key")
+    calls = _stub_http_post(monkeypatch, _ok_response(b"\x00"))
+
+    pipeline._synth_minimax(_cfg(model=""), "你好")
+
+    assert calls["body"]["model"] == "speech-2.8-hd"
+
+
+def test_nonzero_base_resp_raises(monkeypatch):
+    """base_resp.status_code != 0 raises a clear error instead of decoding junk."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "fake-key")
+    _stub_http_post(monkeypatch, {
+        "data": {},
+        "base_resp": {"status_code": 1004, "status_msg": "authentication failed"},
+    })
+    with pytest.raises(RuntimeError, match="base_resp"):
+        pipeline._synth_minimax(_cfg(), "你好")
+
+
+def test_unfinished_status_raises(monkeypatch):
+    """A non-finished data.status (with no audio) raises rather than returning empty audio."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "fake-key")
+    _stub_http_post(monkeypatch, {
+        "data": {"status": 1, "audio": ""},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    })
+    with pytest.raises(RuntimeError, match="finished audio"):
+        pipeline._synth_minimax(_cfg(), "你好")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Reason: The MiniMax TTS adapter still called the legacy api.minimax.chat endpoint with a required GroupId and defaulted to a retired model.

## What changed
- `pipeline.py`: `_synth_minimax` now posts to the `/v1/t2a_v2` endpoint with Bearer auth and no `GroupId` query parameter. A new `_minimax_endpoint()` helper selects the global `api.minimax.io` host by default and the mainland-China `api.minimaxi.com` host when `MINIMAX_REGION` requests it.
- The default synthesis model is refreshed to `speech-2.8-hd` (with `speech-2.8-turbo` documented as the other current option).
- Response handling now validates `base_resp.status_code` (success is `0`), `data.status` (must indicate a finished synthesis) and `data.audio`, raising a clear error instead of decoding an empty or partial payload.
- `config.py`: the provider registry drops the no-longer-needed `MINIMAX_GROUP_ID` requirement, and the representative config uses `speech-2.8-hd`.
- `env.example` / `README.md`: document the key-only Bearer setup, the `MINIMAX_REGION` switch, and the current default model.
- Added `test_minimax_t2a_refresh.py` covering endpoint/region selection, Bearer auth without GroupId, the default-model fallback, and the three response validations.

## Checks
- `python -m pytest -q` — 12 passed
- `python -m py_compile pipeline.py config.py test_minimax_t2a_refresh.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能更新**
  * Minimax TTS 默认模型更新为 `speech-2.8-hd`，并支持 `speech-2.8-turbo`。
  * 改用 API Key 认证，无需配置 Group ID。
  * 新增 `MINIMAX_REGION`，支持 `global` 与 `cn` 区域选择。

* **稳定性改进**
  * 完善合成结果校验，未完成或无效响应将明确报告失败。
  * 增加不同区域、默认模型及异常响应的回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->