### PR TITLE
fix: 统一 LLM PII 输出为 structured pii_items

### DIFF
--- a/chapter3/log-sanitization/agent.py
+++ b/chapter3/log-sanitization/agent.py
@@ -27,6 +27,11 @@ from config import (
 from metrics import PerformanceMetrics, MetricsCollector
 
 
+def _value_appears_in_text(value: str, text: str) -> bool:
+    """Return True if *value* appears as a substring of *text* (case-insensitive)."""
+    return value.lower() in text.lower()
+
+
 class LogSanitizationAgent:
     """Agent for sanitizing logs using local Qwen3 0.6B model via Ollama"""
     
@@ -100,8 +105,8 @@ class LogSanitizationAgent:
             for chunk in stream:
                 yield chunk.get('message', {}).get('content', '')
         else:
-            # 用与 Ollama 相同的 JSON Schema 强约束输出结构（pii_values 数组），
-            # 避免模型自行发明字段名。strict 模式要求 additionalProperties=false。
+            # 用与 Ollama 相同的 JSON Schema 强约束输出结构 (pii_items 数组),
+            # 避免模型自行发明字段名. strict 模式要求 additionalProperties=false.
             strict_schema = dict(PII_DETECTION_SCHEMA)
             strict_schema["additionalProperties"] = False
             stream = self.client.chat.completions.create(
@@ -194,25 +199,38 @@ class LogSanitizationAgent:
         
         # Parse JSON response
         pii_values = []
+        accepted_items = []
         
         try:
             response_json = json.loads(full_response)
+            if not isinstance(response_json, dict):
+                return [], {}
             
-            # Extract PII values
-            pii_values = response_json.get('pii_values') or []
-            # Strip leading/trailing whitespace and special characters like '-' or empty
-            cleaned_pii_values = []
-            for pii in pii_values:
-                if pii and isinstance(pii, str):
-                    cleaned = pii.strip().strip('-').strip()
-                    if cleaned:
-                        cleaned_pii_values.append(cleaned)
-            pii_values = cleaned_pii_values
+            raw_items = response_json.get('pii_items')
+            if isinstance(raw_items, list):
+                for item in raw_items:
+                    if isinstance(item, dict):
+                        value = item.get('value')
+                        if value and isinstance(value, str) and _value_appears_in_text(value, conversation_text):
+                            pii_values.append(value)
+                            accepted_items.append(item)
+                    elif isinstance(item, str) and item and _value_appears_in_text(item, conversation_text):
+                        pii_values.append(item)
+                        accepted_items.append({"value": item})
+            else:
+                legacy_values = response_json.get('pii_values')
+                if isinstance(legacy_values, list):
+                    for pii in legacy_values:
+                        if pii and isinstance(pii, str):
+                            cleaned = pii.strip().strip('-').strip()
+                            if cleaned:
+                                pii_values.append(cleaned)
 
         except json.JSONDecodeError as e:
             print(f"\n   ⚠️  Failed to parse JSON response: {e}")
             # Fallback to simple line splitting if JSON parsing fails
             pii_values = [line.strip() for line in full_response.split('\n') if line.strip()]
+            accepted_items = []
 
         metrics = {
             'input_tokens': input_tokens,
@@ -222,7 +240,8 @@ class LogSanitizationAgent:
             'total_time_ms': total_time_ms,
             'prefill_speed_tps': prefill_speed,
             'output_speed_tps': output_speed,
-            'pii_items_found': len(pii_values)
+            'pii_items_found': len(pii_values),
+            'pii_items': accepted_items
         }
         
         return pii_values, metrics
@@ -268,6 +287,7 @@ class LogSanitizationAgent:
         
         # Detect PII
         pii_values, perf_metrics = self.detect_pii(conv_text)
+        accepted_items = perf_metrics.get('pii_items', [])
         
         if pii_values:
             print(f"   ✅ Found {len(pii_values)} PII items:")
@@ -307,6 +327,7 @@ class LogSanitizationAgent:
             'pii_found': pii_values,
             'replacements_made': replacements,
             'sanitized_text': sanitized_text,
+            'pii_items': accepted_items,
             'metrics': metric.to_dict()
         }
     

--- a/chapter3/log-sanitization/config.py
+++ b/chapter3/log-sanitization/config.py
@@ -45,7 +45,11 @@ Level 3 PII includes:
 - Usernames for Financial Accounts
 - Passwords
 
-Analyze the conversation and return a JSON with the exact PII values found. NEVER use placeholders. Simply return the PII values found."""
+Analyze the conversation and return JSON with a pii_items array. Each item must include:
+- type: the PII category label
+- value: the exact sensitive substring copied verbatim from the input text
+
+Do not include labels or explanations inside value. NEVER use placeholders."""
 
 USER_PROMPT_TEMPLATE = """Analyze the following conversation for Level 3 PII:
 
@@ -55,13 +59,26 @@ USER_PROMPT_TEMPLATE = """Analyze the following conversation for Level 3 PII:
 PII_DETECTION_SCHEMA = {
     "type": "object",
     "properties": {
-        "pii_values": {
+        "pii_items": {
             "type": "array",
             "items": {
-                "type": "string"
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "PII category label, e.g. ssn, credit_card_number, email"
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "Exact sensitive substring copied verbatim from the input text"
+                    }
+                },
+                "required": ["type", "value"],
+                "additionalProperties": False
             },
-            "description": "Array of exact PII values found in the conversation. NEVER use placeholders."
+            "description": "Array of structured PII items. The value field must be copied verbatim from the input text."
         }
     },
-    "required": ["pii_values"]
+    "required": ["pii_items"],
+    "additionalProperties": False
 }

