### PR TITLE
fix(search-codegen): don't crash import on non-integer DEFAULT_MAX_TOKENS; report real token usage

### DIFF
--- a/chapter1/search-codegen/config.py
+++ b/chapter1/search-codegen/config.py
@@ -8,6 +8,17 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
+def _optional_int_env(name: str) -> Optional[int]:
+    """Read an optional integer without making module import configuration-fatal."""
+    raw_value = os.getenv(name)
+    if raw_value is None or not raw_value.strip():
+        return None
+    try:
+        return int(raw_value.strip())
+    except ValueError:
+        return None
+
+
 class Config:
     OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
     OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
@@ -24,13 +35,7 @@ class Config:
     BACKEND = os.getenv("BACKEND", "openai")
     MODEL_NAME = os.getenv("MODEL_NAME", "gpt-5.6-sol")
     DEFAULT_TEMPERATURE = 0.3  # legacy CLI compatibility; intentionally omitted
-    DEFAULT_MAX_TOKENS: Optional[int] = (
-        int(os.getenv("DEFAULT_MAX_TOKENS"))
-        # Only parse a plain integer; a non-numeric value (e.g. "4000.0") would
-        # otherwise raise ValueError at import and kill every entry point.
-        if (os.getenv("DEFAULT_MAX_TOKENS") or "").strip().isdigit()
-        else None
-    )
+    DEFAULT_MAX_TOKENS: Optional[int] = _optional_int_env("DEFAULT_MAX_TOKENS")
     DEFAULT_TOOL_CHOICE = os.getenv("DEFAULT_TOOL_CHOICE", "auto")
     LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
     LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/chapter1/search-codegen/config.py
+++ b/chapter1/search-codegen/config.py
@@ -11,10 +11,13 @@ load_dotenv()
 def _optional_int_env(name: str) -> Optional[int]:
     """Read an optional integer without making module import configuration-fatal."""
     raw_value = os.getenv(name)
-    if raw_value is None or not raw_value.strip():
+    if raw_value is None:
+        return None
+    cleaned = raw_value.strip()
+    if not cleaned or not cleaned.isascii() or not cleaned.isdecimal():
         return None
     try:
-        return int(raw_value.strip())
+        return int(cleaned)
     except ValueError:
         return None
 

--- a/chapter1/search-codegen/config.py
+++ b/chapter1/search-codegen/config.py
@@ -26,7 +26,9 @@ class Config:
     DEFAULT_TEMPERATURE = 0.3  # legacy CLI compatibility; intentionally omitted
     DEFAULT_MAX_TOKENS: Optional[int] = (
         int(os.getenv("DEFAULT_MAX_TOKENS"))
-        if os.getenv("DEFAULT_MAX_TOKENS")
+        # Only parse a plain integer; a non-numeric value (e.g. "4000.0") would
+        # otherwise raise ValueError at import and kill every entry point.
+        if (os.getenv("DEFAULT_MAX_TOKENS") or "").strip().isdigit()
         else None
     )
     DEFAULT_TOOL_CHOICE = os.getenv("DEFAULT_TOOL_CHOICE", "auto")

