### PR TITLE
fix(trajectory-verifier): tolerate null fields in ProcessVerifier

### DIFF
--- a/chapter8/trajectory-verifier/test_verifier_null_fields.py
+++ b/chapter8/trajectory-verifier/test_verifier_null_fields.py
@@ -1,0 +1,19 @@
+"""Regression test: ProcessVerifier must tolerate null/None values for process_facts, sensitive_values, claims, and promises."""
+import pytest
+from verifier import ProcessVerifier, PASS, UNCERTAIN
+
+
+def test_process_verifier_tolerates_null_fields():
+    verifier = ProcessVerifier()
+    trajectory = {
+        "messages": [{"role": "assistant", "content": "Hello"}],
+        "process_facts": None,
+        "sensitive_values": None,
+        "claims": None,
+        "promises": None,
+        "tool_calls": None,
+    }
+    results = verifier.evaluate(trajectory)
+    assert len(results) == 4
+    for res in results:
+        assert res.verdict in (PASS, UNCERTAIN)

--- a/chapter8/trajectory-verifier/test_verifier_null_fields.py
+++ b/chapter8/trajectory-verifier/test_verifier_null_fields.py
@@ -17,3 +17,17 @@ def test_process_verifier_tolerates_null_fields():
     assert len(results) == 4
     for res in results:
         assert res.verdict in (PASS, UNCERTAIN)
+def test_process_verifier_tolerates_invalid_container_types():
+    verifier = ProcessVerifier()
+    trajectory = {
+        "messages": [{"role": "assistant", "content": "Hello"}],
+        "process_facts": 123,
+        "sensitive_values": "invalid",
+        "claims": 456,
+        "promises": True,
+        "tool_calls": 789,
+    }
+    results = verifier.evaluate(trajectory)
+    assert len(results) == 4
+    for res in results:
+        assert res.verdict in (PASS, UNCERTAIN)

--- a/chapter8/trajectory-verifier/verifier.py
+++ b/chapter8/trajectory-verifier/verifier.py
@@ -32,7 +32,9 @@ class QualityJudge(Protocol):
 
 
 def _successful_calls(trajectory: Dict[str, Any]) -> List[Dict[str, Any]]:
-    calls = trajectory.get("tool_calls") or []
+    calls = trajectory.get("tool_calls")
+    if not isinstance(calls, list):
+        calls = []
     return [
         call
         for call in calls
@@ -87,10 +89,13 @@ class ProcessVerifier:
             self._grounding(trajectory),
             self._promise_action(trajectory),
         ]
-
     def _policy(self, trajectory: Dict[str, Any]) -> DimensionResult:
-        facts = trajectory.get("process_facts") or {}
-        violations = facts.get("policy_violations") or []
+        facts = trajectory.get("process_facts")
+        if not isinstance(facts, dict):
+            facts = {}
+        violations = facts.get("policy_violations")
+        if not isinstance(violations, list):
+            violations = []
         if violations:
             evidence = [
                 f"turn {item.get('turn', '?')}: {item.get('rule', 'policy violation')}"
@@ -98,13 +103,17 @@ class ProcessVerifier:
                 if isinstance(item, dict)
             ]
             return DimensionResult("rule_compliance", "process_rules", FAIL, 0.0, evidence, 1.0)
-        checked = facts.get("checked_rules") or []
+        checked = facts.get("checked_rules")
+        if not isinstance(checked, list):
+            checked = []
         evidence = [f"checked: {rule}" for rule in checked] or ["No policy violation in action log"]
         return DimensionResult("rule_compliance", "process_rules", PASS, 1.0, evidence, 0.95)
 
     def _privacy(self, trajectory: Dict[str, Any]) -> DimensionResult:
         reply = _assistant_text(trajectory)
-        sensitive = trajectory.get("sensitive_values") or []
+        sensitive = trajectory.get("sensitive_values")
+        if not isinstance(sensitive, list):
+            sensitive = []
         leaks = [
             item for item in sensitive
             if isinstance(item, dict) and item.get("value") and str(item["value"]) in reply
@@ -121,7 +130,9 @@ class ProcessVerifier:
         )
 
     def _grounding(self, trajectory: Dict[str, Any]) -> DimensionResult:
-        claims = trajectory.get("claims") or []
+        claims = trajectory.get("claims")
+        if not isinstance(claims, list):
+            claims = []
         unsupported = [
             claim for claim in claims
             if isinstance(claim, dict) and not claim.get("supported_by")
@@ -144,7 +155,9 @@ class ProcessVerifier:
             call.get("name") for call in _successful_calls(trajectory)
             if isinstance(call, dict)
         }
-        promises = trajectory.get("promises") or []
+        promises = trajectory.get("promises")
+        if not isinstance(promises, list):
+            promises = []
         missing = [
             promise for promise in promises
             if isinstance(promise, dict) and promise.get("required_tool") not in successful

--- a/chapter8/trajectory-verifier/verifier.py
+++ b/chapter8/trajectory-verifier/verifier.py
@@ -32,10 +32,13 @@ class QualityJudge(Protocol):
 
 
 def _successful_calls(trajectory: Dict[str, Any]) -> List[Dict[str, Any]]:
+    calls = trajectory.get("tool_calls") or []
     return [
         call
-        for call in trajectory.get("tool_calls", [])
-        if call.get("result", {}).get("success") is True
+        for call in calls
+        if isinstance(call, dict)
+        and isinstance(call.get("result"), dict)
+        and call.get("result", {}).get("success") is True
     ]
 
 
@@ -86,22 +89,25 @@ class ProcessVerifier:
         ]
 
     def _policy(self, trajectory: Dict[str, Any]) -> DimensionResult:
