### PR TITLE
feat(web): serve translated site homepages, shipping Korean first

### DIFF
--- a/extras/lang-switcher.js
+++ b/extras/lang-switcher.js
@@ -48,6 +48,18 @@
           if (cfg[codes[r]].readmeSuffix === readmeMatch[1]) return codes[r];
         }
       }
+      // Translated homepages (/index.<code>/) carry their locale in the slug.
+      var homeMatch = p.match(/(?:^|\/)index\.([a-zA-Z-]+)$/);
+      if (homeMatch && cfg[homeMatch[1]]) return homeMatch[1];
+      // The site root always serves the default-language homepage (translated
+      // homepages are matched above), so don't let a remembered locale make
+      // the Chinese homepage look pre-translated.
+      if (p === "" || p === "index.html" || p === "/index.html") {
+        for (var h in cfg) {
+          if (cfg.hasOwnProperty(h) && cfg[h].default) return h;
+        }
+        return "zh";
+      }
       // No language prefix matched. This happens on /chapterN/ experiment
       // index pages (experiments are language-agnostic, single copy).
       // Fall back to whatever the user last selected — stored in
@@ -71,7 +83,9 @@
     // the same site base, or null if no translation applies.
     //
     // URL shapes we have to handle:
-    //   /                          → site home (per-language intro)
+    //   /                          → site home, default language
+    //   /index.<code>/             → site home, translated (when the root
+    //                                 file index.<code>.md exists)
     //   /book[-lang]/chapterN[.suffix]/  → chapter prose
     //   /chapterN/                 → experiment index, Chinese (README.md)
     //   /chapterN/README.<readmeSuffix>/ → experiment index, translated
@@ -82,12 +96,25 @@
       var src = cfg[fromCode];
       var dst = cfg[toCode];
 
