### PR TITLE
fix(self-modifying-agent): reject degenerate candidates cleanly; scan before executing untrusted source

### DIFF
--- a/chapter8/self-modifying-agent/evolution.py
+++ b/chapter8/self-modifying-agent/evolution.py
@@ -218,10 +218,26 @@ def validate_candidate(
     """Run trusted gates outside the candidate's writable surface."""
     checks = {name: False for name in CHECK_NAMES}
     try:
-        namespace = _namespace(candidate_source)
-        checks["static_compile"] = True
+        # Scan the candidate BEFORE executing it: this validator runs untrusted,
+        # model-generated code, so a source that fails the security scan must
+        # never have its module-level side effects executed. static_compile uses
+        # a non-executing compile() so it is still recorded for a rejected source.
+        checks["static_compile"] = bool(
+            compile(candidate_source, "candidate/retry_policy.py", "exec")
+        )
         checks["security_scan"] = _safe_ast(candidate_source)
+        if not checks["security_scan"]:
+            return checks
+        namespace = _namespace(candidate_source)
     except Exception:
+        return checks
+
+    # A syntactically valid but degenerate candidate (e.g. an empty LLM "source")
+    # compiles yet may define neither public function; reject cleanly here so the
+    # behavior gates below cannot KeyError on a missing name.
+    if not callable(namespace.get("should_retry")) or not callable(
+        namespace.get("should_open_circuit")
+    ):
         return checks
 
     expected_retry = "(error_code, retryable, attempt)"

--- a/chapter8/self-modifying-agent/evolution.py
+++ b/chapter8/self-modifying-agent/evolution.py
@@ -222,9 +222,8 @@ def validate_candidate(
         # model-generated code, so a source that fails the security scan must
         # never have its module-level side effects executed. static_compile uses
         # a non-executing compile() so it is still recorded for a rejected source.
-        checks["static_compile"] = bool(
-            compile(candidate_source, "candidate/retry_policy.py", "exec")
-        )
+        compile(candidate_source, "candidate/retry_policy.py", "exec")
+        checks["static_compile"] = True
         checks["security_scan"] = _safe_ast(candidate_source)
         if not checks["security_scan"]:
             return checks
@@ -249,29 +248,34 @@ def validate_candidate(
         )
     except (TypeError, ValueError):
         checks["public_api_compatible"] = False
-    failures = [item for item in trajectories if item.get("outcome") == "failure"]
-    checks["failure_replay"] = bool(failures) and all(
-        not namespace["should_retry"](item["error_code"], item["retryable"], attempt)
-        for item in failures for attempt in range(item["attempts"])
-    )
-    checks["nonretryable_circuit"] = bool(failures) and all(
-        namespace["should_open_circuit"](1, error_code=item["error_code"], retryable=item["retryable"])
-        for item in failures
-    )
-    checks["temporary_recovery"] = _temporary_recovery(namespace)
-    checks["old_task_regression"] = all((
-        namespace["should_retry"]("TEMPORARY_TIMEOUT", True, 0),
-        namespace["should_retry"]("TEMPORARY_TIMEOUT", True, 2),
-        not namespace["should_retry"]("TEMPORARY_TIMEOUT", True, 3),
-        not namespace["should_open_circuit"](4, error_code="TEMPORARY_TIMEOUT", retryable=True),
-        namespace["should_open_circuit"](5, error_code="TEMPORARY_TIMEOUT", retryable=True),
-    ))
-    # Canary covers an unseen permanent code plus the original temporary path.
-    checks["canary_ready"] = all((
-        not namespace["should_retry"]("AUTH_DENIED", True, 0),
-        namespace["should_open_circuit"](1, error_code="AUTH_DENIED", retryable=True),
-        _temporary_recovery(namespace),
-    ))
+    if not checks["public_api_compatible"]:
+        return checks
+    try:
+        failures = [item for item in trajectories if item.get("outcome") == "failure"]
+        checks["failure_replay"] = bool(failures) and all(
+            not namespace["should_retry"](item["error_code"], item["retryable"], attempt)
+            for item in failures for attempt in range(item["attempts"])
+        )
+        checks["nonretryable_circuit"] = bool(failures) and all(
+            namespace["should_open_circuit"](1, error_code=item["error_code"], retryable=item["retryable"])
+            for item in failures
+        )
+        checks["temporary_recovery"] = _temporary_recovery(namespace)
+        checks["old_task_regression"] = all((
+            namespace["should_retry"]("TEMPORARY_TIMEOUT", True, 0),
+            namespace["should_retry"]("TEMPORARY_TIMEOUT", True, 2),
+            not namespace["should_retry"]("TEMPORARY_TIMEOUT", True, 3),
+            not namespace["should_open_circuit"](4, error_code="TEMPORARY_TIMEOUT", retryable=True),
+            namespace["should_open_circuit"](5, error_code="TEMPORARY_TIMEOUT", retryable=True),
+        ))
+        # Canary covers an unseen permanent code plus the original temporary path.
+        checks["canary_ready"] = all((
+            not namespace["should_retry"]("AUTH_DENIED", True, 0),
+            namespace["should_open_circuit"](1, error_code="AUTH_DENIED", retryable=True),
+            _temporary_recovery(namespace),
+        ))
+    except Exception:
+        return checks
     if stable_source is None:
         # Backward-compatible test path: rollback content is supplied by the caller in production.
         checks["rollback_ready"] = True

--- a/chapter8/self-modifying-agent/test_evolution.py
+++ b/chapter8/self-modifying-agent/test_evolution.py
@@ -1,4 +1,5 @@
 import json
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -71,25 +72,31 @@ class SelfModificationTest(unittest.TestCase):
             self.assertFalse(all(checks.values()))
             self.assertFalse(checks["failure_replay"])
 
+    def test_candidate_exception_is_rejected_without_crashing(self):
+        source = self.candidate["source"].replace(
+            '    """Return whether another tool call should be attempted."""',
+            '    raise RuntimeError("candidate failed")',
+            1,
+        )
+        checks = validate_candidate(source, self.trajectories)
+        self.assertTrue(checks["public_api_compatible"])
+        self.assertFalse(checks["failure_replay"])
+
     def test_unsafe_candidate_is_not_executed_during_validation(self):
         # The security scan must run before the candidate is exec()'d, so a
         # source flagged unsafe never runs its module-level side effects.
-        import os
-        import tempfile
-
-        marker = tempfile.mktemp()
-        unsafe = (
-            "import pathlib\n"
-            f"pathlib.Path({marker!r}).write_text('ran')\n"
-            "def should_retry(error_code, retryable, attempt):\n    return False\n"
-            "def should_open_circuit(consecutive_failures, *, error_code='', retryable=True):\n"
-            "    return True\n"
-        )
-        checks = validate_candidate(unsafe, self.trajectories)
-        self.assertFalse(checks["security_scan"])
-        self.assertFalse(os.path.exists(marker))
-        if os.path.exists(marker):
-            os.remove(marker)
+        with tempfile.TemporaryDirectory() as directory:
+            marker = Path(directory) / "marker"
+            unsafe = (
+                "import pathlib\n"
+                f"pathlib.Path({str(marker)!r}).write_text('ran')\n"
+                "def should_retry(error_code, retryable, attempt):\n    return False\n"
+                "def should_open_circuit(consecutive_failures, *, error_code='', retryable=True):\n"
+                "    return True\n"
+            )
+            checks = validate_candidate(unsafe, self.trajectories)
+            self.assertFalse(checks["security_scan"])
+            self.assertFalse(marker.exists())
 
 
 if __name__ == "__main__":

--- a/chapter8/self-modifying-agent/test_evolution.py
+++ b/chapter8/self-modifying-agent/test_evolution.py
@@ -62,6 +62,35 @@ class SelfModificationTest(unittest.TestCase):
         self.assertTrue(manifest["canary_gate"]["eligible"])
         self.assertEqual(manifest["stable_sha256"], manifest["rollback_sha256"])
 
+    def test_degenerate_candidate_is_rejected_without_crashing(self):
+        # A syntactically valid but degenerate source (e.g. an empty LLM reply)
+        # compiles yet defines neither public function; validate_candidate must
+        # reject it cleanly, not raise KeyError from the behavior gates.
+        for source in ("\n", "# only a comment\n"):
+            checks = validate_candidate(source, self.trajectories)
+            self.assertFalse(all(checks.values()))
+            self.assertFalse(checks["failure_replay"])
+
+    def test_unsafe_candidate_is_not_executed_during_validation(self):
+        # The security scan must run before the candidate is exec()'d, so a
+        # source flagged unsafe never runs its module-level side effects.
+        import os
+        import tempfile
+
+        marker = tempfile.mktemp()
+        unsafe = (
+            "import pathlib\n"
+            f"pathlib.Path({marker!r}).write_text('ran')\n"
+            "def should_retry(error_code, retryable, attempt):\n    return False\n"
+            "def should_open_circuit(consecutive_failures, *, error_code='', retryable=True):\n"
+            "    return True\n"
+        )
+        checks = validate_candidate(unsafe, self.trajectories)
+        self.assertFalse(checks["security_scan"])
+        self.assertFalse(os.path.exists(marker))
+        if os.path.exists(marker):
+            os.remove(marker)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two problems in `validate_candidate()` (`chapter8/self-modifying-agent/evolution.py`), which runs untrusted model-generated candidate source:

### 1. Crash on a degenerate candidate (major)
A syntactically valid source that defines neither public function compiles fine, then the behavior gates do `namespace["should_retry"](...)` / `_temporary_recovery(...)` and raise **`KeyError: 'should_retry'`** — aborting the whole 8-5 release harness mid-run (after the paid API call) instead of returning a clean reject. This is exactly what happens when `generate_with_openai` gets a reply with an empty `"source"` (→ candidate source `"\n"`, `llm_generator.py`). Now the validator checks both public functions are callable and returns the failing checks dict if not.

### 2. Executed before scanning (security ordering)
`_namespace()` (which `exec()`s the source) ran **before** `_safe_ast()`, so a candidate that fails the security scan still executed its module-level side effects during validation — defeating the safety story for a self-modifying agent (repro: a candidate whose body does `import pathlib; pathlib.Path(...).write_text(...)` writes the file even though the scan then flags it). The scan (and a non-executing `compile()` for `static_compile`) now runs first; `exec` only happens if the scan passes.

**Verification:** added two regression tests (empty/degenerate → clean reject, no KeyError; unsafe candidate → side effect not executed). Both fail on the old code; the existing `test_evolution.py` suite still passes (8/8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进候选代码验证流程：先完成编译和安全扫描，再执行模块代码。
  * 及时拒绝不安全、为空或仅含注释的候选代码，避免触发运行时异常。
  * 检查必要接口是否存在且可调用，提升验证结果的可靠性。
  * 阻止包含模块级副作用的非安全代码在验证期间执行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->