### PR TITLE
ci: avoid publishing rolling releases from forks

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -236,7 +236,7 @@ jobs:
         run: ./build_epub.sh ar
 
       - name: Upload verification artifacts
-        if: github.ref != 'refs/heads/main'
+        if: github.repository != 'bojieli/ai-agent-book' || github.ref != 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: book-verification-${{ inputs.edition || 'all' }}
@@ -246,7 +246,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload to the rolling latest release
-        if: github.ref == 'refs/heads/main'
+        if: github.repository == 'bojieli/ai-agent-book' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- publish the rolling `latest` release only from the canonical repository's `main` branch
- upload normal verification artifacts for forks and non-main branches

## Motivation
A fork's `main` branch also satisfies the previous branch-only condition, so inherited runs attempt to upload to a fork-local `latest` release and fail. This keeps fork builds useful without treating them as official publication runs.

## Validation
- parsed the workflow as YAML
- verified all repository/ref combinations with a truth table
- confirmed exactly one upload path is selected in every case
- ran `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **构建与发布**
  * 优化构建产物上传条件，确保 `latest` 版本仅在官方仓库的 `main` 分支发布。
  * 其他分支或仓库将按非正式构建流程处理，降低误发布风险。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->