-      // Site home → target language's introduction.
+      // Site home. Editions with a translated homepage (root index.<code>.md,
+      // listed by scripts/site_i18n.py in the generated catalog) map
+      // home → home; the rest keep the original fallback to their
+      // introduction page, which every edition has.
+      var homePages = i18n.homePages || [];
       if (cleanPath === "/" || cleanPath === "/index.html") {
+        if (homePages.indexOf(toCode) !== -1) return "/index." + toCode + "/";
         return "/" + dst.prefix + "introduction" + (dst.suffix || "") + "/";
       }
 
       var pp = cleanPath.replace(/^\//, "").replace(/\/$/, "");
+
+      // Translated homepage: /index.<code>/
+      var homeMatch = pp.match(/^index\.([a-zA-Z-]+)$/);
+      if (homeMatch) {
+        if (dst.default) return "/";
+        if (homePages.indexOf(toCode) !== -1) return "/index." + toCode + "/";
+        return "/" + dst.prefix + "introduction" + (dst.suffix || "") + "/";
+      }
 
       // Chapter prose: <srcPrefix>chapterN[<srcSuffix>]
       // E.g. /book/chapter1/  or  /book-zhtw/chapter1.zhtw/

--- a/index.ko.md
+++ b/index.ko.md
@@ -1,0 +1,113 @@
+---
+title: AI 에이전트를 깊이 이해하기
+description: 핵심 공식 Agent = LLM + 컨텍스트 + 도구를 중심으로, 10개 장에 걸쳐 AI 에이전트를 원리부터 엔지니어링 실전까지 다루는 오픈소스 기술서. 본문·그림·94개 연계 실습을 모두 공개합니다.
+---
+
+<div class="hero" markdown>
+
+# AI 에이전트를 깊이 이해하기
+
+**설계 원리와 엔지니어링 실전** · 완전한 오픈소스 AI 에이전트 기술서
+
+<div class="hero-formula" markdown>
+
+`Agent = LLM + 컨텍스트 + 도구`
+
+</div>
+
+<div class="cta-row" markdown>
+
+📥 [한국어 PDF](https://github.com/bojieli/ai-agent-book/releases/download/latest/AI-Agents-in-Depth-ko.pdf){.cta}
+📚 [한국어 EPUB](https://github.com/bojieli/ai-agent-book/releases/download/latest/AI-Agents-in-Depth-ko.epub){.cta}
+
+</div>
+
+</div>
+
+---
+
+## 한눈에 보는 구성
+
+<div class="exp-grid" markdown>
+
+<a class="exp-card" href="../book-ko/introduction.ko/">
+<span class="exp-title">📖 들어가며</span>
+<span class="exp-desc">왜 이 책을 썼는가 · 좋은 설계 원칙은 어떻게 모델 세대 교체를 넘어서는가</span>
+</a>
+
+<a class="exp-card" href="../book-ko/chapter1.ko/">
+<span class="exp-title">🚀 제1장 · AI 에이전트 기초</span>
+<span class="exp-desc">Agent = LLM + 컨텍스트 + 도구 · 경쟁력의 핵심은 하네스 엔지니어링</span>
+</a>
+
+<a class="exp-card" href="../book-ko/chapter2.ko/">
+<span class="exp-title">🎯 제2장 · 컨텍스트 엔지니어링</span>
+<span class="exp-desc">컨텍스트가 능력의 상한을 결정 · KV Cache, 프롬프트 엔지니어링, Agent Skills, 컨텍스트 압축</span>
+</a>
+
+<a class="exp-card" href="../book-ko/chapter3.ko/">
+<span class="exp-title">📚 제3장 · 사용자 메모리와 지식 베이스</span>
+<span class="exp-desc">세션을 넘어 사용자를 기억하고 외부 지식을 연결 · 사용자 메모리, RAG, 구조화 색인, 지식 그래프</span>
+</a>
+
+<a class="exp-card" href="../book-ko/chapter4.ko/">
+<span class="exp-title">🛠️ 제4장 · 도구</span>
+<span class="exp-desc">도구는 에이전트의 두 손 · MCP 프로토콜, 인식·실행·협업 세 종류의 도구, 비동기 에이전트</span>
+</a>
+
+<a class="exp-card" href="../book-ko/chapter5.ko/">
+<span class="exp-title">💻 제5장 · 코딩 에이전트와 코드 생성</span>
+<span class="exp-desc">코드는 '새 도구를 만들 수 있는 도구' · 프로덕션급 코딩 에이전트의 전체 그림</span>
+</a>
+
+<a class="exp-card" href="../book-ko/chapter6.ko/">
+<span class="exp-title">🎯 제6장 · 에이전트 평가</span>
+<span class="exp-desc">성능을 비교 가능한 신호로 · 평가 환경, 지표, 통계적 유의성</span>
+</a>
+
+<a class="exp-card" href="../book-ko/chapter7.ko/">
+<span class="exp-title">🧠 제7장 · 모델 사후 학습</span>
+<span class="exp-desc">SFT와 강화 학습 · 하네스에 쌓인 피드백 신호를 모델 파라미터에 기록</span>
+</a>
+
+<a class="exp-card" href="../book-ko/chapter8.ko/">
+<span class="exp-title">🌱 제8장 · 에이전트의 지속적 진화</span>
+<span class="exp-desc">신뢰할 수 있는 학습 신호에서 지식·지침·프로그램·파라미터 갱신까지</span>
+</a>
+
+<a class="exp-card" href="../book-ko/chapter9.ko/">
+<span class="exp-title">🎙️ 제9장 · 멀티모달과 실시간 상호작용</span>
+<span class="exp-desc">음성 에이전트, Computer Use, 로봇 조작</span>
+</a>
+
+<a class="exp-card" href="../book-ko/chapter10.ko/">
+<span class="exp-title">🤝 제10장 · 멀티 에이전트 협업</span>
+<span class="exp-desc">협업 아키텍처, 실패 유형, 에이전트 사회</span>
+</a>
+
+<a class="exp-card" href="../book-ko/afterword.ko/">
+<span class="exp-title">📝 후기</span>
+<span class="exp-desc">모델이 하네스를 삼키게 될까? 완전한 답과 전망</span>
+</a>
+
+</div>
+
+---
+
+## 온라인 읽기 · 다국어
+
+상단 내비게이션 바의 언어 탭으로 전환할 수 있습니다.
+
+| 中文 | 繁體中文（台灣） | English | العربية | Русский | தமிழ் | Tiếng Việt | 日本語 | Türkçe | 한국어 |
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| ✅ 원서 | 커뮤니티 번역 | 커뮤니티 번역 | 커뮤니티 번역 | 커뮤니티 번역 | 커뮤니티 번역 | 커뮤니티 번역 | 커뮤니티 번역 | 커뮤니티 번역 | 커뮤니티 번역 |
+
+---
+
+## 소개
+
+- **저장소**: [bojieli/ai-agent-book](https://github.com/bojieli/ai-agent-book)
+- **라이선스**: Apache License 2.0
+- **이 사이트**: 저장소에 푸시될 때마다 GitHub Actions가 자동으로 다시 빌드합니다
+
+> 💡 이 책의 내용은 계속 갱신되며, 이 사이트는 저장소에 푸시될 때마다 자동으로 다시 빌드됩니다. 전체 PDF가 필요하면 위의 다운로드 버튼을 사용하거나 [Releases](https://github.com/bojieli/ai-agent-book/releases)를 방문하세요.

--- a/scripts/build_site.sh
+++ b/scripts/build_site.sh
@@ -13,6 +13,14 @@ mkdir -p "$DEST"
 # Site homepage (root index.md).
 cp "$ROOT/index.md" "$DEST/index.md"
 
+# Translated site homepages (root index.<lang>.md), when present. The
+# language switcher maps home <-> home for these editions (see
+# scripts/site_i18n.py, which lists them in the generated catalog).
+for home in "$ROOT"/index.*.md; do
+  [ -f "$home" ] || continue
+  cp "$home" "$DEST/$(basename "$home")"
+done
+
 # robots.txt at the site root (points crawlers at the auto-generated sitemap).
 [ -f "$ROOT/robots.txt" ] && cp "$ROOT/robots.txt" "$DEST/robots.txt"
 

--- a/scripts/site_i18n.py
+++ b/scripts/site_i18n.py
@@ -287,10 +287,18 @@ def build_catalog() -> dict[str, Any]:
     default = "zh"
     if default not in browser_languages:
         raise CatalogError(f"Default language {default!r} is not configured")
+
+    # Languages with a translated site homepage (root index.<code>.md).
+    # The language switcher maps home <-> home for these editions and keeps
+    # the introduction-page fallback for the rest. The default edition's
+    # homepage is the root index.md itself.
+    home_pages = [code for code in codes if (ROOT / f"index.{code}.md").is_file()]
+
     return {
         "default": default,
         "languages": browser_languages,
         "canonicalNav": nav_labels,
+        "homePages": home_pages,
     }
 
 


### PR DESCRIPTION
## Summary

On the online site, the homepage is always the Chinese `index.md`: all 13 editions share one MkDocs build, so a reader browsing the Korean edition sees a localized sidebar around a Chinese landing page, and the language dropdown does nothing on the site root (the remembered locale makes the target language look already active).

This PR adds a small mechanism for translated homepages and ships the first one in Korean:

- A translated homepage is a root-level `index.<code>.md`. `scripts/build_site.sh` copies any such file into `_web/`, and `scripts/site_i18n.py` lists the codes that have one in the generated catalog (`homePages`).
- `extras/lang-switcher.js` maps home ↔ home for editions with a translated homepage, and keeps the existing introduction-page fallback for all other editions.
- The site root now always identifies as the default (Chinese) edition, which makes the language dropdown functional on the root page and lets the sidebar home link follow the reader's language.
- `index.ko.md`: Korean homepage content, adapted from the existing wording in `docs/ko/README.md`, with the download buttons pointing at the Korean PDF/EPUB.

Other editions keep their current behavior until someone contributes their `index.<code>.md` — the file's existence is picked up automatically, with no config change needed.

## Behavior

| Case | Before | After |
| --- | --- | --- |
| On `/`, dropdown → 한국어 | nothing happened (locale looked already active) | navigates to `/index.ko/` |
| On `/`, dropdown → any other language | jumps to that edition's introduction | unchanged |
| Sidebar home link, Korean mode | pointed at the Chinese homepage | points at `/index.ko/` |
| Sidebar home link, editions without a translated homepage | pointed at the Chinese homepage | points at that edition's introduction — this matches the switcher's existing home fallback, but I'm happy to revert this part if the previous behavior was intentional |
| `/index.ko/`, dropdown → 中文 | — | navigates to `/` |
| `/index.ko/`, dropdown → an edition without a homepage | — | introduction fallback |

## Testing

- Extracted `detectLang` / `translatePath` from the source file and ran 20 URL-mapping cases (6 for the new mappings, 14 regression cases across the existing shapes: prose pages, book pages, experiment indexes, individual experiments) — all pass.
- `node --check extras/lang-switcher.js`, `bash -n scripts/build_site.sh`, `python -m py_compile scripts/site_i18n.py` all pass.
- I was not able to run a full `mkdocs build` locally, so I'd appreciate CI confirming the site build — happy to fix anything that comes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增韩语主页，提供韩语版本的书籍介绍、电子书下载、章节导航和在线阅读入口。
  * 支持识别并访问翻译后的语言主页。
  * 语言切换可根据目标语言跳转至对应主页；默认语言返回网站根路径，其他情况回退至介绍页。
* **改进**
  * 网站构建和语言目录现会自动收录已配置的翻译主页。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->