### PR TITLE
Improve the header language dropdown

### DIFF
--- a/extras/book-theme.css
+++ b/extras/book-theme.css
@@ -621,8 +621,3 @@ html[dir="rtl"] .md-typeset table:not([class]) th,
 html[dir="rtl"] .md-typeset table:not([class]) td {
   text-align: right;
 }
-
-html[dir="rtl"] .lang-select {
-  margin-left: 0;
-  margin-right: 0.5rem;
-}

--- a/extras/lang-switcher.css
+++ b/extras/lang-switcher.css
@@ -1,58 +1,177 @@
-/* ── Language selector <select> in the header bar ─────────── */
+/* ── Custom language dropdown in the header bar ──────────── */
+
+.lang-switcher {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  margin-inline-start: 0.5rem;
+}
 
 .lang-select {
-  display: inline-block;
-  margin-left: 0.5rem;
-  padding: 4px 28px 4px 10px;
-  font-size: 0.7rem;
-  font-weight: 500;
-  color: var(--md-default-fg-color);
-  background:
-    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23666' d='M2 4l4 4 4-4z'/%3E%3C/svg%3E")
-    no-repeat right 8px center / 14px;
-  border: 1px solid rgba(128, 128, 128, 0.35);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  min-height: 1.9rem;
+  padding: 0.32rem 0.48rem;
+  color: var(--fenix-ink, var(--md-default-fg-color));
+  background: transparent;
+  border: 1px solid transparent;
   border-radius: 6px;
-  appearance: none;        /* remove native arrow */
-  -webkit-appearance: none;
   cursor: pointer;
-  line-height: 1.4;
+  font: inherit;
+  font-size: 0.68rem;
+  font-weight: 500;
   letter-spacing: 0.01em;
-  font-family: inherit;
-  flex-shrink: 0;
-  transition: all 0.15s ease;
+  line-height: 1;
+  white-space: nowrap;
+  transition: background-color 0.15s ease, border-color 0.15s ease,
+              color 0.15s ease;
 }
 
