### PR TITLE
fix(providers): prefix qwen model ids and handle empty OPENROUTER_MODEL

### DIFF
--- a/agentbook/providers/openrouter.py
+++ b/agentbook/providers/openrouter.py
@@ -88,7 +88,7 @@ def map_model_to_openrouter(model: str, *, substitute_unknown: bool = False) -> 
     * ``claude-*`` becomes the matching Anthropic id
     * ``kimi-*`` becomes ``moonshotai/kimi-k2.6`` (kimi-k3 is not hosted)
     * ``deepseek-*`` becomes ``deepseek/<id>``
-
+    * ``qwen-*`` / ``qwen2*`` / ``qwen3*`` becomes ``qwen/<id>``
     What to do with an unmapped id -- a native one such as ``doubao-*`` or
     ``glm-*``, which OpenRouter does not reliably host -- depends on why the
     caller is mapping, so it is the caller's decision rather than a fixed rule
@@ -125,6 +125,8 @@ def map_model_to_openrouter(model: str, *, substitute_unknown: bool = False) -> 
         return "moonshotai/kimi-k2.6"
     if ml.startswith("deepseek"):
         return "deepseek/" + m
+    if ml.startswith("qwen"):
+        return "qwen/" + m
     if substitute_unknown:
-        return os.getenv("OPENROUTER_MODEL", OPENROUTER_DEFAULT_MODEL)
+        return os.getenv("OPENROUTER_MODEL", "").strip() or OPENROUTER_DEFAULT_MODEL
     return m

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -9,6 +9,7 @@ import dataclasses
 import pytest
 
 from agentbook.providers import (
+    OPENROUTER_DEFAULT_MODEL,
     PROVIDERS,
     SUPPORTED_PROVIDERS,
     Provider,
@@ -64,6 +65,8 @@ def clean_env(monkeypatch):
         # Regression: two of the three original copies dropped deepseek ids to
         # the catch-all default instead of mapping them.
         ("deepseek-v4-flash", "deepseek/deepseek-v4-flash"),
+        ("qwen-2.5-72b-instruct", "qwen/qwen-2.5-72b-instruct"),
+        ("qwen2.5-coder-32b", "qwen/qwen2.5-coder-32b"),
     ],
 )
 def test_map_model_to_openrouter(model, expected):
@@ -77,6 +80,17 @@ def test_unknown_model_falls_back_to_openrouter_model_env(monkeypatch):
     mapped = map_model_to_openrouter("doubao-seed-1-6", substitute_unknown=True)
     assert mapped == "google/gemma-4-31b-it:free"
 
+
+
+def test_unknown_model_falls_back_to_default_when_openrouter_model_env_is_empty(monkeypatch):
+    """Empty or whitespace OPENROUTER_MODEL must fall back to the package default.
+
+    Locks out regression where OPENROUTER_MODEL set to empty string or whitespace
+    bypassed OPENROUTER_DEFAULT_MODEL when substitute_unknown is True.
+    """
+    monkeypatch.setenv("OPENROUTER_MODEL", "   ")
+    mapped = map_model_to_openrouter("doubao-seed-1-6", substitute_unknown=True)
+    assert mapped == OPENROUTER_DEFAULT_MODEL
 
 def test_unknown_model_is_returned_unchanged_by_default(monkeypatch):
     """The default keeps the reader's model id, so an unhosted one is rejected


### PR DESCRIPTION
### Summary

Adds missing `qwen/` vendor prefix mapping for Qwen models in `map_model_to_openrouter` and ensures empty/whitespace `OPENROUTER_MODEL` environment variables fall back to `OPENROUTER_DEFAULT_MODEL`.

### Root Cause
Bare Qwen model names (e.g. `qwen-2.5-72b-instruct`) were passed to OpenRouter without the `qwen/` vendor prefix, causing routing failures. Whitespace-only `OPENROUTER_MODEL` strings also bypassed default fallback checks.

### Fix
Prefixes Qwen model identifiers with `qwen/` and treats empty/whitespace environment strings as unconfigured defaults.

### Verification
Added unit tests in `tests/test_providers.py` asserting prefix mapping and environment variable fallback.