### PR TITLE
fix(docs): protect code blocks and support combined Pandoc attributes in mkdocs_pandoc_strip

### DIFF
--- a/scripts/mkdocs_pandoc_strip.py
+++ b/scripts/mkdocs_pandoc_strip.py
@@ -5,22 +5,33 @@ understand and would otherwise render as literal text:
 
     ## 标题 {.unnumbered}        ->  ## 标题
     ![图](x.svg){height=55%}     ->  ![图](x.svg)
-    [文本](#sec:foo){.unnumbered}
+    [文本](#sec:foo){.unnumbered} ->  [文本](#sec:foo)
 """
 import re
 
-# Patterns are intentionally strict: they only match real Pandoc attribute
-# syntax so that inline code and code blocks (e.g. JSON `{"data": {...}}` or
-# JS `catch (e) {...}`) are never touched.
-_ID_ATTR = re.compile(r"\{#[\w:.-]+\}")
-_CLASS_ATTR = re.compile(r"\{\.[\w-]+(?:\s+\.[\w-]+)*\}")
-_TRAILING_ATTR = re.compile(
-    r"\)\{(?:#[\w:.-]+|\.[\w-]+(?:\s+\.[\w-]+)*|[\w-]+=[^{}]*)\}"
+_CODE_PATTERN = re.compile(r"(?P<fence>```+|~~~+|`+)([\s\S]*?)(?P=fence)")
+_TRAILING_LINK_ATTR = re.compile(r"\)\{[^{}]*\}")
+_PANDOC_ATTR = re.compile(
+    r"[ \t]*\{(?:\s*#[a-zA-Z0-9_.:-]+|\s*\.[a-zA-Z0-9_-]+|\s*[a-zA-Z0-9_-]+=[^{}]*)+\s*\}"
 )
 
 
 def on_page_markdown(markdown, **kwargs):
-    markdown = _ID_ATTR.sub("", markdown)
-    markdown = _CLASS_ATTR.sub("", markdown)
-    markdown = _TRAILING_ATTR.sub(")", markdown)
-    return markdown
+    """MkDocs hook to strip Pandoc attributes outside code blocks and inline code."""
+    out = []
+    last_end = 0
+    for match in _CODE_PATTERN.finditer(markdown):
+        start, end = match.span()
+        if start > last_end:
+            non_code = markdown[last_end:start]
+            non_code = _TRAILING_LINK_ATTR.sub(")", non_code)
+            non_code = _PANDOC_ATTR.sub("", non_code)
+            out.append(non_code)
+        out.append(match.group(0))
+        last_end = end
+    if last_end < len(markdown):
+        non_code = markdown[last_end:]
+        non_code = _TRAILING_LINK_ATTR.sub(")", non_code)
+        non_code = _PANDOC_ATTR.sub("", non_code)
+        out.append(non_code)
+    return "".join(out)

--- a/scripts/mkdocs_pandoc_strip.py
+++ b/scripts/mkdocs_pandoc_strip.py
@@ -10,7 +10,6 @@ understand and would otherwise render as literal text:
 import re
 
 _CODE_PATTERN = re.compile(r"(?P<fence>```+|~~~+|`+)([\s\S]*?)(?P=fence)")
-_TRAILING_LINK_ATTR = re.compile(r"\)\{[^{}]*\}")
 _PANDOC_ATTR = re.compile(
     r"[ \t]*\{(?:\s*#[a-zA-Z0-9_.:-]+|\s*\.[a-zA-Z0-9_-]+|\s*[a-zA-Z0-9_-]+=[^{}]*)+\s*\}"
 )
@@ -24,14 +23,12 @@ def on_page_markdown(markdown, **kwargs):
         start, end = match.span()
         if start > last_end:
             non_code = markdown[last_end:start]
-            non_code = _TRAILING_LINK_ATTR.sub(")", non_code)
             non_code = _PANDOC_ATTR.sub("", non_code)
             out.append(non_code)
         out.append(match.group(0))
         last_end = end
     if last_end < len(markdown):
         non_code = markdown[last_end:]
-        non_code = _TRAILING_LINK_ATTR.sub(")", non_code)
         non_code = _PANDOC_ATTR.sub("", non_code)
         out.append(non_code)
     return "".join(out)

--- a/tests/test_mkdocs_pandoc_strip.py
+++ b/tests/test_mkdocs_pandoc_strip.py
@@ -1,0 +1,67 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from mkdocs_pandoc_strip import on_page_markdown
+
+
+def test_pandoc_strip_preserves_code_blocks_and_inline_code():
+    """Prove that code blocks and inline code containing Pandoc-like attribute patterns
+
+    (e.g., {.unnumbered}, {.highlight}, `const sel = "{.my-class}"`) are left completely untouched,
+    locking out code corruption bugs where attributes inside code snippets are stripped.
+    """
+    content = """# Title {.unnumbered}
+
+```markdown
+## Example Title {.unnumbered}
+This uses the class {.highlight}.
+```
+
+Inline code: `const sel = "{.my-class}";`
+"""
+
+    result = on_page_markdown(content)
+
+    assert "## Example Title {.unnumbered}" in result
+    assert "This uses the class {.highlight}." in result
+    assert '`const sel = "{.my-class}";`' in result
+    assert result.startswith("# Title\n")
+
+
+def test_pandoc_strip_handles_combined_attributes():
+    """Prove that combined Pandoc attribute blocks (e.g. {#sec:ch1 .unnumbered},
+
+    {#fig:arch .responsive width=80%}) and link attributes ({#link1 .unnumbered}) outside
+    code blocks are stripped correctly, locking out unhandled attribute rendering bugs.
+    """
+    content = """## Section 1 {#sec:ch1 .unnumbered}
+![Architecture](arch.png){#fig:arch .responsive width=80%}
+[Link](#sec:ch1){#link1 .unnumbered}
+"""
+
+    result = on_page_markdown(content)
+
+    assert "## Section 1\n" in result
+    assert "![Architecture](arch.png)\n" in result
+    assert "[Link](#sec:ch1)\n" in result
+
+
+def test_pandoc_strip_does_not_mutate_json_data():
+    """Prove that JSON data structures with braces and quotes (e.g. `{"data": {"#key": 123}}`)
+
+    are preserved without modification, locking out false-positive attribute matching on JSON.
+    """
+    content = 'JSON data: `{"data": {"#key": 123}}`'
+    assert on_page_markdown(content) == content
+
+
+def test_pandoc_strip_handles_nested_inline_backticks():
+    """Prove that double backticks wrapping single backticks (e.g. ``foo `bar` baz {.unnumbered}``)
+
+    are correctly matched as inline code blocks and not prematurely split, locking out backtick parsing bugs.
+    """
+    content = "Code: ``foo `bar` baz {.unnumbered}`` outside {.unnumbered}"
+    result = on_page_markdown(content)
+    assert result == "Code: ``foo `bar` baz {.unnumbered}`` outside"

--- a/tests/test_mkdocs_pandoc_strip.py
+++ b/tests/test_mkdocs_pandoc_strip.py
@@ -57,6 +57,12 @@ def test_pandoc_strip_does_not_mutate_json_data():
     assert on_page_markdown(content) == content
 
 
+def test_pandoc_strip_preserves_non_pandoc_braces_after_links():
+    """Only recognized Pandoc attributes may be removed after a link."""
+    content = "Literal: [link](https://example.com){not a Pandoc attribute}"
+    assert on_page_markdown(content) == content
+
+
 def test_pandoc_strip_handles_nested_inline_backticks():
     """Prove that double backticks wrapping single backticks (e.g. ``foo `bar` baz {.unnumbered}``)
 


### PR DESCRIPTION
### Summary

Protects fenced code blocks and inline code samples from destructive attribute stripping in the `mkdocs_pandoc_strip` rendering hook, and supports combined Pandoc attribute blocks.

### Root Cause
The Pandoc attribute stripping regex ran indiscriminately over Markdown page text, accidentally altering attribute annotations inside fenced code blocks and inline code samples.

### Fix
Strips Pandoc attribute blocks only outside fenced code blocks and inline code spans, supporting combined attribute blocks (`{.class #id key=val}`).

### Verification
Added comprehensive tests in `tests/test_mkdocs_pandoc_strip.py` asserting code block protection and combined attribute stripping.