### PR TITLE
ci: skip Pages deployment in forks

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -41,7 +39,12 @@ jobs:
           path: site
 
   deploy:
+    # Publishing is owned by the canonical repository; forks still verify builds.
+    if: github.repository == 'bojieli/ai-agent-book'
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- keep the MkDocs build running in forks for verification
- skip the GitHub Pages deployment job outside `bojieli/ai-agent-book`
- scope `pages: write` and `id-token: write` to the deploy job

## Motivation
Forks without GitHub Pages enabled currently build successfully and then fail in `actions/deploy-pages` with a 404. The repository already uses the same canonical-repository guard for the star-history maintenance job.

## Validation
- parsed the workflow as YAML
- verified the repository guard and job-level permissions
- ran `actionlint`
- ran `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **部署改进**
  * 优化页面发布流程，确保仅正式仓库执行页面部署。
  * Fork 仓库仍会进行构建检查，但不会发布页面。
  * 调整权限范围，提升部署流程的安全性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->