### PR TITLE
fix(web): preserve per-page revision dates

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,9 @@ docs_dir: _web
 # Strip Pandoc/LaTeX attributes the source Markdown uses (e.g. `{.unnumbered}`,
 # `{#sec:foo}`, image `{height=55%}`) which Python-Markdown cannot parse.
 hooks:
+  # `_web/` is an ignored staging tree, so map each staged page back to its
+  # tracked source before the revision-date plugin asks Git for timestamps.
+  - scripts/git_revision_dates.py
   # Validates every configured language and generates the browser-side
   # translation catalog from Material's locales + our book navigation labels.
   - scripts/site_i18n.py

--- a/scripts/git_revision_dates.py
+++ b/scripts/git_revision_dates.py
@@ -1,0 +1,76 @@
+"""Use tracked source files for revision dates in the assembled MkDocs site.
+
+``scripts/build_site.sh`` copies documentation into the ignored ``_web/``
+directory before MkDocs runs.  The git revision-date plugin would otherwise
+query those generated paths, find no history, and give every page the build
+time.  This hook primes the plugin's timestamp cache with the corresponding
+tracked source paths before the plugin's own ``on_files`` handler runs.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import subprocess
+from typing import Any, Iterable
+
+from mkdocs.plugins import event_priority
+
+from site_source_paths import REPO_ROOT, git_commit_range, original_source_map
+
+_PLUGIN_NAME = "git-revision-date-localized"
+
+
+@event_priority(100)
+def on_files(files: Iterable[Any], config: Any, **_: Any) -> None:
+    """Populate the revision plugin's caches before its default-priority hook."""
+    plugin = config.plugins.get(_PLUGIN_NAME)
+    if plugin is None:
+        return
+
+    sources = original_source_map(files)
+    tracked = _tracked_paths()
+    jobs = [
+        (staged, source)
+        for staged, source in sources.items()
+        if _relative_source(source) in tracked
+    ]
+
+    ignored = tuple(getattr(plugin.util, "ignored_commits", ()))
+    follow = bool(plugin.config.get("enable_git_follow"))
+    include_creation = bool(plugin.config.get("enable_creation_date"))
+
+    def read_dates(job: tuple[str, str]):
+        staged, source = job
+        dates = git_commit_range(
+            Path(source),
+            ignored_commits=ignored,
+            follow=follow,
+            include_creation=include_creation,
+        )
+        return staged, dates
+
+    plugin.last_revision_commits.clear()
+    plugin.created_commits.clear()
+
+    # Cache under the staged path because that is the key the plugin looks up
+    # while rendering. Doing this at priority 100 also makes its default
+    # on_files handler see a populated cache and skip querying `_web/` itself.
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        for staged, (latest, created) in executor.map(read_dates, jobs):
+            plugin.last_revision_commits[staged] = latest
+            if include_creation:
+                plugin.created_commits[staged] = created
+
+
+def _relative_source(source: str) -> str:
+    return Path(source).resolve().relative_to(REPO_ROOT).as_posix()
+
+
+def _tracked_paths() -> set[str]:
+    output = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    ).stdout
+    return {path.decode() for path in output.split(b"\0") if path}

--- a/scripts/site_source_paths.py
+++ b/scripts/site_source_paths.py
@@ -1,0 +1,97 @@
+"""Map pages in the generated MkDocs tree to their repository sources."""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+import subprocess
+import time
+from typing import Any, Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+Commit = tuple[str, int]
+
+
+def source_path_for_page(src_uri: str, root: Path = REPO_ROOT) -> Path:
+    """Return the tracked source represented by an assembled page URI."""
+    relative = PurePosixPath(src_uri)
+    parts = relative.parts
+
+    # build_site.sh promotes book/chapterN.md to book/chapterN/index.md so
+    # navigation.indexes can make the chapter section itself clickable.
+    if (
+        len(parts) == 3
+        and parts[0] == "book"
+        and parts[1].startswith("chapter")
+        and parts[1][7:].isdigit()
+        and parts[2] == "index.md"
+    ):
+        return root / "book" / f"{parts[1]}.md"
+
+    return root.joinpath(*parts)
+
+
+def original_source_map(files: Iterable[Any], root: Path = REPO_ROOT) -> dict[str, str]:
+    """Map staged absolute paths to existing source files in the repository."""
+    sources: dict[str, str] = {}
+    for file in files:
+        abs_src_path = getattr(file, "abs_src_path", None)
+        src_uri = getattr(file, "src_uri", None)
+        if not abs_src_path or not src_uri:
+            continue
+
+        source = source_path_for_page(str(src_uri), root)
+        if source.is_file():
+            sources[str(abs_src_path)] = str(source)
+    return sources
+
+
+def git_commit_range(
+    source: Path,
+    root: Path = REPO_ROOT,
+    *,
+    ignored_commits: tuple[str, ...] = (),
+    follow: bool = False,
+    include_creation: bool = True,
+) -> tuple[Commit, Commit]:
+    """Return the latest and creation commits for one tracked source file."""
+    relative = source.resolve().relative_to(root.resolve()).as_posix()
+    common = ["git", "-C", str(root), "log", "--format=%H%x00%at"]
+    if follow:
+        common.append("--follow")
+
+    latest_lines = _git_log(common + [f"-n{len(ignored_commits) + 1}", "--", relative])
+    latest = next(
+        (
+            commit
+            for commit in map(_parse_commit, latest_lines)
+            if not any(commit[0].startswith(prefix) for prefix in ignored_commits)
+        ),
+        _fallback_commit(),
+    )
+
+    if not include_creation:
+        return latest, latest
+
+    creation_lines = _git_log(common + ["--diff-filter=A", "--", relative])
+    created = _parse_commit(creation_lines[-1]) if creation_lines else _fallback_commit()
+    return latest, created
+
+
+def _git_log(command: list[str]) -> list[str]:
+    output = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return [line for line in output.splitlines() if line]
+
+
+def _parse_commit(line: str) -> Commit:
+    commit_hash, timestamp = line.split("\0", 1)
+    return commit_hash, int(timestamp)
+
+
+def _fallback_commit() -> Commit:
+    return "", int(time.time())

