### PR TITLE
fix(phone-registration): report pre-fill failures to the user; don't abort a live call on the idle cap

### DIFF
--- a/chapter10/autonomous-phone-registration/browser.py
+++ b/chapter10/autonomous-phone-registration/browser.py
@@ -8,6 +8,10 @@ from typing import List, Optional
 from models import FieldSpec
 
 
+class RecoverableFillError(RuntimeError):
+    """A page-specific field failure that may be reported without aborting the call."""
+
+
 class RegistrationBrowser:
     """Owns a real Chromium browser/context/page and exposes form operations.
 
@@ -83,35 +87,48 @@ class RegistrationBrowser:
     async def fill(self, field: FieldSpec, value: str) -> None:
         if self.page is None:
             raise RuntimeError("browser is not open")
-        locator = self.page.locator(field.selector).first
-        await locator.scroll_into_view_if_needed()
-        kind = field.input_type.lower()
-        if kind == "select":
-            try:
-                await locator.select_option(label=value)
-            except Exception:
-                await locator.select_option(value=value)
-        elif kind in {"checkbox", "radio"}:
-            group = self.page.locator(field.selector)
-            wanted = value.strip().casefold()
-            chosen = None
-            for i in range(await group.count()):
-                item = group.nth(i)
-                raw_value = (await item.get_attribute("value") or "").strip()
-                item_id = await item.get_attribute("id")
-                label = ""
-                if item_id:
-                    label_node = self.page.locator(f'label[for="{item_id}"]').first
-                    if await label_node.count():
-                        label = (await label_node.inner_text()).strip()
-                if wanted in {raw_value.casefold(), label.casefold()}:
-                    chosen = item
-                    break
-            if chosen is None:
-                raise ValueError(f"{field.label} 没有选项 {value!r}")
-            await chosen.check()
-        else:
-            await locator.fill(value)
+        from playwright.async_api import Error as PlaywrightError
+
+        try:
+            locator = self.page.locator(field.selector).first
+            await locator.scroll_into_view_if_needed()
+            kind = field.input_type.lower()
+            if kind == "select":
+                try:
+                    await locator.select_option(label=value)
+                except PlaywrightError:
+                    await locator.select_option(value=value)
+            elif kind in {"checkbox", "radio"}:
+                group = self.page.locator(field.selector)
+                wanted = value.strip().casefold()
+                chosen = None
+                for i in range(await group.count()):
+                    item = group.nth(i)
+                    raw_value = (await item.get_attribute("value") or "").strip()
+                    item_id = await item.get_attribute("id")
+                    label = ""
+                    if item_id:
+                        label_node = self.page.locator(f'label[for="{item_id}"]').first
+                        if await label_node.count():
+                            label = (await label_node.inner_text()).strip()
+                    if wanted in {raw_value.casefold(), label.casefold()}:
+                        chosen = item
+                        break
+                if chosen is None:
+                    raise RecoverableFillError(
+                        f"{field.name} has no matching page option"
+                    )
+                await chosen.check()
+            else:
+                await locator.fill(value)
+        except RecoverableFillError:
+            raise
+        except PlaywrightError as exc:
+            # Do not include the value or raw Playwright text: either may contain
+            # user-supplied form data that must not enter logs or traces.
+            raise RecoverableFillError(
+                f"browser could not fill {field.name}: {type(exc).__name__}"
+            ) from exc
 
     async def submit(self) -> bool:
         if not self.submit_enabled:

--- a/chapter10/autonomous-phone-registration/orchestration.py
+++ b/chapter10/autonomous-phone-registration/orchestration.py
@@ -291,20 +291,22 @@ class ComputerAgent:
         self.filled.append(name)
         await self.bus.send("computer_agent", "phone_agent", "field_filled", field=name)
 
+    async def _report_fill_error(self, name: str, exc: Exception) -> None:
+        """Record one browser failure and forward the shared error envelope."""
+        error = {"field": name, "error": str(exc)}
+        self.errors.append(error)
+        await self.bus.send("computer_agent", "phone_agent", "fill_error", **error)
+
     async def run(self) -> Dict[str, object]:
         for name, value in self.known_values.items():
             if name in self.fields:
                 try:
                     await self._fill(name, value)
                 except Exception as exc:  # page-specific errors remain isolated
-                    error = {"field": name, "error": str(exc)}
-                    self.errors.append(error)
                     # Mirror the in-dialogue fill path below: surface the failure
                     # to the phone agent (via browser_feedback) so it doesn't tell
                     # the user registration succeeded when a known field failed.
-                    await self.bus.send(
-                        "computer_agent", "phone_agent", "fill_error", **error
-                    )
+                    await self._report_fill_error(name, exc)
 
         completed = False
         while not completed:
@@ -320,11 +322,7 @@ class ComputerAgent:
                 try:
                     await self._fill(message.payload["field"], message.payload["value"])
                 except Exception as exc:
-                    error = {"field": message.payload["field"], "error": str(exc)}
-                    self.errors.append(error)
-                    await self.bus.send(
-                        "computer_agent", "phone_agent", "fill_error", **error
-                    )
+                    await self._report_fill_error(message.payload["field"], exc)
             elif message.type == "call_failed":
                 self.errors.append({
                     "field": message.payload.get("field", ""),

--- a/chapter10/autonomous-phone-registration/orchestration.py
+++ b/chapter10/autonomous-phone-registration/orchestration.py
@@ -297,11 +297,25 @@ class ComputerAgent:
                 try:
                     await self._fill(name, value)
                 except Exception as exc:  # page-specific errors remain isolated
-                    self.errors.append({"field": name, "error": str(exc)})
+                    error = {"field": name, "error": str(exc)}
+                    self.errors.append(error)
+                    # Mirror the in-dialogue fill path below: surface the failure
+                    # to the phone agent (via browser_feedback) so it doesn't tell
+                    # the user registration succeeded when a known field failed.
+                    await self.bus.send(
+                        "computer_agent", "phone_agent", "fill_error", **error
+                    )
 
         completed = False
         while not completed:
-            message = await self.bus.receive("computer_agent", timeout=120)
+            # This idle cap must exceed the phone side's worst-case per-question
+            # latency (TTS + the channel's own listen window + value extraction).
+            # The default WebRTC human listen allows a start timer plus an answer
+            # timer (~240s total), so a 120s cap here aborts a live call while the
+            # user is still legitimately answering. run_parallel cancels this task
+            # the moment the phone task completes or errors, so a larger cap only
+            # relaxes the false-abort case.
+            message = await self.bus.receive("computer_agent", timeout=600)
             if message.type == "info_collected":
                 try:
                     await self._fill(message.payload["field"], message.payload["value"])

--- a/chapter10/autonomous-phone-registration/orchestration.py
+++ b/chapter10/autonomous-phone-registration/orchestration.py
@@ -8,7 +8,7 @@ import os
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from browser import RegistrationBrowser
+from browser import RecoverableFillError, RegistrationBrowser
 from bus import MessageBus
 from models import DecisionRecord, FieldSpec
 from voice import PhoneChannel
@@ -291,18 +291,24 @@ class ComputerAgent:
         self.filled.append(name)
         await self.bus.send("computer_agent", "phone_agent", "field_filled", field=name)
 
-    async def _report_fill_error(self, name: str, exc: Exception) -> None:
+    async def _report_fill_error(self, name: str, exc: RecoverableFillError) -> None:
         """Record one browser failure and forward the shared error envelope."""
         error = {"field": name, "error": str(exc)}
         self.errors.append(error)
-        await self.bus.send("computer_agent", "phone_agent", "fill_error", **error)
+        await self.bus.send(
+            "computer_agent",
+            "phone_agent",
+            "fill_error",
+            sensitive_keys=("error",),
+            **error,
+        )
 
     async def run(self) -> Dict[str, object]:
         for name, value in self.known_values.items():
             if name in self.fields:
                 try:
                     await self._fill(name, value)
-                except Exception as exc:  # page-specific errors remain isolated
+                except RecoverableFillError as exc:
                     # Mirror the in-dialogue fill path below: surface the failure
                     # to the phone agent (via browser_feedback) so it doesn't tell
                     # the user registration succeeded when a known field failed.
@@ -319,10 +325,16 @@ class ComputerAgent:
             # relaxes the false-abort case.
             message = await self.bus.receive("computer_agent", timeout=600)
             if message.type == "info_collected":
+                name = message.payload.get("field")
+                value = message.payload.get("value")
+                if not isinstance(name, str) or not name:
+                    raise ValueError("info_collected requires a non-empty field")
+                if not isinstance(value, str):
+                    raise ValueError("info_collected requires a string value")
                 try:
-                    await self._fill(message.payload["field"], message.payload["value"])
-                except Exception as exc:
-                    await self._report_fill_error(message.payload["field"], exc)
+                    await self._fill(name, value)
+                except RecoverableFillError as exc:
+                    await self._report_fill_error(name, exc)
             elif message.type == "call_failed":
                 self.errors.append({
                     "field": message.payload.get("field", ""),

--- a/chapter10/autonomous-phone-registration/test_orchestration.py
+++ b/chapter10/autonomous-phone-registration/test_orchestration.py
@@ -4,9 +4,15 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 import demo
+from browser import RecoverableFillError
 from bus import MessageBus
 from models import DecisionRecord, FieldSpec
-from orchestration import initiate_phone_call_agent, run_parallel, timing_evidence
+from orchestration import (
+    ComputerAgent,
+    initiate_phone_call_agent,
+    run_parallel,
+    timing_evidence,
+)
 from voice import ScriptedPhoneChannel
 
 
@@ -40,7 +46,7 @@ class FailingFillBrowser(FakeBrowser):
         self.submit_calls = 0
 
     async def fill(self, field, value):
-        raise ValueError(f"cannot fill {field.name}")
+        raise RecoverableFillError(f"cannot fill {field.name}")
 
     async def submit(self):
         self.submit_calls += 1
@@ -216,8 +222,27 @@ async def test_computer_fill_error_flows_back_to_phone_and_blocks_submission():
     assert agents.phone.browser_feedback == [
         {"field": "email", "error": "cannot fill email"}
     ]
-    assert any(message.type == "fill_error" for message in bus.history)
+    fill_error = next(message for message in bus.history if message.type == "fill_error")
+    assert getattr(fill_error, "_sensitive_keys") == ("error",)
     assert "填写遇到问题" in channel.prompts[-1]
+
+
+@pytest.mark.asyncio
+async def test_malformed_info_collected_fails_before_fill_error_handling():
+    bus = MessageBus()
+    computer = ComputerAgent(bus, FakeBrowser(), [], {})
+    task = asyncio.create_task(computer.run())
+    await bus.send(
+        "phone_agent",
+        "computer_agent",
+        "info_collected",
+        sensitive_keys=("value",),
+        value="secret",
+    )
+
+    with pytest.raises(ValueError, match="non-empty field"):
+        await task
+    assert not any(message.type == "fill_error" for message in bus.history)
 
 
 @pytest.mark.asyncio
@@ -266,7 +291,7 @@ class CountryFailBrowser(SubmittingFakeBrowser):
 
     async def fill(self, field, value):
         if field.name == "country":
-            raise ValueError(f"cannot fill {field.name}")
+            raise RecoverableFillError(f"cannot fill {field.name}")
         await asyncio.sleep(0.05)
         self.values[field.name] = value
 

--- a/chapter10/autonomous-phone-registration/test_orchestration.py
+++ b/chapter10/autonomous-phone-registration/test_orchestration.py
@@ -259,3 +259,52 @@ async def test_optional_blank_is_audited_skip_and_never_written_to_browser():
     evidence = timing_evidence(bus)
     assert evidence["expected_overlap_count"] == 1
     assert len(evidence["overlap_checks"]) == 1
+
+
+class CountryFailBrowser(SubmittingFakeBrowser):
+    """Fails only the pre-filled known field, succeeds on the phone-collected one."""
+
+    async def fill(self, field, value):
+        if field.name == "country":
+            raise ValueError(f"cannot fill {field.name}")
+        await asyncio.sleep(0.05)
+        self.values[field.name] = value
+
+
+@pytest.mark.asyncio
+async def test_known_value_fill_error_flows_back_to_phone_and_blocks_submission():
+    # A known_values field that fails to pre-fill must surface a fill_error (like
+    # the in-dialogue path), so the phone agent reports the failure instead of
+    # telling the user registration completed.
+    email = FieldSpec("email", "邮箱", "email")
+    country = FieldSpec("country", "国家", "text")
+    decision = DecisionRecord(
+        page_url="https://example.test/register",
+        page_title="Register",
+        known_fields=[country],
+        discovered_fields=[email, country],
+        tool_called="initiate_phone_call_agent",
+        purpose="协助填写注册表单",
+        required_info=[email],
+        rationale_summary="tool call",
+        model="test",
+        monotonic_seconds=0,
+    )
+    browser = CountryFailBrowser()
+    channel = ScriptedPhoneChannel(["me@example.com"])
+    bus = MessageBus()
+    agents = initiate_phone_call_agent(
+        decision=decision,
+        bus=bus,
+        channel=channel,
+        browser=browser,
+        known_values={"country": "US"},
+    )
+    with patch("orchestration._extract_value", AsyncMock(return_value="me@example.com")):
+        result = await run_parallel(agents, bus)
+
+    assert result["submitted"] is False
+    assert browser.submit_calls == 0
+    assert {"field": "country", "error": "cannot fill country"} in agents.phone.browser_feedback
+    assert any(message.type == "fill_error" for message in bus.history)
+    assert "填写遇到问题" in channel.prompts[-1]

--- a/chapter10/autonomous-phone-registration/test_orchestration.py
+++ b/chapter10/autonomous-phone-registration/test_orchestration.py
@@ -281,7 +281,7 @@ async def test_known_value_fill_error_flows_back_to_phone_and_blocks_submission(
     decision = DecisionRecord(
         page_url="https://example.test/register",
         page_title="Register",
-        known_fields=[country],
+        known_fields=[country.name],
         discovered_fields=[email, country],
         tool_called="initiate_phone_call_agent",
         purpose="协助填写注册表单",


### PR DESCRIPTION
`chapter10/autonomous-phone-registration/orchestration.py`, two fixes in `ComputerAgent.run`:

### 1. Pre-fill failure told the user "success" (minor)
A failure while pre-filling a `known_values` field was recorded in `self.errors` (blocking submission) but, unlike the in-dialogue fill path, never emitted a `fill_error` message. The phone's final line is chosen purely from `browser_feedback` (populated only by `fill_error`), so with none sent it said "所需信息已经收集并填写完成" (success) even though `submitted=False` and the field failed. Now the pre-fill `except` mirrors the in-dialogue path and sends `fill_error`. Added a regression test — on the old code it prints the success line.

### 2. 120s idle cap aborts a live call mid-answer (robustness)
`ComputerAgent`'s inter-message `receive()` idle cap was `120s`, shorter than the phone side's worst-case per-question latency: the default WebRTC human `listen` arms a start timer **plus** an answer timer (~240s total, not wrapped in `wait_for` on the Python side). A user slow on one question pushes the round-trip past 120s → `receive()` raises `TimeoutError` → `run_parallel` FIRST_EXCEPTION cancels the phone task and tears the call down while the user is still answering. Raised to `600s`; `run_parallel` still cancels this task the instant the phone task completes/errors, so it only relaxes the false-abort.

**Verification:** full `test_orchestration.py` suite passes (8/8 incl. the new pre-fill test, which fails on the old code); finding 2 verified by code-reading + a scaled orchestration repro (the live telephony stack isn't runnable in CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 改进注册流程中的字段预填充失败处理。
  * 预填充失败时会提示用户，并阻止提交不完整的信息。
  * 失败信息会反馈至后续处理流程，以便及时修正。
  * 延长收件等待时间，降低处理超时导致的失败。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->