### PR TITLE
fix(trajectory-verifier): tolerate explicit null score/confidence/evidence from the quality judge

### DIFF
--- a/chapter8/trajectory-verifier/llm_judge.py
+++ b/chapter8/trajectory-verifier/llm_judge.py
@@ -73,12 +73,20 @@ Trajectory evidence:
             verdict = item.get("verdict", UNCERTAIN)
             if verdict not in {PASS, FAIL, UNCERTAIN}:
                 verdict = UNCERTAIN
+            # dict.get(key, default) returns the default only when the key is
+            # ABSENT; a model that emits an explicit JSON null (common for a
+            # dimension it marks "uncertain") returns None, and float(None) /
+            # iterating None both raise. Coerce non-numeric / non-list values to
+            # the neutral defaults instead of crashing the whole trajectory.
+            score = item.get("score")
+            confidence = item.get("confidence")
+            evidence = item.get("evidence")
             results.append(DimensionResult(
                 dimension=name,
                 layer="llm_rubric",
                 verdict=verdict,
-                score=float(item.get("score", 0.5)),
-                evidence=[str(value) for value in item.get("evidence", ["LLM returned no evidence"])],
-                confidence=float(item.get("confidence", 0.5)),
+                score=float(score) if isinstance(score, (int, float)) and not isinstance(score, bool) else 0.5,
+                evidence=[str(value) for value in evidence] if isinstance(evidence, list) and evidence else ["LLM returned no evidence"],
+                confidence=float(confidence) if isinstance(confidence, (int, float)) and not isinstance(confidence, bool) else 0.5,
             ))
         return results

--- a/chapter8/trajectory-verifier/test_llm_judge_null_fields.py
+++ b/chapter8/trajectory-verifier/test_llm_judge_null_fields.py
@@ -1,0 +1,48 @@
+"""Regression: OpenAIQualityJudge must tolerate an explicit JSON null for
+score / confidence / evidence in the model's response — dict.get(key, default)
+only applies the default when the key is ABSENT, so a null value returns None and
+float(None) / iterating None crash the whole trajectory evaluation."""
+import json
+import types
+
+from llm_judge import OpenAIQualityJudge
+
+
+class _FakeClient:
+    model = "fake-model"
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def complete(self, **kwargs):
+        message = types.SimpleNamespace(content=json.dumps(self._payload))
+        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=message)])
+
+
+def test_quality_judge_tolerates_null_score_confidence_evidence():
+    payload = {
+        "dimensions": [
+            {
+                "dimension": "expression_quality",
+                "verdict": "uncertain",
+                "score": None,
+                "confidence": None,
+                "evidence": None,
+            },
+            {
+                "dimension": "compliant_flexibility",
+                "verdict": "pass",
+                "score": 0.8,
+                "confidence": 0.9,
+                "evidence": ["turn 2"],
+            },
+        ]
+    }
+    judge = OpenAIQualityJudge(evidence_client=_FakeClient(payload))
+    results = list(judge.evaluate({"messages": [], "process_facts": {}}))
+
+    assert len(results) == 2
+    eq = next(r for r in results if r.dimension == "expression_quality")
+    assert eq.score == 0.5
+    assert eq.confidence == 0.5
+    assert eq.evidence == ["LLM returned no evidence"]


### PR DESCRIPTION
`chapter8/trajectory-verifier/llm_judge.py` — `OpenAIQualityJudge.evaluate` read the LLM's per-dimension fields with `dict.get(key, default)`, but the default only applies when the key is **absent**. A model that emits an explicit JSON `null` (common for a dimension it marks `"uncertain"`) returns `None`, and `float(None)` / iterating `None` both raise `TypeError` — crashing the whole trajectory evaluation. `response_format={"type":"json_object"}` does not forbid null-valued fields.

**Fix:** coerce a non-numeric `score`/`confidence` and a non-list `evidence` to the neutral defaults (`0.5` / placeholder), excluding `bool` so `score: true` isn't read as `1.0`.

**Verification:** added a regression test that feeds `{"score":null,"confidence":null,"evidence":null}` via an injected fake client — it fails on the old code (`TypeError` at the `float(...)`) and passes after (score/confidence `0.5`, placeholder evidence). Existing tests pass.