--- a/tests/test_git_revision_dates.py
+++ b/tests/test_git_revision_dates.py
@@ -1,0 +1,98 @@
+"""Regression tests for Git dates in the assembled online-reading site."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from site_source_paths import (  # noqa: E402
+    git_commit_range,
+    original_source_map,
+    source_path_for_page,
+)
+
+
+def test_regular_page_maps_to_same_repository_path(tmp_path: Path):
+    source = tmp_path / "book-en" / "chapter1.md"
+    source.parent.mkdir(parents=True)
+    source.touch()
+
+    assert source_path_for_page("book-en/chapter1.md", tmp_path) == source
+
+
+def test_promoted_chapter_index_maps_back_to_chapter_source(tmp_path: Path):
+    source = tmp_path / "book" / "chapter10.md"
+    source.parent.mkdir(parents=True)
+    source.touch()
+
+    assert source_path_for_page("book/chapter10/index.md", tmp_path) == source
+
+
+def test_original_source_map_uses_tracked_sources_and_skips_missing_files(tmp_path: Path):
+    chapter = tmp_path / "book" / "chapter1.md"
+    readme = tmp_path / "chapter1" / "README.md"
+    chapter.parent.mkdir(parents=True)
+    readme.parent.mkdir(parents=True)
+    chapter.touch()
+    readme.touch()
+
+    files = [
+        SimpleNamespace(
+            src_uri="book/chapter1/index.md",
+            abs_src_path="/staging/book/chapter1/index.md",
+        ),
+        SimpleNamespace(
+            src_uri="chapter1/README.md",
+            abs_src_path="/staging/chapter1/README.md",
+        ),
+        SimpleNamespace(
+            src_uri="generated/missing.md",
+            abs_src_path="/staging/generated/missing.md",
+        ),
+    ]
+
+    assert original_source_map(files, tmp_path) == {
+        "/staging/book/chapter1/index.md": str(chapter),
+        "/staging/chapter1/README.md": str(readme),
+    }
+
+
+def test_git_commit_range_returns_distinct_creation_and_update_dates(tmp_path: Path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.name", "Test"],
+        check=True,
+    )
+
+    page = tmp_path / "page.md"
+    page.write_text("created\n", encoding="utf-8")
+    _commit(tmp_path, "create", "1704067200 +0000")
+    page.write_text("updated\n", encoding="utf-8")
+    _commit(tmp_path, "update", "1706745600 +0000")
+
+    latest, created = git_commit_range(page, tmp_path)
+
+    assert latest[1] == 1706745600
+    assert created[1] == 1704067200
+    assert latest[0] != created[0]
+
+
+def _commit(repository: Path, message: str, date: str) -> None:
+    subprocess.run(["git", "-C", str(repository), "add", "page.md"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "commit", "-qm", message],
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_DATE": date,
+            "GIT_COMMITTER_DATE": date,
+        },
+    )


### PR DESCRIPTION
## Summary

- map pages in the generated _web staging tree back to their tracked Markdown sources
- populate creation and last-update metadata from each source file Git history
- preserve the promoted book/chapterN/index.md to book/chapterN.md mapping
- add regression coverage for source mapping and distinct creation/update commits

## Root cause

The deployment assembles documentation under the ignored _web directory. The revision-date plugin queried those generated paths, found no Git history, and fell back to the build timestamp for every page.

## Verification

- python -m pytest -q tests — 59 passed
- Ruff checks passed
- git diff --check passed
- production MkDocs build passed
- rendered Chapter 1 and Chapter 3 timestamps match git log

Closes #584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 文档页面现在可自动关联 Git 中的源文件。
  * MkDocs 可显示更准确的页面创建日期和最近修订日期。
  * 支持章节索引页、文件重命名历史及可配置的提交过滤。

* **测试**
  * 新增页面路径映射、缺失文件处理及 Git 日期计算的回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->