### PR TITLE
fix(dynamic-form): keep trip-type modifiers out of destination_city

### DIFF
--- a/chapter5/dynamic-form/demo.py
+++ b/chapter5/dynamic-form/demo.py
@@ -235,7 +235,7 @@ FLIGHT_FORM_SCHEMA = {
 
 def _extract_destination(user_request):
     """从"去XX的机票"里粗抽目的地，作为表单常量随提交一起带回。抽不到就回落 None。"""
-    m = re.search(r"去(.+?)的?(?:机票|航班|票)", user_request)
+    m = re.search(r"去(.+?)的?(?:单程|往返)?(?:机票|航班|票)", user_request)
     if m:
         return m.group(1).strip()
     return None

--- a/chapter5/dynamic-form/demo.py
+++ b/chapter5/dynamic-form/demo.py
@@ -235,7 +235,7 @@ FLIGHT_FORM_SCHEMA = {
 
 def _extract_destination(user_request):
     """从"去XX的机票"里粗抽目的地，作为表单常量随提交一起带回。抽不到就回落 None。"""
-    m = re.search(r"去(.+?)的?(?:单程|往返)?(?:机票|航班|票)", user_request)
+    m = re.search(r"去(.+?)(?:的?(?:单程|往返))?的?(?:机票|航班|票)", user_request)
     if m:
         return m.group(1).strip()
     return None
@@ -706,7 +706,7 @@ def main():
         note = f"（模型 {model}）"
     print("-" * 68)
     print(summary)
-    print(f"-" * 68 + f"  {note}")
+    print("-" * 68 + f"  {note}")
 
     # 结果汇总
     print("\n" + "=" * 68)

--- a/chapter5/dynamic-form/test_round_trip_destination.py
+++ b/chapter5/dynamic-form/test_round_trip_destination.py
@@ -6,25 +6,36 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "user_request",
+    ("user_request", "expected_destination"),
     [
-        "我想订一张去北京的机票",
-        "我想订一张去北京的往返机票",
-        "我想订一张去北京往返机票",
-        "我想订一张去北京的单程机票",
-        "我想订一张去北京单程机票",
+        ("我想订一张去上海的机票", "上海"),
+        ("我想订一张去上海的往返机票", "上海"),
+        ("我想订一张去上海往返的机票", "上海"),
+        ("我想订一张去上海往返机票", "上海"),
+        ("我想订一张去广州的单程机票", "广州"),
+        ("我想订一张去广州单程的票", "广州"),
+        ("我想订一张去广州单程机票", "广州"),
+        ("我想订一张去深圳的航班", "深圳"),
+        ("我想订一张去深圳往返的航班", "深圳"),
+        ("我想订一张去杭州单程的票", "杭州"),
     ],
     ids=[
-        "simple",
-        "round-trip-with-de",
+        "simple-jipiao",
+        "round-trip-with-de-before",
+        "round-trip-with-de-after",
         "round-trip-without-de",
-        "one-way-with-de",
+        "one-way-with-de-before",
+        "one-way-with-de-after",
         "one-way-without-de",
+        "hangban-simple",
+        "hangban-round-trip",
+        "piao-one-way",
     ],
 )
-def test_offline_cli_extracts_only_the_destination(user_request, tmp_path):
+def test_offline_cli_extracts_only_the_destination(user_request, expected_destination, tmp_path):
     """Trip-type modifiers must not become part of the submitted destination."""
     demo = Path(__file__).with_name("demo.py")
+    output_html = tmp_path / "form.html"
     result = subprocess.run(
         [
             sys.executable,
@@ -33,12 +44,14 @@ def test_offline_cli_extracts_only_the_destination(user_request, tmp_path):
             "--request",
             user_request,
             "--output",
-            str(tmp_path / "form.html"),
+            str(output_html),
         ],
         capture_output=True,
         text=True,
     )
 
     assert result.returncode == 0, result.stderr
-    assert '"destination_city": "北京"' in result.stdout
-    assert "已收到您的订票信息：上海 → 北京，出发日期" in result.stdout
+    assert f'"destination_city": "{expected_destination}"' in result.stdout
+    assert f"已收到您的订票信息：上海 → {expected_destination}，出发日期" in result.stdout
+    form_html_content = output_html.read_text(encoding="utf-8")
+    assert f'"destination_city": "{expected_destination}"' in form_html_content

--- a/chapter5/dynamic-form/test_round_trip_destination.py
+++ b/chapter5/dynamic-form/test_round_trip_destination.py
@@ -1,0 +1,44 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "user_request",
+    [
+        "我想订一张去北京的机票",
+        "我想订一张去北京的往返机票",
+        "我想订一张去北京往返机票",
+        "我想订一张去北京的单程机票",
+        "我想订一张去北京单程机票",
+    ],
+    ids=[
+        "simple",
+        "round-trip-with-de",
+        "round-trip-without-de",
+        "one-way-with-de",
+        "one-way-without-de",
+    ],
+)
+def test_offline_cli_extracts_only_the_destination(user_request, tmp_path):
+    """Trip-type modifiers must not become part of the submitted destination."""
+    demo = Path(__file__).with_name("demo.py")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(demo),
+            "--offline",
+            "--request",
+            user_request,
+            "--output",
+            str(tmp_path / "form.html"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert '"destination_city": "北京"' in result.stdout
+    assert "已收到您的订票信息：上海 → 北京，出发日期" in result.stdout


### PR DESCRIPTION
Offline requests like `我想订一张去北京的往返机票` filled `destination_city` with `北京的往返` instead of `北京`.

Stop the destination capture before `单程` / `往返` so trip type stays on its own field.

Repro:
```bash
python3 -m pytest -q chapter5/dynamic-form/test_round_trip_destination.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 支持从包含“单程”或“往返”的中文机票请求中准确提取目的地。
  * 改进不同“的”字用法下的目的地识别，确保仅显示正确的目的地信息。

* **测试**
  * 新增离线命令行回归测试，覆盖五种中文订票请求场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->