-        violations = trajectory.get("process_facts", {}).get("policy_violations", [])
+        facts = trajectory.get("process_facts") or {}
+        violations = facts.get("policy_violations") or []
         if violations:
             evidence = [
                 f"turn {item.get('turn', '?')}: {item.get('rule', 'policy violation')}"
                 for item in violations
+                if isinstance(item, dict)
             ]
             return DimensionResult("rule_compliance", "process_rules", FAIL, 0.0, evidence, 1.0)
-        checked = trajectory.get("process_facts", {}).get("checked_rules", [])
+        checked = facts.get("checked_rules") or []
         evidence = [f"checked: {rule}" for rule in checked] or ["No policy violation in action log"]
         return DimensionResult("rule_compliance", "process_rules", PASS, 1.0, evidence, 0.95)
 
     def _privacy(self, trajectory: Dict[str, Any]) -> DimensionResult:
         reply = _assistant_text(trajectory)
+        sensitive = trajectory.get("sensitive_values") or []
         leaks = [
-            item for item in trajectory.get("sensitive_values", [])
-            if item.get("value") and str(item["value"]) in reply
+            item for item in sensitive
+            if isinstance(item, dict) and item.get("value") and str(item["value"]) in reply
         ]
         if leaks:
             return DimensionResult(
@@ -115,9 +121,10 @@ class ProcessVerifier:
         )
 
     def _grounding(self, trajectory: Dict[str, Any]) -> DimensionResult:
+        claims = trajectory.get("claims") or []
         unsupported = [
-            claim for claim in trajectory.get("claims", [])
-            if not claim.get("supported_by")
+            claim for claim in claims
+            if isinstance(claim, dict) and not claim.get("supported_by")
         ]
         if unsupported:
             return DimensionResult(
@@ -125,20 +132,22 @@ class ProcessVerifier:
                 [f"turn {claim.get('turn', '?')}: unsupported claim: {claim.get('text', '')}" for claim in unsupported],
                 0.95,
             )
-        claims = trajectory.get("claims", [])
         evidence = [
             f"turn {claim.get('turn', '?')}: supported by {claim.get('supported_by')}"
             for claim in claims
+            if isinstance(claim, dict)
         ] or ["No externally checkable claim was made"]
         return DimensionResult("factual_reliability", "process_rules", PASS, 1.0, evidence, 0.9)
 
     def _promise_action(self, trajectory: Dict[str, Any]) -> DimensionResult:
         successful = {
             call.get("name") for call in _successful_calls(trajectory)
+            if isinstance(call, dict)
         }
+        promises = trajectory.get("promises") or []
         missing = [
-            promise for promise in trajectory.get("promises", [])
-            if promise.get("required_tool") not in successful
+            promise for promise in promises
+            if isinstance(promise, dict) and promise.get("required_tool") not in successful
         ]
         if missing:
             return DimensionResult(
@@ -152,7 +161,8 @@ class ProcessVerifier:
             )
         evidence = [
             f"turn {promise.get('turn', '?')}: {promise.get('required_tool')} succeeded"
-            for promise in trajectory.get("promises", [])
+            for promise in promises
+            if isinstance(promise, dict)
         ] or ["No action promise was made"]
         return DimensionResult(
             "promise_action_consistency", "process_rules", PASS, 1.0, evidence, 0.98,


### PR DESCRIPTION
### Summary
Fix `ProcessVerifier` in `chapter8/trajectory-verifier/verifier.py` to safely handle `None` / `null` values for optional trajectory dictionary keys (`process_facts`, `sensitive_values`, `claims`, `promises`, `tool_calls`).

### Root Cause
When a trajectory payload has explicit `None` values for optional keys (such as `{"process_facts": None}` or `{"sensitive_values": None}` from JSON deserialization), `trajectory.get("process_facts", {})` returned `None` (since the key exists), causing subsequent `.get()` calls or `for item in None` iterations to raise `AttributeError: 'NoneType' object has no attribute 'get'` or `TypeError: 'NoneType' object is not iterable`.

### Fix
Guarded dictionary access using `trajectory.get(...) or {}` / `or []` and `isinstance(..., dict)` checks before attribute access.

### Verification
Added `chapter8/trajectory-verifier/test_verifier_null_fields.py`.
- Executed `pytest chapter8/trajectory-verifier/`: 8 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 搜索结果数量设置为零或负数时，将立即返回空结果，避免不必要的处理。
  * 增强轨迹数据解析的容错性，缺失、空值或格式异常的字段不再导致评估失败。
  * 工具调用及其结果需满足严格的成功条件，提升验证结果准确性。

* **测试**
  * 新增搜索数量边界场景及轨迹字段为空值时的回归测试，覆盖正常与异常输入。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->