--- a/chapter3/log-sanitization/test_sanitize_conversation.py
+++ b/chapter3/log-sanitization/test_sanitize_conversation.py
@@ -60,3 +60,80 @@ def test_working_backend_still_detects_pii(tmp_path):
     assert result["replacements_made"] == 1
     assert "[REDACTED]" in result["sanitized_text"]
     assert result["metrics"]["pii_items_found"] == 1
+
+
+def test_working_backend_with_structured_pii_items(tmp_path):
+    conv = {
+        "conversation_id": "demo_002",
+        "messages": [
+            {
+                "role": "user",
+                "content": "My SSN is 000-00-0000 and my card is 0000-0000-0000-0000.",
+            }
+        ],
+    }
+    payload = (
+        '{"pii_items": ['
+        '{"type": "social_security_number", "value": "000-00-0000"}, '
+        '{"type": "credit_card_number", "value": "0000-0000-0000-0000"}'
+        ']}'
+    )
+    ag = _make_agent(_FakeClient(payload), tmp_path)
+    result = ag.sanitize_conversation(conv, "t2")
+    assert result["pii_found"] == ["000-00-0000", "0000-0000-0000-0000"]
+    assert result["replacements_made"] == 2
+    assert result["sanitized_text"].count("[REDACTED]") == 2
+    assert result["metrics"]["pii_items_found"] == 2
+
+
+def test_structured_pii_items_preserve_original_value(tmp_path):
+    conv = {
+        "conversation_id": "demo_003",
+        "messages": [
+            {
+                "role": "user",
+                "content": "The secret is -abc- and the password is   p4ss  .",
+            }
+        ],
+    }
+    payload = (
+        '{"pii_items": ['
+        '{"type": "secret", "value": "-abc-"}, '
+        '{"type": "password", "value": "  p4ss  "}'
+        ']}'
+    )
+    ag = _make_agent(_FakeClient(payload), tmp_path)
+    result = ag.sanitize_conversation(conv, "t3")
+    assert result["pii_found"] == ["-abc-", "  p4ss  "]
+    assert result["replacements_made"] == 2
+    assert result["sanitized_text"].count("[REDACTED]") == 2
+
+
+def test_pii_items_metric_excludes_rejected_and_malformed_items(tmp_path):
+    conv = {
+        "conversation_id": "demo_004",
+        "messages": [
+            {
+                "role": "user",
+                "content": "My email is alice@example.com.",
+            }
+        ],
+    }
+    payload = (
+        '{"pii_items": ['
+        '{"type": "email", "value": "alice@example.com"}, '
+        '{"type": "ssn", "value": "999-99-9999"}, '
+        '{"type": "unknown", "value": ""}, '
+        '{"type": "broken"}, '
+        '"just a string"'
+        ']}'
+    )
+    ag = _make_agent(_FakeClient(payload), tmp_path)
+    result = ag.sanitize_conversation(conv, "t4")
+    assert result["pii_found"] == ["alice@example.com"]
+    assert result["replacements_made"] == 1
+    assert result["metrics"]["pii_items_found"] == 1
+    items = result["pii_items"]
+    assert len(items) == 1
+    assert items[0]["type"] == "email"
+    assert items[0]["value"] == "alice@example.com"


### PR DESCRIPTION
## 问题

LLM 模式下，PII 检测结果有时会返回 `标签 + 值` 的字符串，例如：

```text
Social Security Number: 123-45-6789
```

但脱敏逻辑按原文中的精确片段替换，导致这些结果无法命中，出现 `Replacements Made: 0`。

## 修改

- 将 `PII_DETECTION_SCHEMA` 从 `pii_values` 改为 `pii_items`
- 每个 item 显式包含 `type` 和 `value`
- `detect_pii()` 同时兼容新的 `pii_items` 和旧的 `pii_values`
- 替换逻辑继续使用 `value` 字段中的原文片段进行 redaction
- 新增回归测试覆盖 structured `pii_items` 输出

## 验证

```bash
conda run -n chapter3 python -m pytest chapter3/log-sanitization/test_sanitize_conversation.py -q
```

```text
3 passed
```

```bash
conda run -n chapter3 python -m pytest chapter3/log-sanitization -q
```

```text
24 passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * PII 输出改为支持结构化返回：返回 `pii_items` 数组，每项包含敏感类型与逐字原始值。
  * 脱敏指标增强：在原有统计基础上新增 `pii_items` 明细与计数。

* **错误修复**
  * 兼容旧版返回格式：当未收到标准 `pii_items` 时自动回退到旧字段解析。
  * 返回内容无法解析时仍可继续生成脱敏结果，并移除结构化明细。

* **测试**
  * 新增用例覆盖结构化 `pii_items` 解析、`value` 保留与 `[REDACTED]` 出现次数校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->