### PR TITLE
fix(self-evolving-tools): handle null fields in ToolLibrary search_tools and list_tools

### DIFF
--- a/chapter8/self-evolving-tools/test_search_null_fields.py
+++ b/chapter8/self-evolving-tools/test_search_null_fields.py
@@ -14,3 +14,9 @@ def test_search_null_name_or_description():
         assert res["success"] is True
         assert res["count"] == 1
         assert res["tools"][0]["name"] == "null_desc"
+def test_get_tool_non_dict_json():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lib = ToolLibrary(library_dir=Path(tmpdir))
+        p = Path(tmpdir) / "bad_list.json"
+        p.write_text('[1, 2, 3]')
+        assert lib.get_tool("bad_list") is None

--- a/chapter8/self-evolving-tools/test_search_null_fields.py
+++ b/chapter8/self-evolving-tools/test_search_null_fields.py
@@ -1,0 +1,16 @@
+from tool_manager import ToolLibrary
+import tempfile
+from pathlib import Path
+
+
+def test_search_null_name_or_description():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lib = ToolLibrary(library_dir=Path(tmpdir))
+        # Create a tool file manually with null description
+        p = Path(tmpdir) / "null_desc.json"
+        p.write_text('{"name": "null_desc", "description": null, "parameters": {}, "code": "def run(): pass"}')
+
+        res = lib.search_tools("null")
+        assert res["success"] is True
+        assert res["count"] == 1
+        assert res["tools"][0]["name"] == "null_desc"

--- a/chapter8/self-evolving-tools/tool_manager.py
+++ b/chapter8/self-evolving-tools/tool_manager.py
@@ -145,7 +145,11 @@ class ToolLibrary:
         p = self.dir / f"{name}.json"
         if not p.exists():
             return None
-        return json.loads(p.read_text())
+        try:
+            data = json.loads(p.read_text())
+            return data if isinstance(data, dict) else None
+        except Exception:  # noqa: BLE001
+            return None
 
     # -------------------------- execute a wrapped tool --------------------- #
     def execute_tool(self, name: str, arguments: dict, timeout: int = 60) -> dict:

--- a/chapter8/self-evolving-tools/tool_manager.py
+++ b/chapter8/self-evolving-tools/tool_manager.py
@@ -121,9 +121,9 @@ class ToolLibrary:
             "count": len(hits),
             "tools": [
                 {
-                    "name": r.get("name", ""),
-                    "description": r.get("description", ""),
-                    "parameters": r.get("parameters", {}),
+                    "name": str(r.get("name") or ""),
+                    "description": str(r.get("description") or ""),
+                    "parameters": r.get("parameters") or {},
                 }
                 for _, r in hits
             ],

--- a/chapter8/self-evolving-tools/tool_manager.py
+++ b/chapter8/self-evolving-tools/tool_manager.py
@@ -108,7 +108,9 @@ class ToolLibrary:
         terms = [t for t in query.replace(",", " ").split() if t]
         hits = []
         for rec in self.list_tools():
-            haystack = (rec["name"] + " " + rec["description"]).lower()
+            name = str(rec.get("name") or "")
+            desc = str(rec.get("description") or "")
+            haystack = (name + " " + desc).lower()
             score = sum(1 for t in terms if t in haystack)
             if score > 0 or not terms:
                 hits.append((score, rec))
@@ -118,7 +120,11 @@ class ToolLibrary:
             "query": query,
             "count": len(hits),
             "tools": [
-                {"name": r["name"], "description": r["description"], "parameters": r["parameters"]}
+                {
+                    "name": r.get("name", ""),
+                    "description": r.get("description", ""),
+                    "parameters": r.get("parameters", {}),
+                }
                 for _, r in hits
             ],
         }
@@ -128,7 +134,9 @@ class ToolLibrary:
         recs = []
         for p in sorted(self.dir.glob("*.json")):
             try:
-                recs.append(json.loads(p.read_text()))
+                data = json.loads(p.read_text())
+                if isinstance(data, dict):
+                    recs.append(data)
             except Exception:  # noqa: BLE001
                 continue
         return recs


### PR DESCRIPTION
### Summary
Fix `ToolLibrary.search_tools` and `list_tools` in `chapter8/self-evolving-tools/tool_manager.py` to handle `null` / `None` values for tool fields (`name`, `description`, `parameters`).

### Root Cause
If a tool file in the tool library contains `"description": null` or `"name": null`, calling `search_tools(query)` raised `TypeError: can only concatenate str (not "NoneType") to str` at `haystack = (rec["name"] + " " + rec["description"]).lower()`.

### Fix
- Coerced `name` and `description` to strings via `str(rec.get("name") or "")` and `str(rec.get("description") or "")`.
- Guarded returned dictionary keys with `r.get(...)`.
- Filtered non-dictionary JSON contents in `list_tools`.

### Verification
Added `chapter8/self-evolving-tools/test_search_null_fields.py`.
- Executed `pytest chapter8/self-evolving-tools/`: 12 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 增强工具搜索和列表展示对缺失名称、描述字段的兼容性。
  * 忽略格式无效的工具记录，避免影响工具加载和搜索。
  * 确保缺少描述信息的工具仍可被成功搜索并正确显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->