### PR TITLE
fix(providers): honour OPENROUTER_MODEL for the openrouter default model

### DIFF
--- a/agentbook/providers/resolution.py
+++ b/agentbook/providers/resolution.py
@@ -12,6 +12,8 @@ talks to.
 
 from __future__ import annotations
 
+import os
+
 from .models import Backend, Provider
 from .openrouter import (
     ZERO_COST_HINT,
@@ -136,7 +138,16 @@ def resolve_backend(
             neither its own variables nor ``OPENROUTER_API_KEY`` are set.
     """
     spec = lookup(provider)
-    resolved_model = model or spec.default_model
+    if model:
+        resolved_model = model
+    elif spec.name == _OPENROUTER:
+        # The OpenRouter default honours OPENROUTER_MODEL — the env var this
+        # package documents (see the module docstring / ZERO_COST_HINT) as the
+        # ':free' zero-cost selector. Without this, the documented free recipe
+        # silently resolves the paid OPENROUTER_DEFAULT_MODEL instead.
+        resolved_model = os.getenv("OPENROUTER_MODEL", "").strip() or spec.default_model
+    else:
+        resolved_model = spec.default_model
     key = (api_key or "").strip() or spec.api_key()
 
     # Only OpenRouter's own credential can authenticate against OpenRouter. An

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -470,3 +470,21 @@ def test_placeholder_key_is_not_a_provider_name():
     assert backend.api_key
     assert backend.api_key != backend.provider
     assert backend.api_key not in PROVIDERS
+
+
+def test_openrouter_default_model_honours_openrouter_model_env(monkeypatch):
+    """resolve_backend("openrouter") with no explicit model must use
+    OPENROUTER_MODEL (the documented ':free' zero-cost selector), not the paid
+    OPENROUTER_DEFAULT_MODEL."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+    monkeypatch.setenv("OPENROUTER_MODEL", "google/gemma-4-31b-it:free")
+    backend = resolve_backend("openrouter")
+    assert backend.using_openrouter is True
+    assert backend.model == "google/gemma-4-31b-it:free"
+
+
+def test_openrouter_explicit_model_still_wins_over_env(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+    monkeypatch.setenv("OPENROUTER_MODEL", "google/gemma-4-31b-it:free")
+    backend = resolve_backend("openrouter", model="gpt-4o")
+    assert backend.model == "openai/gpt-4o"


### PR DESCRIPTION
`agentbook/providers` — `resolve_backend("openrouter")` with no explicit model used the hardcoded **paid** `OPENROUTER_DEFAULT_MODEL` and never read `OPENROUTER_MODEL`.

But the package documents `OPENROUTER_MODEL` (module docstring + `ZERO_COST_HINT`) as *the* `:free` zero-cost selector, and the `map_model_to_openrouter(substitute_unknown=True)` path already reads it (`openrouter.py:129`) — that path is just never reached because the concrete default id already contains `/`, so `map_model_to_openrouter` returns it unchanged. Result: the documented free recipe (`OPENROUTER_API_KEY` + `OPENROUTER_MODEL=…:free`, no `--model`, e.g. `python chapter1/context/main.py --provider openrouter`) silently resolved `openai/gpt-5.6-luna` and **billed the user**.

**Fix:** the openrouter default now reads `OPENROUTER_MODEL` (trimmed), falling back to the package default only when unset. An explicit `model=` still wins; no other provider's default changes.

**Verification:** `resolve_backend("openrouter")` with `OPENROUTER_MODEL=google/gemma-4-31b-it:free` → `google/gemma-4-31b-it:free` (was the paid default); `resolve_backend("openrouter", model="gpt-4o")` → `openai/gpt-4o`; unset → the default. Added 2 regression tests (the default test fails on the old code); the existing 53 provider tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 使用 OpenRouter 时，未指定模型将优先采用 `OPENROUTER_MODEL` 环境变量中的配置。
  - 环境变量为空或未设置时，将自动使用默认模型。
  - 手动指定模型时，手动配置优先级更高。

- **测试**
  - 增加了相关模型选择场景的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->