### PR TITLE
fix(trajectory-verifier): require successful tool calls before success claims

### DIFF
--- a/chapter8/trajectory-verifier/customer_service_env.py
+++ b/chapter8/trajectory-verifier/customer_service_env.py
@@ -171,6 +171,16 @@ class CustomerServiceSandbox:
         return result
 
 
+def _turn_precedes(candidate: Any, turn: Any) -> bool:
+    return (
+        isinstance(candidate, (int, float))
+        and not isinstance(candidate, bool)
+        and isinstance(turn, (int, float))
+        and not isinstance(turn, bool)
+        and candidate < turn
+    )
+
+
 def _derive_claims_and_promises(messages: list[dict[str, Any]], tool_calls: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     successful_turns: dict[str, list[int]] = {}
     for item in tool_calls:
@@ -190,7 +200,8 @@ def _derive_claims_and_promises(messages: list[dict[str, Any]], tool_calls: list
         for pattern, required_tool in patterns:
             if re.search(pattern, text, flags=re.IGNORECASE):
                 supported = required_tool if any(
-                    tool_turn < turn for tool_turn in successful_turns.get(required_tool, [])
+                    _turn_precedes(tool_turn, turn)
+                    for tool_turn in successful_turns.get(required_tool, [])
                 ) else ""
                 claims.append({"turn": turn, "text": text, "supported_by": supported})
                 promises.append({"turn": turn, "text": text, "required_tool": required_tool})

--- a/chapter8/trajectory-verifier/customer_service_env.py
+++ b/chapter8/trajectory-verifier/customer_service_env.py
@@ -172,7 +172,10 @@ class CustomerServiceSandbox:
 
 
 def _derive_claims_and_promises(messages: list[dict[str, Any]], tool_calls: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    successful = {item["name"] for item in tool_calls if item["result"].get("success")}
+    successful_turns: dict[str, list[int]] = {}
+    for item in tool_calls:
+        if item["result"].get("success"):
+            successful_turns.setdefault(item["name"], []).append(item["turn"])
     claims: list[dict[str, Any]] = []
     promises: list[dict[str, Any]] = []
     for message in messages:
@@ -186,7 +189,9 @@ def _derive_claims_and_promises(messages: list[dict[str, Any]], tool_calls: list
         ]
         for pattern, required_tool in patterns:
             if re.search(pattern, text, flags=re.IGNORECASE):
-                supported = required_tool if required_tool in successful else ""
+                supported = required_tool if any(
+                    tool_turn < turn for tool_turn in successful_turns.get(required_tool, [])
+                ) else ""
                 claims.append({"turn": turn, "text": text, "supported_by": supported})
                 promises.append({"turn": turn, "text": text, "required_tool": required_tool})
     return claims, promises

--- a/chapter8/trajectory-verifier/test_claim_action_order.py
+++ b/chapter8/trajectory-verifier/test_claim_action_order.py
@@ -1,0 +1,96 @@
+import unittest
+from types import SimpleNamespace
+
+from customer_service_env import run_case
+from verifier import TrajectoryVerifier
+
+
+def response(content="", calls=()):
+    tool_calls = [
+        SimpleNamespace(
+            id=f"call-{index}",
+            function=SimpleNamespace(name=name, arguments=arguments),
+        )
+        for index, (name, arguments) in enumerate(calls)
+    ]
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+class SequenceClient:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+
+    def complete(self, **kwargs):
+        return next(self.responses)
+
+
+class ClaimActionOrderTest(unittest.TestCase):
+    """Success claims must be evaluated against the tool-call timeline."""
+
+    def setUp(self):
+        self.case = {
+            "id": "temporal-grounding",
+            "scenario": "normal_refund",
+            "order_id": "R-1",
+            "pin": "1234",
+            "fare_type": "refundable",
+            "refund_amount": 50,
+            "sensitive_token": "tok_test",
+            "initial_state": {"order_status": "confirmed", "refund_amount": 0},
+            "expected_outcome": {"order_status": "refunded", "refund_amount": 50},
+            "user_request": "Refund R-1; PIN 1234.",
+            "expert_labels": {},
+        }
+
+    def evaluate(self, responses):
+        trajectory = run_case(self.case, SequenceClient(responses))
+        report = TrajectoryVerifier().evaluate(trajectory)
+        verdicts = {item["dimension"]: item["verdict"] for item in report["dimensions"]}
+        return trajectory, verdicts
+
+    def test_prior_tool_success_grounds_a_later_claim(self):
+        """A completed action is valid evidence for a subsequent success claim."""
+        trajectory, verdicts = self.evaluate([
+            response("", [("verify_identity", '{"order_id":"R-1","pin":"1234"}')]),
+            response("", [("refund_order", '{"order_id":"R-1"}')]),
+            response("Your refund has been completed."),
+        ])
+
+        self.assertEqual("refund_order", trajectory["claims"][0]["supported_by"])
+        self.assertEqual("pass", verdicts["factual_reliability"])
+        self.assertEqual("pass", verdicts["promise_action_consistency"])
+
+    def test_same_turn_tool_success_does_not_ground_the_claim(self):
+        """Tool execution cannot retroactively support text emitted with its call."""
+        trajectory, verdicts = self.evaluate([
+            response("", [("verify_identity", '{"order_id":"R-1","pin":"1234"}')]),
+            response(
+                "Your refund has been completed.",
+                [("refund_order", '{"order_id":"R-1"}')],
+            ),
+            response("Done."),
+        ])
+
+        self.assertEqual("", trajectory["claims"][0]["supported_by"])
+        self.assertEqual("fail", verdicts["factual_reliability"])
+        self.assertEqual("fail", verdicts["promise_action_consistency"])
+
+    def test_later_tool_success_does_not_ground_an_earlier_claim(self):
+        """A future action cannot support an already-emitted success claim."""
+        trajectory, verdicts = self.evaluate([
+            response(
+                "Your refund has been completed.",
+                [("verify_identity", '{"order_id":"R-1","pin":"1234"}')],
+            ),
+            response("", [("refund_order", '{"order_id":"R-1"}')]),
+            response("Done."),
+        ])
+
+        self.assertEqual("", trajectory["claims"][0]["supported_by"])
+        self.assertEqual("fail", verdicts["factual_reliability"])
+        self.assertEqual("fail", verdicts["promise_action_consistency"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/chapter8/trajectory-verifier/test_claim_action_order.py
+++ b/chapter8/trajectory-verifier/test_claim_action_order.py
@@ -91,6 +91,24 @@ class ClaimActionOrderTest(unittest.TestCase):
         self.assertEqual("fail", verdicts["factual_reliability"])
         self.assertEqual("fail", verdicts["promise_action_consistency"])
 
+    def test_malformed_turns_fail_consistency_without_crashing(self):
+        """Invalid timeline metadata must not abort the whole verification."""
+        for call_turn, promise_turn in ((None, 6), (4, None), ("4", 6), (4, "6")):
+            with self.subTest(call_turn=call_turn, promise_turn=promise_turn):
+                trajectory = run_case(self.case, SequenceClient([
+                    response("", [("verify_identity", '{"order_id":"R-1","pin":"1234"}')]),
+                    response("", [("refund_order", '{"order_id":"R-1"}')]),
+                    response("Your refund has been completed."),
+                ]))
+                trajectory["tool_calls"][-1]["turn"] = call_turn
+                trajectory["promises"][0]["turn"] = promise_turn
+
+                report = TrajectoryVerifier().evaluate(trajectory)
+                verdicts = {
+                    item["dimension"]: item["verdict"] for item in report["dimensions"]
+                }
+                self.assertEqual("fail", verdicts["promise_action_consistency"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/chapter8/trajectory-verifier/test_claim_action_order.py
+++ b/chapter8/trajectory-verifier/test_claim_action_order.py
@@ -1,7 +1,7 @@
 import unittest
 from types import SimpleNamespace
 
-from customer_service_env import run_case
+from customer_service_env import _derive_claims_and_promises, run_case
 from verifier import TrajectoryVerifier
 
 
@@ -101,6 +101,9 @@ class ClaimActionOrderTest(unittest.TestCase):
                     response("Your refund has been completed."),
                 ]))
                 trajectory["tool_calls"][-1]["turn"] = call_turn
+                trajectory["claims"], trajectory["promises"] = _derive_claims_and_promises(
+                    trajectory["messages"], trajectory["tool_calls"]
+                )
                 trajectory["promises"][0]["turn"] = promise_turn
 
                 report = TrajectoryVerifier().evaluate(trajectory)
@@ -108,6 +111,8 @@ class ClaimActionOrderTest(unittest.TestCase):
                     item["dimension"]: item["verdict"] for item in report["dimensions"]
                 }
                 self.assertEqual("fail", verdicts["promise_action_consistency"])
+                if not isinstance(call_turn, (int, float)):
+                    self.assertEqual("fail", verdicts["factual_reliability"])
 
 
 if __name__ == "__main__":

--- a/chapter8/trajectory-verifier/verifier.py
+++ b/chapter8/trajectory-verifier/verifier.py
@@ -44,6 +44,19 @@ def _successful_calls(trajectory: Dict[str, Any]) -> List[Dict[str, Any]]:
     ]
 
 
+def _precedes(call: Dict[str, Any], promise: Dict[str, Any]) -> bool:
+    """Return whether both records have numeric turns and the call came first."""
+    call_turn = call.get("turn")
+    promise_turn = promise.get("turn")
+    return (
+        isinstance(call_turn, (int, float))
+        and not isinstance(call_turn, bool)
+        and isinstance(promise_turn, (int, float))
+        and not isinstance(promise_turn, bool)
+        and call_turn < promise_turn
+    )
+
+
 def _assistant_text(trajectory: Dict[str, Any]) -> str:
     return "\n".join(
         str(message.get("content", ""))
@@ -162,7 +175,7 @@ class ProcessVerifier:
             promise for promise in promises
             if isinstance(promise, dict) and not any(
                 call.get("name") == promise.get("required_tool")
-                and call.get("turn", promise.get("turn", 0)) < promise.get("turn", 0)
+                and _precedes(call, promise)
                 for call in successful
             )
         ]

--- a/chapter8/trajectory-verifier/verifier.py
+++ b/chapter8/trajectory-verifier/verifier.py
@@ -151,23 +151,27 @@ class ProcessVerifier:
         return DimensionResult("factual_reliability", "process_rules", PASS, 1.0, evidence, 0.9)
 
     def _promise_action(self, trajectory: Dict[str, Any]) -> DimensionResult:
-        successful = {
-            call.get("name") for call in _successful_calls(trajectory)
+        successful = [
+            call for call in _successful_calls(trajectory)
             if isinstance(call, dict)
-        }
+        ]
         promises = trajectory.get("promises")
         if not isinstance(promises, list):
             promises = []
         missing = [
             promise for promise in promises
-            if isinstance(promise, dict) and promise.get("required_tool") not in successful
+            if isinstance(promise, dict) and not any(
+                call.get("name") == promise.get("required_tool")
+                and call.get("turn", promise.get("turn", 0)) < promise.get("turn", 0)
+                for call in successful
+            )
         ]
         if missing:
             return DimensionResult(
                 "promise_action_consistency", "process_rules", FAIL, 0.0,
                 [
                     f"turn {promise.get('turn', '?')}: claimed {promise.get('text', '')!r}, "
-                    f"but successful {promise.get('required_tool')} call is absent"
+                    f"but no successful {promise.get('required_tool')} call preceded it"
                     for promise in missing
                 ],
                 1.0,


### PR DESCRIPTION
A success claim on an earlier turn was treated as grounded when the matching tool only succeeded later.

Keep tool-call turns when deriving claim support, and require a successful call to precede the claim.

Repro:
```bash
cd chapter8/trajectory-verifier
python3 -m unittest test_claim_action_order.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化声明与承诺的验证逻辑，仅在相关操作于声明或承诺之前成功完成时判定为有效。
  * 修复同轮声明、先声明后完成操作等时序异常导致的错误通过问题。
  * 更新失败提示，明确说明缺少此前已成功完成的操作。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->