### PR TITLE
fix(public-health-eval): treat null tool arguments like an empty dict

### DIFF
--- a/chapter6/public-health-reporting-eval/reporting_tools.py
+++ b/chapter6/public-health-reporting-eval/reporting_tools.py
@@ -131,7 +131,9 @@ class ReportingEnvironment:
             "evidence": [row["row_id"] for row in affected],
         }
 
-    def call(self, tool: str, arguments: dict[str, str]) -> dict[str, Any]:
+    def call(self, tool: str, arguments: dict[str, str] | None) -> dict[str, Any]:
+        if arguments is None:
+            arguments = {}
         allowed_tools = {
             "calculate_test_positivity": self.calculate_test_positivity,
             "calculate_reporting_completeness": self.calculate_reporting_completeness,

--- a/chapter6/public-health-reporting-eval/tests/test_blank_csv_int.py
+++ b/chapter6/public-health-reporting-eval/tests/test_blank_csv_int.py
@@ -74,4 +74,3 @@ def test_reporting_environment_call_null_arguments(tmp_path):
         env.call("calculate_test_positivity", {})
     assert "mapping" not in str(null_exc.value)
     assert str(null_exc.value) == str(empty_exc.value)
-

--- a/chapter6/public-health-reporting-eval/tests/test_blank_csv_int.py
+++ b/chapter6/public-health-reporting-eval/tests/test_blank_csv_int.py
@@ -59,3 +59,19 @@ def test_numeric_tests_unchanged(tmp_path):
     _write_csv(path, "12")
     env = ReportingEnvironment(path)
     assert env.rows[0]["tests"] == 12
+
+
+def test_reporting_environment_call_null_arguments(tmp_path):
+    """JSON null tool arguments should behave like an empty object."""
+    import pytest
+
+    path = tmp_path / "ok.csv"
+    _write_csv(path, "12")
+    env = ReportingEnvironment(path)
+    with pytest.raises(TypeError) as null_exc:
+        env.call("calculate_test_positivity", None)
+    with pytest.raises(TypeError) as empty_exc:
+        env.call("calculate_test_positivity", {})
+    assert "mapping" not in str(null_exc.value)
+    assert str(null_exc.value) == str(empty_exc.value)
+


### PR DESCRIPTION
`ReportingEnvironment.call` crashed with `TypeError: argument after ** must be a mapping, not NoneType` when `arguments` was null.

Treat null like `{}`, matching the usual JSON shape for tool calls with no args.

Repro:
```bash
python3 -m pytest -q chapter6/public-health-reporting-eval/tests/test_blank_csv_int.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 调用工具时可省略参数，系统会自动按空参数处理，使用更加便捷。
  * 统一无参数调用与传入空参数时的校验行为，并提供一致的错误提示。
* **测试**
  * 新增相关验证，确保不同无参数调用方式表现一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->