### PR TITLE
fix: 修复 JSON cards 模式的 stringified JSON 解析

### DIFF
--- a/chapter3/user-memory/agent.py
+++ b/chapter3/user-memory/agent.py
@@ -438,25 +438,33 @@ Current Memory Context will be provided with each message."""
                 # Content should already have the structure
                 memory_content = content
             else:
-                # Parse content to extract structure
-                parts = str(content).split(':')
-                if len(parts) >= 2:
-                    category = "personal"
-                    subcategory = "info"
-                    key = parts[0].strip().replace(' ', '_').lower()
-                    value = ':'.join(parts[1:]).strip()
+                try:
+                    parsed_content = json.loads(content)
+                except (TypeError, json.JSONDecodeError):
+                    parsed_content = None
+
+                if isinstance(parsed_content, dict):
+                    memory_content = parsed_content
                 else:
-                    category = "general"
-                    subcategory = "notes"
-                    key = f"note_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-                    value = content
-                
-                memory_content = {
-                    'category': category,
-                    'subcategory': subcategory,
-                    'key': key,
-                    'value': value
-                }
+                    # Fallback for legacy "key: value" style content.
+                    parts = str(content).split(':')
+                    if len(parts) >= 2:
+                        category = "personal"
+                        subcategory = "info"
+                        key = parts[0].strip().replace(' ', '_').lower()
+                        value = ':'.join(parts[1:]).strip()
+                    else:
+                        category = "general"
+                        subcategory = "notes"
+                        key = f"note_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+                        value = content
+
+                    memory_content = {
+                        'category': category,
+                        'subcategory': subcategory,
+                        'key': key,
+                        'value': value
+                    }
             
             memory_id = self.memory_manager.add_memory(
                 content=memory_content,

--- a/chapter3/user-memory/test_json_cards_string_payload.py
+++ b/chapter3/user-memory/test_json_cards_string_payload.py
@@ -1,0 +1,37 @@
+"""Regression test for JSON cards tool payload parsing."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from agent import UserMemoryAgent
+from config import MemoryMode
+
+
+def test_json_cards_add_memory_parses_stringified_json():
+    captured = {}
+
+    class FakeMemoryManager:
+        def add_memory(self, content, session_id, **kwargs):
+            captured["content"] = content
+            captured["session_id"] = session_id
+            return "banking.first_national.checking_account_number"
+
+    agent = UserMemoryAgent.__new__(UserMemoryAgent)
+    agent.config = type("Cfg", (), {"memory_mode": MemoryMode.JSON_CARDS})()
+    agent.memory_manager = FakeMemoryManager()
+    agent.session_id = "session-test"
+
+    result = agent._tool_add_memory(
+        content='{"category": "banking", "subcategory": "first_national", "key": "checking_account_number", "value": "4429853327"}'
+    )
+
+    assert captured["session_id"] == "session-test"
+    assert captured["content"] == {
+        "category": "banking",
+        "subcategory": "first_national",
+        "key": "checking_account_number",
+        "value": "4429853327",
+    }
+    assert result["success"] is True
+    assert result["memory_id"] == "banking.first_national.checking_account_number"


### PR DESCRIPTION
## 问题

`json_cards` 模式下，`add_memory` 实际收到的是 stringified JSON，但 `agent.py` 里仍按 `:` 硬拆，导致 card key 被写坏。

## 修改

- 在 `MemoryMode.JSON_CARDS` 分支中，优先 `json.loads(content)`
- 只有解析失败时才走 legacy fallback
- 新增回归测试覆盖 stringified JSON payload

## 验证

```bash
python -m pytest test_json_cards_string_payload.py -q
```

结果：

```text
1 passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * JSON Cards 模式下，添加记忆功能现支持直接传入 JSON 对象字符串。
  * 保留原有的“键: 值”格式，提升记忆内容输入的兼容性。

* **测试**
  * 新增回归测试，验证 JSON 字符串可正确解析并保存，同时确保会话信息和记忆标识正常返回。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->