### PR TITLE
fix(public-health-eval): compare unhashable evidence without set()

### DIFF
--- a/chapter6/public-health-reporting-eval/evaluator.py
+++ b/chapter6/public-health-reporting-eval/evaluator.py
@@ -35,6 +35,16 @@ def _equivalent(actual: Any, expected: Any, tolerance: float) -> bool:
     return actual == expected
 
 
+def _same_evidence(actual: list[Any], expected: list[Any]) -> bool:
+    """Compare evidence as set-like collections, including JSON objects."""
+    try:
+        return set(actual) == set(expected)
+    except TypeError:
+        return all(item in expected for item in actual) and all(
+            item in actual for item in expected
+        )
+
+
 def score_prediction(
     prediction: dict[str, Any], expected: dict[str, Any], tolerance: float = 0.01
 ) -> dict[str, Any]:
@@ -57,10 +67,7 @@ def score_prediction(
     expected_evidence = expected_result.get("evidence", []) if isinstance(expected_result, dict) else []
     if not isinstance(expected_evidence, list):
         expected_evidence = []
-    try:
-        details["evidence"] = int(set(actual_evidence) == set(expected_evidence))
-    except TypeError:
-        details["evidence"] = int(actual_evidence == expected_evidence)
+    details["evidence"] = int(_same_evidence(actual_evidence, expected_evidence))
 
     claims = prediction.get("claims", [])
     details["grounding_and_safety"] = int(

--- a/chapter6/public-health-reporting-eval/evaluator.py
+++ b/chapter6/public-health-reporting-eval/evaluator.py
@@ -54,7 +54,13 @@ def score_prediction(
     actual_evidence = actual_result.get("evidence", [])
     if not isinstance(actual_evidence, list):
         actual_evidence = []
-    details["evidence"] = int(set(actual_evidence) == set(expected_result["evidence"]))
+    expected_evidence = expected_result.get("evidence", []) if isinstance(expected_result, dict) else []
+    if not isinstance(expected_evidence, list):
+        expected_evidence = []
+    try:
+        details["evidence"] = int(set(actual_evidence) == set(expected_evidence))
+    except TypeError:
+        details["evidence"] = int(actual_evidence == expected_evidence)
 
     claims = prediction.get("claims", [])
     details["grounding_and_safety"] = int(

--- a/chapter6/public-health-reporting-eval/tests/test_null_result.py
+++ b/chapter6/public-health-reporting-eval/tests/test_null_result.py
@@ -49,3 +49,11 @@ def test_valid_result_still_full_score():
     prediction, expected = _sample_expected()
     result = score_prediction(prediction, expected)
     assert result["score"] == MAX_SCORE
+
+
+def test_unhashable_evidence_in_result():
+    prediction, expected = _sample_expected()
+    prediction = deepcopy(prediction)
+    prediction["result"]["evidence"] = [{"url": "http://example.com"}]
+    result = score_prediction(prediction, expected)
+    assert isinstance(result["score"], int)

--- a/chapter6/public-health-reporting-eval/tests/test_null_result.py
+++ b/chapter6/public-health-reporting-eval/tests/test_null_result.py
@@ -57,3 +57,15 @@ def test_unhashable_evidence_in_result():
     prediction["result"]["evidence"] = [{"url": "http://example.com"}]
     result = score_prediction(prediction, expected)
     assert isinstance(result["score"], int)
+
+
+def test_unhashable_evidence_remains_order_independent():
+    prediction, expected = _sample_expected()
+    prediction = deepcopy(prediction)
+    expected = deepcopy(expected)
+    expected["result"]["evidence"] = [{"url": "a"}, {"url": "b"}]
+    prediction["result"]["evidence"] = [{"url": "b"}, {"url": "a"}]
+
+    result = score_prediction(prediction, expected)
+
+    assert result["details"]["evidence"] == 1

--- a/chapter6/public-health-reporting-eval/tests/test_null_result.py
+++ b/chapter6/public-health-reporting-eval/tests/test_null_result.py
@@ -56,7 +56,7 @@ def test_unhashable_evidence_in_result():
     prediction = deepcopy(prediction)
     prediction["result"]["evidence"] = [{"url": "http://example.com"}]
     result = score_prediction(prediction, expected)
-    assert isinstance(result["score"], int)
+    assert result["details"]["evidence"] == 0
 
 
 def test_unhashable_evidence_remains_order_independent():


### PR DESCRIPTION
`score_prediction` crashed with `TypeError: unhashable type: 'dict'` when `result.evidence` contained dicts.

Fall back to direct list comparison when evidence items are unhashable.

Repro:
```bash
python3 -m pytest -q chapter6/public-health-reporting-eval/tests/test_null_result.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化证据匹配逻辑，支持包含 JSON 对象的证据及不同排列顺序。
  * 改进异常或非列表证据结果的处理，避免评分过程出错。

* **Tests**
  * 新增测试，覆盖不可哈希证据对象和证据顺序变化的场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->