-.lang-select:hover {
-  border-color: var(--md-accent-fg-color);
-  box-shadow: 0 0 0 1px var(--md-accent-fg-color--light);
+.lang-select:hover,
+.lang-select[aria-expanded="true"] {
+  color: var(--fenix-link-hover, var(--md-accent-fg-color));
+  background: var(--fenix-bg-soft, rgba(128, 128, 128, 0.08));
+  border-color: var(--fenix-border, rgba(128, 128, 128, 0.25));
 }
 
-.lang-select:focus {
+.lang-select:focus-visible {
+  outline: 2px solid var(--fenix-link-hover, var(--md-accent-fg-color));
+  outline-offset: 2px;
+}
+
+.lang-select__icon,
+.lang-select__chevron {
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.lang-select__icon svg {
+  width: 0.92rem;
+  height: 0.92rem;
+  fill: currentcolor;
+}
+
+.lang-select__chevron svg {
+  width: 0.68rem;
+  height: 0.68rem;
+  fill: currentcolor;
+  transition: transform 0.15s ease;
+}
+
+.lang-select[aria-expanded="true"] .lang-select__chevron svg {
+  transform: rotate(180deg);
+}
+
+.lang-menu {
+  position: absolute;
+  z-index: 20;
+  inset-block-start: calc(100% + 0.42rem);
+  inset-inline-end: 0;
+  width: max-content;
+  min-width: 11.5rem;
+  max-height: min(25rem, calc(100vh - 4.5rem));
+  overflow-y: auto;
+  padding: 0.35rem;
+  color: var(--fenix-ink, var(--md-default-fg-color));
+  background: var(--fenix-bg, var(--md-default-bg-color));
+  border: 1px solid var(--fenix-border, rgba(128, 128, 128, 0.25));
+  border-radius: 8px;
+  box-shadow: 0 12px 32px rgba(27, 31, 35, 0.14),
+              0 2px 8px rgba(27, 31, 35, 0.08);
+  animation: lang-menu-enter 0.14s ease-out;
+}
+
+.lang-menu[hidden] {
+  display: none;
+}
+
+.lang-menu__option {
+  display: grid;
+  grid-template-columns: 0.8rem minmax(0, 1fr);
+  align-items: center;
+  gap: 0.48rem;
+  width: 100%;
+  padding: 0.48rem 0.58rem;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.68rem;
+  line-height: 1.35;
+  text-align: start;
+}
+
+.lang-menu__option:hover,
+.lang-menu__option:focus-visible {
+  color: var(--fenix-link-hover, var(--md-accent-fg-color));
+  background: var(--fenix-bg-soft, rgba(128, 128, 128, 0.08));
   outline: none;
-  border-color: var(--md-accent-fg-color);
-  box-shadow: 0 0 0 2px var(--md-accent-bg-color--light);
 }
 
-/* Disabled (current language) option styling */
-.lang-select option[disabled] {
+.lang-menu__option[aria-checked="true"] {
+  color: var(--fenix-link-hover, var(--md-accent-fg-color));
+  background: rgba(66, 185, 131, 0.1);
   font-weight: 600;
-  color: var(--md-primary-fg-color);
 }
 
-/* Dark mode tweaks */
-[data-md-color-scheme="slate"] .lang-select {
-  color: #d0d0d0;
-  border-color: rgba(255, 255, 255, 0.15);
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23aaa' d='M2 4l4 4 4-4z'/%3E%3C/svg%3E");
-}
-[data-md-color-scheme="slate"] .lang-select:hover {
-  border-color: rgba(168, 199, 250, 0.5);
+.lang-menu__check {
+  width: 0.55rem;
+  height: 0.3rem;
+  border-bottom: 2px solid currentcolor;
+  border-left: 2px solid currentcolor;
+  opacity: 0;
+  transform: translateY(-0.08rem) rotate(-45deg);
 }
 
-@media screen and (max-width: 59.9375em) {
+.lang-menu__option[aria-checked="true"] .lang-menu__check {
+  opacity: 1;
+}
+
+.lang-menu__label {
+  white-space: nowrap;
+}
+
+[data-md-color-scheme="slate"] .lang-menu {
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.42),
+              0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+@keyframes lang-menu-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-0.25rem) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lang-menu,
+  .lang-select__chevron svg {
+    animation: none;
+    transition: none;
+  }
+}
+
+@media screen and (max-width: 44.984375em) {
+  .lang-switcher {
+    margin-inline-start: 0.15rem;
+  }
+
   .lang-select {
-    font-size: 0.64rem;
-    padding: 3px 24px 3px 8px;
-    margin-left: 0.25rem;
+    width: 2rem;
+    min-height: 2rem;
+    padding: 0.4rem;
+  }
+
+  .lang-select__label,
+  .lang-select__chevron {
+    display: none;
   }
 }

--- a/extras/lang-switcher.js
+++ b/extras/lang-switcher.js
@@ -1,5 +1,5 @@
-// Language switcher: populates a <select> dropdown in the header bar.
-// On change, navigates to the equivalent page in the target language and
+// Language switcher: populates the custom dropdown in the header bar.
+// On selection, navigates to the equivalent page in the target language and
 // rewrites the left sidebar (links + text) to match the new edition.
 //
 // window.LANG_CONFIG = { zh: {label, prefix, default?}, ... }
@@ -317,7 +317,49 @@
       window.location.replace(finalUrl);
     }
 
-    // ── render the <select> options ──────────────────────────
+    // ── custom dropdown ─────────────────────────────────────
+
+    function closeDropdown(returnFocus) {
+      var trigger = document.getElementById("lang-selector");
+      var menu = document.getElementById("lang-menu");
+      if (!trigger || !menu) return;
+      trigger.setAttribute("aria-expanded", "false");
+      menu.hidden = true;
+      if (returnFocus) trigger.focus();
+    }
+
+    function openDropdown(focusDirection) {
+      var trigger = document.getElementById("lang-selector");
+      var menu = document.getElementById("lang-menu");
+      if (!trigger || !menu) return;
+      trigger.setAttribute("aria-expanded", "true");
+      menu.hidden = false;
+
+      if (focusDirection) {
+        var options = menu.querySelectorAll(".lang-menu__option");
+        if (!options.length) return;
+        var target = menu.querySelector('[aria-checked="true"]');
+        if (focusDirection === "first") target = options[0];
+        if (focusDirection === "last") target = options[options.length - 1];
+        (target || options[0]).focus();
+      }
+    }
+
+    function moveMenuFocus(current, amount) {
+      var menu = document.getElementById("lang-menu");
+      if (!menu) return;
+      var options = Array.prototype.slice.call(
+        menu.querySelectorAll(".lang-menu__option")
+      );
+      if (!options.length) return;
+      var currentIndex = options.indexOf(current);
+      var nextIndex = (currentIndex + amount + options.length) % options.length;
+      options[nextIndex].focus();
+    }
+
+    function optionLocale(code) {
+      return code === "zhtw" ? "zh-TW" : code;
+    }
 
     function render() {
       var rawPath = location.pathname;
@@ -326,24 +368,62 @@
       var activeLang = detectLang(cleanPath);
       applyDocumentLocale(activeLang);
 
-      var sel = document.getElementById("lang-selector");
-      if (!sel) return;
+      var trigger = document.getElementById("lang-selector");
+      var menu = document.getElementById("lang-menu");
+      if (!trigger || !menu) return;
 
-      // Build options on first sight of an empty select.
-      if (sel.children.length === 0) {
+      // Build menu items on first sight of an empty dropdown.
+      if (menu.children.length === 0) {
         var codes = Object.keys(cfg);
         for (var idx = 0; idx < codes.length; idx++) {
           var code = codes[idx];
-          var opt = document.createElement("option");
-          opt.value = code;
-          opt.textContent = cfg[code].label;
-          if (code === activeLang) opt.selected = true;
-          sel.appendChild(opt);
+          var option = document.createElement("button");
+          option.type = "button";
+          option.className = "lang-menu__option";
+          option.setAttribute("role", "menuitemradio");
+          option.setAttribute("data-lang-code", code);
+          option.setAttribute(
+            "aria-checked",
+            code === activeLang ? "true" : "false"
+          );
+          option.setAttribute("tabindex", "-1");
+
+          var check = document.createElement("span");
+          check.className = "lang-menu__check";
+          check.setAttribute("aria-hidden", "true");
+
+          var label = document.createElement("span");
+          label.className = "lang-menu__label";
+          label.setAttribute("lang", optionLocale(code));
+          label.setAttribute("dir", code === "ar" ? "rtl" : "auto");
+          label.textContent = cfg[code].label;
+
+          option.appendChild(check);
+          option.appendChild(label);
+          menu.appendChild(option);
         }
-      } else {
-        // Update which option is selected for the current page.
-        sel.value = activeLang;
       }
+
+      // Keep the trigger and checked item in sync after SPA navigation.
+      var currentLabel = cfg[activeLang].label;
+      var labelNode = trigger.querySelector("[data-lang-label]");
+      if (labelNode) {
+        labelNode.textContent = currentLabel;
+        labelNode.setAttribute("lang", optionLocale(activeLang));
+        labelNode.setAttribute("dir", activeLang === "ar" ? "rtl" : "auto");
+      }
+      trigger.setAttribute(
+        "aria-label",
+        "Switch language. Current language: " + currentLabel
+      );
+
+      var options = menu.querySelectorAll(".lang-menu__option");
+      for (var optionIndex = 0; optionIndex < options.length; optionIndex++) {
+        var isActive =
+          options[optionIndex].getAttribute("data-lang-code") === activeLang;
+        options[optionIndex].setAttribute("aria-checked", isActive ? "true" : "false");
+      }
+      closeDropdown(false);
 
       var defCode = null;
       for (var c in cfg) { if (cfg[c].default) { defCode = c; break; } }
@@ -355,13 +435,69 @@
 
     // ── bootstrap ────────────────────────────────────────────
 
-    // Bind the change handler ONCE via event delegation. This way it keeps
-    // working even if Material re-creates the <select> during SPA navigation.
+    // Bind handlers once via event delegation so the dropdown keeps working
+    // if Material re-creates the header during SPA navigation.
     if (!window.__langSwitcherBound) {
       window.__langSwitcherBound = true;
-      document.addEventListener("change", function (e) {
-        if (!e.target || e.target.id !== "lang-selector") return;
-        switchTo(e.target.value);
+      document.addEventListener("click", function (e) {
+        if (!e.target || !e.target.closest) return;
+
+        var trigger = e.target.closest("#lang-selector");
+        if (trigger) {
+          var isOpen = trigger.getAttribute("aria-expanded") === "true";
+          if (isOpen) closeDropdown(false);
+          else openDropdown(false);
+          return;
+        }
+
+        var option = e.target.closest(".lang-menu__option");
+        if (option) {
+          var targetCode = option.getAttribute("data-lang-code");
+          closeDropdown(false);
+          switchTo(targetCode);
+          return;
+        }
+
+        if (!e.target.closest(".lang-switcher")) closeDropdown(false);
+      });
+
+      document.addEventListener("keydown", function (e) {
+        if (!e.target || !e.target.closest) return;
+        var trigger = e.target.closest("#lang-selector");
+        if (trigger) {
+          if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+            e.preventDefault();
+            openDropdown(e.key === "ArrowDown" ? "first" : "last");
+          } else if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            if (trigger.getAttribute("aria-expanded") === "true") {
+              closeDropdown(false);
+            } else {
+              openDropdown("current");
+            }
+          } else if (e.key === "Escape") {
+            closeDropdown(false);
+          }
+          return;
+        }
+
+        var option = e.target.closest(".lang-menu__option");
+        if (!option) return;
+        if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+          e.preventDefault();
+          moveMenuFocus(option, e.key === "ArrowDown" ? 1 : -1);
+        } else if (e.key === "Home" || e.key === "End") {
+          e.preventDefault();
+          openDropdown(e.key === "Home" ? "first" : "last");
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          closeDropdown(true);
+        } else if (e.key === "Tab") {
+          closeDropdown(false);
+        } else if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          option.click();
+        }
       });
     }
 

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -81,9 +81,28 @@
     {% endif %}
 
     {# ── Language selector dropdown (between search & source) ── #}
-    <select id="lang-selector"
-            class="lang-select"
-            aria-label="Switch language"></select>
+    <div class="lang-switcher">
+      <button id="lang-selector"
+              class="lang-select"
+              type="button"
+              aria-haspopup="menu"
+              aria-expanded="false"
+              aria-controls="lang-menu"
+              aria-label="Switch language">
+        <span class="lang-select__icon" aria-hidden="true">
+          {% include ".icons/material/translate.svg" %}
+        </span>
+        <span class="lang-select__label" data-lang-label>Language</span>
+        <span class="lang-select__chevron" aria-hidden="true">
+          {% include ".icons/material/chevron-down.svg" %}
+        </span>
+      </button>
+      <div id="lang-menu"
+           class="lang-menu"
+           role="menu"
+           aria-labelledby="lang-selector"
+           hidden></div>
+    </div>
 
     {# Expose language config + site root to the switcher script. #}
     <script>window.LANG_CONFIG = {{ config.extra.languages | tojson }};</script>


### PR DESCRIPTION
## Summary
- replace the native system language select with a themed custom dropdown
- show the active language with translate, chevron, and checkmark affordances
- support dark mode, RTL layouts, reduced motion, and an icon-only mobile layout
- add accessible keyboard navigation, focus management, Escape handling, and outside-click dismissal
- preserve the existing language URL and sidebar translation behavior

## Testing
- node --check extras/lang-switcher.js
- git diff --check
- strict MkDocs fixture build using the real header override
- Chromium desktop and mobile visual checks
- Chromium keyboard and outside-click interaction checks

## Build note
The full repository strict MkDocs build reaches an unrelated existing Pygments error in book/chapter2/index.md where a filename value is None. The focused strict header build passes.