### PR TITLE
ci: skip star history updates in forks

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -15,6 +15,8 @@ concurrency:
 
 jobs:
   update-chart:
+    # Avoid running this upstream-only maintenance task in forks.
+    if: github.repository == 'bojieli/ai-agent-book'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Restrict the scheduled star history update job to the upstream repository.

Forks inheriting this workflow may otherwise execute it daily, where chart generation or the push step can fail and repeatedly notify fork owners.

## Changes

- Run `update-chart` only when `github.repository` is `bojieli/ai-agent-book`
- Keep scheduled and manual behavior unchanged for the upstream repository
- Avoid unnecessary GitHub Actions usage and failure notifications in forks

## Validation

- Parsed the workflow successfully as YAML
- Verified the repository guard value
- Ran `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **维护**
  * 限制星标历史图表更新任务仅在指定主仓库中运行，避免在派生仓库中执行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->