### PR TITLE
fix(trajectory-verifier): handle null expected_outcome and final_state in ResultVerifier

### DIFF
--- a/chapter8/trajectory-verifier/test_verifier_null_fields.py
+++ b/chapter8/trajectory-verifier/test_verifier_null_fields.py
@@ -1,9 +1,22 @@
-"""Regression test: ProcessVerifier must tolerate null/None values for process_facts, sensitive_values, claims, and promises."""
+"""Regression tests: verifier module must tolerate null/None or non-dict values for trajectory fields."""
 import pytest
-from verifier import ProcessVerifier, PASS, UNCERTAIN
+from verifier import (
+    ProcessVerifier,
+    ResultVerifier,
+    TrajectoryVerifier,
+    diagnostic_utility,
+    FAIL,
+    PASS,
+    UNCERTAIN,
+)
 
 
 def test_process_verifier_tolerates_null_fields():
+    """Contract: ProcessVerifier returns valid DimensionResults when optional container fields are None.
+
+    Locks out AttributeError/TypeError when process_facts, sensitive_values, claims, promises,
+    or tool_calls are explicitly set to None in trajectory log payloads.
+    """
     verifier = ProcessVerifier()
     trajectory = {
         "messages": [{"role": "assistant", "content": "Hello"}],
@@ -17,7 +30,13 @@ def test_process_verifier_tolerates_null_fields():
     assert len(results) == 4
     for res in results:
         assert res.verdict in (PASS, UNCERTAIN)
+
+
 def test_process_verifier_tolerates_invalid_container_types():
+    """Contract: ProcessVerifier returns valid DimensionResults when container fields are non-iterable non-dict types.
+
+    Locks out TypeError when process_facts, sensitive_values, claims, or promises are integers or booleans.
+    """
     verifier = ProcessVerifier()
     trajectory = {
         "messages": [{"role": "assistant", "content": "Hello"}],
@@ -31,3 +50,35 @@ def test_process_verifier_tolerates_invalid_container_types():
     assert len(results) == 4
     for res in results:
         assert res.verdict in (PASS, UNCERTAIN)
+
+
+def test_result_verifier_tolerates_null_and_invalid_fields():
+    """Contract: ResultVerifier safely handles None or non-dict expected_outcome and final_state.
+
+    Locks out AttributeError ('NoneType' object has no attribute 'items' or 'get') when
+    expected_outcome or final_state is None.
+    """
+    verifier = ResultVerifier()
+    # expected_outcome and final_state set to None or non-dict
+    results1 = verifier.evaluate({"expected_outcome": None, "final_state": None})
+    assert len(results1) == 1
+    assert results1[0].verdict == UNCERTAIN
+    assert results1[0].dimension == "task_resolution"
+
+    results2 = verifier.evaluate({"expected_outcome": {"key": "val"}, "final_state": None})
+    assert len(results2) == 1
+    assert results2[0].verdict == FAIL
+
+    # TrajectoryVerifier with null messages and null expected_outcome
+    tv = TrajectoryVerifier()
+    report = tv.evaluate({
+        "id": "traj-1",
+        "messages": None,
+        "expected_outcome": None,
+        "final_state": None,
+    })
+    assert report["trajectory_id"] == "traj-1"
+    assert isinstance(report["overall_score"], float)
+
+    # diagnostic_utility with null dimensions
+    assert diagnostic_utility({"dimensions": None}) == 1.0

--- a/chapter8/trajectory-verifier/test_verifier_null_fields.py
+++ b/chapter8/trajectory-verifier/test_verifier_null_fields.py
@@ -53,10 +53,10 @@ def test_process_verifier_tolerates_invalid_container_types():
 
 
 def test_result_verifier_tolerates_null_and_invalid_fields():
-    """Contract: ResultVerifier safely handles None or non-dict expected_outcome and final_state.
+    """Contract: ResultVerifier safely handles None, non-dict, empty dict, or nested null expected_outcome and final_state.
 
     Locks out AttributeError ('NoneType' object has no attribute 'items' or 'get') when
-    expected_outcome or final_state is None.
+    expected_outcome or final_state is None, non-dict, or contains null values.
     """
     verifier = ResultVerifier()
     # expected_outcome and final_state set to None or non-dict
@@ -65,11 +65,46 @@ def test_result_verifier_tolerates_null_and_invalid_fields():
     assert results1[0].verdict == UNCERTAIN
     assert results1[0].dimension == "task_resolution"
 
-    results2 = verifier.evaluate({"expected_outcome": {"key": "val"}, "final_state": None})
-    assert len(results2) == 1
-    assert results2[0].verdict == FAIL
+    # Empty dicts
+    results_empty = verifier.evaluate({"expected_outcome": {}, "final_state": {}})
+    assert len(results_empty) == 1
+    assert results_empty[0].verdict == UNCERTAIN
 
-    # TrajectoryVerifier with null messages and null expected_outcome
+    # Non-dict expected_outcome or final_state
+    results_non_dict1 = verifier.evaluate({"expected_outcome": "invalid_type", "final_state": 12345})
+    assert len(results_non_dict1) == 1
+    assert results_non_dict1[0].verdict == UNCERTAIN
+
+    results_non_dict2 = verifier.evaluate({"expected_outcome": {"key": "val"}, "final_state": None})
+    assert len(results_non_dict2) == 1
+    assert results_non_dict2[0].verdict == FAIL
+
+    # Nested nulls - matching
+    results_nested_null_match = verifier.evaluate({
+        "expected_outcome": {"status": None, "code": 200},
+        "final_state": {"status": None, "code": 200},
+    })
+    assert len(results_nested_null_match) == 1
+    assert results_nested_null_match[0].verdict == PASS
+
+    # Nested nulls - mismatch
+    results_nested_null_mismatch = verifier.evaluate({
+        "expected_outcome": {"status": None},
+        "final_state": {"status": "ok"},
+    })
+    assert len(results_nested_null_mismatch) == 1
+    assert results_nested_null_mismatch[0].verdict == FAIL
+
+    # Non-dict trajectory payload itself
+    results_null_traj = verifier.evaluate(None)
+    assert len(results_null_traj) == 1
+    assert results_null_traj[0].verdict == UNCERTAIN
+
+    results_str_traj = verifier.evaluate("invalid_trajectory")
+    assert len(results_str_traj) == 1
+    assert results_str_traj[0].verdict == UNCERTAIN
+
+    # TrajectoryVerifier with null messages, null expected_outcome, and non-dict payload
     tv = TrajectoryVerifier()
     report = tv.evaluate({
         "id": "traj-1",
@@ -80,5 +115,10 @@ def test_result_verifier_tolerates_null_and_invalid_fields():
     assert report["trajectory_id"] == "traj-1"
     assert isinstance(report["overall_score"], float)
 
+    report_null = tv.evaluate(None)
+    assert report_null["trajectory_id"] is None
+    assert isinstance(report_null["overall_score"], float)
+
     # diagnostic_utility with null dimensions
     assert diagnostic_utility({"dimensions": None}) == 1.0
+    assert diagnostic_utility(None) == 1.0

--- a/chapter8/trajectory-verifier/verifier.py
+++ b/chapter8/trajectory-verifier/verifier.py
@@ -32,6 +32,8 @@ class QualityJudge(Protocol):
 
 
 def _successful_calls(trajectory: Dict[str, Any]) -> List[Dict[str, Any]]:
+    if not isinstance(trajectory, dict):
+        trajectory = {}
     calls = trajectory.get("tool_calls")
     if not isinstance(calls, list):
         calls = []
@@ -58,6 +60,8 @@ def _precedes(call: Dict[str, Any], promise: Dict[str, Any]) -> bool:
 
 
 def _assistant_text(trajectory: Dict[str, Any]) -> str:
+    if not isinstance(trajectory, dict):
+        trajectory = {}
     messages = trajectory.get("messages")
     if not isinstance(messages, list):
         messages = []
@@ -72,6 +76,8 @@ class ResultVerifier:
     """Checks the final environment state instead of trusting the reply."""
 
     def evaluate(self, trajectory: Dict[str, Any]) -> List[DimensionResult]:
+        if not isinstance(trajectory, dict):
+            trajectory = {}
         expected = trajectory.get("expected_outcome")
         if not isinstance(expected, dict):
             expected = {}
@@ -214,8 +220,14 @@ class HeuristicQualityJudge:
     """
 
     def evaluate(self, trajectory: Dict[str, Any]) -> List[DimensionResult]:
-        facts = trajectory.get("quality_facts", {})
-        expression_issues = facts.get("expression_issues", [])
+        if not isinstance(trajectory, dict):
+            trajectory = {}
+        facts = trajectory.get("quality_facts")
+        if not isinstance(facts, dict):
+            facts = {}
+        expression_issues = facts.get("expression_issues")
+        if not isinstance(expression_issues, list):
+            expression_issues = []
         if expression_issues:
             expression = DimensionResult(
                 "expression_quality", "llm_rubric", FAIL, 0.0,
@@ -254,6 +266,8 @@ class TrajectoryVerifier:
         self.review_confidence = review_confidence
 
     def evaluate(self, trajectory: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(trajectory, dict):
+            trajectory = {}
         dimensions = [
             *self.result_verifier.evaluate(trajectory),
             *self.process_verifier.evaluate(trajectory),
@@ -307,11 +321,15 @@ class TrajectoryVerifier:
 
 def scalar_baseline(report: Dict[str, Any]) -> Dict[str, Any]:
     """Simulates the information loss of returning one overall number."""
-    return {"trajectory_id": report["trajectory_id"], "score": report["overall_score"]}
+    if not isinstance(report, dict):
+        report = {}
+    return {"trajectory_id": report.get("trajectory_id"), "score": report.get("overall_score")}
 
 
 def diagnostic_utility(report: Dict[str, Any]) -> float:
     """Fraction of failed dimensions that include actionable evidence."""
+    if not isinstance(report, dict):
+        report = {}
     dims = report.get("dimensions")
     if not isinstance(dims, list):
         dims = []

--- a/chapter8/trajectory-verifier/verifier.py
+++ b/chapter8/trajectory-verifier/verifier.py
@@ -58,10 +58,13 @@ def _precedes(call: Dict[str, Any], promise: Dict[str, Any]) -> bool:
 
 
 def _assistant_text(trajectory: Dict[str, Any]) -> str:
+    messages = trajectory.get("messages")
+    if not isinstance(messages, list):
+        messages = []
     return "\n".join(
         str(message.get("content", ""))
-        for message in trajectory.get("messages", [])
-        if message.get("role") == "assistant"
+        for message in messages
+        if isinstance(message, dict) and message.get("role") == "assistant"
     )
 
 
@@ -69,8 +72,12 @@ class ResultVerifier:
     """Checks the final environment state instead of trusting the reply."""
 
     def evaluate(self, trajectory: Dict[str, Any]) -> List[DimensionResult]:
-        expected = trajectory.get("expected_outcome", {})
-        final_state = trajectory.get("final_state", {})
+        expected = trajectory.get("expected_outcome")
+        if not isinstance(expected, dict):
+            expected = {}
+        final_state = trajectory.get("final_state")
+        if not isinstance(final_state, dict):
+            final_state = {}
         mismatches = [
             f"{key}: expected={value!r}, actual={final_state.get(key)!r}"
             for key, value in expected.items()
@@ -305,7 +312,10 @@ def scalar_baseline(report: Dict[str, Any]) -> Dict[str, Any]:
 
 def diagnostic_utility(report: Dict[str, Any]) -> float:
     """Fraction of failed dimensions that include actionable evidence."""
-    failures = [item for item in report.get("dimensions", []) if item.get("verdict") == FAIL]
+    dims = report.get("dimensions")
+    if not isinstance(dims, list):
+        dims = []
+    failures = [item for item in dims if isinstance(item, dict) and item.get("verdict") == FAIL]
     if not failures:
         return 1.0
     actionable = sum(bool(item.get("evidence")) for item in failures)


### PR DESCRIPTION
### Summary

Fixes an unhandled `AttributeError` when `ResultVerifier.evaluate()` evaluates LLM-generated trajectory traces containing explicit JSON `null`/`None` or non-dict values for `expected_outcome` and `final_state`.

### Root Cause
When machine-checkable state fields are missing or populated with `null` by trace generators, `ResultVerifier.evaluate` attempted attribute access/iteration on `None`, crashing with `AttributeError: 'NoneType' object has no attribute 'items'`.

### Fix
Adds explicit type guards checking for `None` or non-dict payloads before accessing items, safely treating missing machine states as unverified without raising unhandled exceptions.

### Verification
Added unit tests in `chapter8/trajectory-verifier/tests/test_verifier_null_fields.py` testing null `expected_outcome`, null `final_state`, and non-dict inputs.