--- a/chapter1/search-codegen/example_request.py
+++ b/chapter1/search-codegen/example_request.py
@@ -94,16 +94,28 @@ def make_gpt5_openrouter_request(
             # Log usage (matching Go logging)
             if "usage" in response_data:
                 usage = response_data["usage"]
+                input_tokens = usage.get(
+                    "prompt_tokens", usage.get("input_tokens", 0)
+                )
+                output_tokens = usage.get(
+                    "completion_tokens", usage.get("output_tokens", 0)
+                )
+                input_details = usage.get(
+                    "prompt_tokens_details", usage.get("input_tokens_details")
+                )
+                output_details = usage.get(
+                    "completion_tokens_details", usage.get("output_tokens_details")
+                )
                 print(f"\nGPT-5 OpenRouter Usage:")
-                print(f"  Input: {usage.get('prompt_tokens', usage.get('input_tokens', 0))} tokens", end="")
-                if "input_tokens_details" in usage:
-                    print(f" (cached: {usage['input_tokens_details'].get('cached_tokens', 0)})")
+                print(f"  Input: {input_tokens} tokens", end="")
+                if isinstance(input_details, dict):
+                    print(f" (cached: {input_details.get('cached_tokens', 0)})")
                 else:
                     print()
                     
-                print(f"  Output: {usage.get('completion_tokens', usage.get('output_tokens', 0))} tokens", end="")
-                if "output_tokens_details" in usage:
-                    print(f" (reasoning: {usage['output_tokens_details'].get('reasoning_tokens', 0)})")
+                print(f"  Output: {output_tokens} tokens", end="")
+                if isinstance(output_details, dict):
+                    print(f" (reasoning: {output_details.get('reasoning_tokens', 0)})")
                 else:
                     print()
                     

--- a/chapter1/search-codegen/example_request.py
+++ b/chapter1/search-codegen/example_request.py
@@ -95,13 +95,13 @@ def make_gpt5_openrouter_request(
             if "usage" in response_data:
                 usage = response_data["usage"]
                 print(f"\nGPT-5 OpenRouter Usage:")
-                print(f"  Input: {usage.get('input_tokens', 0)} tokens", end="")
+                print(f"  Input: {usage.get('prompt_tokens', usage.get('input_tokens', 0))} tokens", end="")
                 if "input_tokens_details" in usage:
                     print(f" (cached: {usage['input_tokens_details'].get('cached_tokens', 0)})")
                 else:
                     print()
                     
-                print(f"  Output: {usage.get('output_tokens', 0)} tokens", end="")
+                print(f"  Output: {usage.get('completion_tokens', usage.get('output_tokens', 0))} tokens", end="")
                 if "output_tokens_details" in usage:
                     print(f" (reasoning: {usage['output_tokens_details'].get('reasoning_tokens', 0)})")
                 else:

--- a/chapter1/search-codegen/example_request.py
+++ b/chapter1/search-codegen/example_request.py
@@ -106,7 +106,7 @@ def make_gpt5_openrouter_request(
                 output_details = usage.get(
                     "completion_tokens_details", usage.get("output_tokens_details")
                 )
-                print(f"\nGPT-5 OpenRouter Usage:")
+                print("\nGPT-5 OpenRouter Usage:")
                 print(f"  Input: {input_tokens} tokens", end="")
                 if isinstance(input_details, dict):
                     print(f" (cached: {input_details.get('cached_tokens', 0)})")

--- a/chapter1/search-codegen/test_config_and_usage.py
+++ b/chapter1/search-codegen/test_config_and_usage.py
@@ -1,0 +1,69 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import example_request
+
+
+ROOT = Path(__file__).parent
+
+
+def _import_config_with(value: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["DEFAULT_MAX_TOKENS"] = value
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from config import Config; print(repr(Config.DEFAULT_MAX_TOKENS))",
+        ],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_default_max_tokens_import_accepts_only_values_int_can_parse():
+    for value in ("4000.0", "abc", "²"):
+        result = _import_config_with(value)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "None"
+
+    result = _import_config_with(" 4000 ")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "4000"
+
+
+def test_chat_completions_usage_uses_chat_token_and_detail_keys(monkeypatch, capsys):
+    payload = {
+        "usage": {
+            "prompt_tokens": 123,
+            "completion_tokens": 45,
+            "total_tokens": 168,
+            "prompt_tokens_details": {"cached_tokens": 7},
+            "completion_tokens_details": {"reasoning_tokens": 9},
+        }
+    }
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return payload
+
+    monkeypatch.setattr(
+        example_request.requests,
+        "post",
+        lambda *args, **kwargs: FakeResponse(),
+    )
+
+    result = example_request.make_gpt5_openrouter_request("key", "system", "user")
+    output = capsys.readouterr().out
+
+    assert result == payload
+    assert "Input: 123 tokens (cached: 7)" in output
+    assert "Output: 45 tokens (reasoning: 9)" in output
+    assert "Total: 168" in output

--- a/chapter1/search-codegen/test_config_and_usage.py
+++ b/chapter1/search-codegen/test_config_and_usage.py
@@ -9,9 +9,12 @@ import example_request
 ROOT = Path(__file__).parent
 
 
-def _import_config_with(value: str) -> subprocess.CompletedProcess[str]:
+def _import_config_with(value: str | None) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
-    env["DEFAULT_MAX_TOKENS"] = value
+    if value is None:
+        env.pop("DEFAULT_MAX_TOKENS", None)
+    else:
+        env["DEFAULT_MAX_TOKENS"] = value
     return subprocess.run(
         [
             sys.executable,
@@ -27,7 +30,7 @@ def _import_config_with(value: str) -> subprocess.CompletedProcess[str]:
 
 
 def test_default_max_tokens_import_accepts_only_values_int_can_parse():
-    for value in ("4000.0", "abc", "²"):
+    for value in (None, "", "   ", "4000.0", "abc", "²", "-1", "+1"):
         result = _import_config_with(value)
         assert result.returncode == 0, result.stderr
         assert result.stdout.strip() == "None"
@@ -67,3 +70,20 @@ def test_chat_completions_usage_uses_chat_token_and_detail_keys(monkeypatch, cap
     assert "Input: 123 tokens (cached: 7)" in output
     assert "Output: 45 tokens (reasoning: 9)" in output
     assert "Total: 168" in output
+
+    payload = {
+        "usage": {
+            "input_tokens": 210,
+            "output_tokens": 34,
+            "total_tokens": 244,
+            "input_tokens_details": {"cached_tokens": 11},
+            "output_tokens_details": {"reasoning_tokens": 13},
+        }
+    }
+    result = example_request.make_gpt5_openrouter_request("key", "system", "user")
+    output = capsys.readouterr().out
+
+    assert result == payload
+    assert "Input: 210 tokens (cached: 11)" in output
+    assert "Output: 34 tokens (reasoning: 13)" in output
+    assert "Total: 244" in output


### PR DESCRIPTION
Two minor fixes in `chapter1/search-codegen/`.

### 1. `config.py` — import-time crash on a non-integer `DEFAULT_MAX_TOKENS`
`int(os.getenv("DEFAULT_MAX_TOKENS"))` ran for any non-empty value, so a plausible misconfig (e.g. `DEFAULT_MAX_TOKENS=4000.0`) raised `ValueError` at module import — and since every entry point imports `config`, the whole tool died with a cryptic traceback. Only parse a plain integer (`.isdigit()`), else `None`. Verified: `"4000"`→`4000`, `"4000.0"`/`"abc"`→`None` (was `ValueError` at import).

### 2. `example_request.py` — token usage always prints `0`
This demo calls the **Chat Completions** endpoint (`/v1/chat/completions`), whose usage object uses `prompt_tokens`/`completion_tokens`, but the logging read the Responses-API keys `input_tokens`/`output_tokens` (defaulting to `0`), so every run printed `Input: 0 / Output: 0`. Read `prompt_tokens`/`completion_tokens` with the responses keys as a fallback. Verified: a chat-completions usage `{prompt=123, completion=45}` now prints `123 / 45`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 配置读取现在可安全处理缺失、空白或无效的最大令牌数，避免应用启动失败。
  * 用量日志兼容更多响应格式，并显示输入、缓存、输出、推理及总令牌数。

* **测试**
  * 新增配置解析和令牌用量输出的验证，提升相关功能的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->