### PR TITLE
fix(i18n): preserve colons in quoted mkdocs nav labels

### DIFF
--- a/scripts/site_i18n.py
+++ b/scripts/site_i18n.py
@@ -1,43 +1,22 @@
-#!/usr/bin/env python3
-"""Validate and build the static site's browser-side translation catalog.
-
-The site contains all book editions in one MkDocs build. MkDocs Material can
-only use one ``theme.language`` per build, so its generated chrome is Chinese
-and translated editions localize it in the browser. This hook combines:
-
-* Material for MkDocs' own locale catalogs (search, actions, footer, etc.); and
-* ``extras/site-nav-i18n.json`` (book navigation and custom controls).
-
-Run ``python scripts/site_i18n.py`` after installing ``requirements-docs.txt``
-to audit every language. During ``mkdocs build`` the same validation runs and
-the hook emits ``_web/extras/site-i18n.generated.js`` for the browser.
-"""
+"""i18n catalog generation and audit helper for MkDocs site translation."""
 
 from __future__ import annotations
 
-import ast
 import json
 import re
 import sys
 from pathlib import Path
-from typing import Any
 
-
-ROOT = Path(__file__).resolve().parent.parent
+ROOT = Path(__file__).resolve().parents[1]
 MKDOCS_CONFIG = ROOT / "mkdocs.yml"
 CUSTOM_CATALOG = ROOT / "extras" / "site-nav-i18n.json"
 GENERATED_CATALOG = ROOT / "_web" / "extras" / "site-i18n.generated.js"
 
 # Material strings that the configured theme features can render. Search
-# result strings are updated dynamically, while the rest occur in the initial
-# document or in tooltips/dialogs.
-REQUIRED_UI_KEYS = (
-    "action.edit",
-    "action.skip",
-    "action.view",
-    "clipboard.copy",
-    "clipboard.copied",
-    "footer",
+# keys match standard Material translation tokens. Custom keys cover custom
+# header/footer/control elements added by theme overrides.
+MATERIAL_KEYS = [
+    "actions.select.language",
     "footer.next",
     "footer.previous",
     "header",
@@ -45,35 +24,39 @@ REQUIRED_UI_KEYS = (
     "search",
     "search.placeholder",
     "search.share",
-    "search.reset",
     "search.result.initializer",
     "search.result.placeholder",
     "search.result.none",
     "search.result.one",
     "search.result.other",
-    "search.result.more.one",
-    "search.result.more.other",
     "search.result.term.missing",
     "select.language",
-    "source",
-    "source.file.contributors",
-    "source.file.date.created",
-    "source.file.date.updated",
-    "tabs",
-    "toc",
-    "top",
-)
+
+    # Material search configuration tokens used by search JS
+    "search.config.pipeline",
+    "search.config.separator",
+]
 
 CUSTOM_GROUPS = {
-    "sidebar": ("show", "hide"),
-    "palette": ("light", "dark"),
+    "header": ["title", "tagline", "badge", "backToBook"],
+    "home": ["heroTitle", "heroDesc", "startReading", "starOnGithub", "chapterCount"],
+    "footer": ["builtWith", "copyrightNotice", "terms"],
 }
 
-HAN_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff]")
+HAN_RE = re.compile(r"[\u4e00-\u9fff]")
 
 
-class CatalogError(RuntimeError):
-    """Raised when the checked-in translation catalog is incomplete."""
+class CatalogError(Exception):
+    pass
+
+
+def load_custom_catalog() -> dict:
+    if not CUSTOM_CATALOG.is_file():
+        raise CatalogError(f"Missing catalog file: {CUSTOM_CATALOG}")
+    try:
+        return json.loads(CUSTOM_CATALOG.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise CatalogError(f"Malformed catalog JSON: {CUSTOM_CATALOG}: {exc}") from exc
 
 
 def configured_languages(config_text: str) -> dict[str, dict[str, str]]:
@@ -83,7 +66,7 @@ def configured_languages(config_text: str) -> dict[str, dict[str, str]]:
         raise CatalogError("mkdocs.yml: could not find extra.languages")
     languages: dict[str, dict[str, str]] = {}
     for code, attributes in re.findall(
-        r"(?m)^    ([a-zA-Z][a-zA-Z0-9_-]*):\s*\{([^}]*)\}\s*$",
+        r"(?m)^\s{4}(\w[\w-]*):\s*\n(?P<attrs>(?:\s{6}\w+:\s*.*(?:\n|$))+)",
         match.group("body"),
     ):
         parsed: dict[str, str] = {}
@@ -104,9 +87,10 @@ def canonical_nav_labels(config_text: str) -> list[str]:
         raise CatalogError("mkdocs.yml: could not find nav")
 
     labels: list[str] = []
-    for label in re.findall(r"(?m)^\s*-\s+([^:\n]+):(?:\s|$)", match.group("body")):
-        label = label.strip().strip("\"'")
-        if label not in labels:
+    pattern = re.compile(r'''(?m)^\s*-\s+(?:"([^"\n]+)"|'([^'\n]+)'|([^:\n]+)):(?:\s|$)''')
+    for double_q, single_q, unquoted in pattern.findall(match.group("body")):
+        label = (double_q or single_q or unquoted or "").strip().strip("\"'")
+        if label and label not in labels:
             labels.append(label)
     if not labels:
         raise CatalogError("mkdocs.yml: no named nav entries found")
@@ -131,36 +115,42 @@ def load_material_locale(locale: str, languages_dir: Path) -> dict[str, str]:
     text = path.read_text(encoding="utf-8")
     start_match = re.search(r'\{\s*\n\s*"language"\s*:', text)
     if not start_match:
-        raise CatalogError(f"Could not parse Material locale: {path}")
-    end = text.find("}[key]", start_match.start())
-    if end < 0:
-        raise CatalogError(f"Could not parse Material locale: {path}")
+        raise CatalogError(f"Material locale missing language dict: {path}")
+
+    end_index = text.rfind("}")
+    if end_index == -1 or end_index < start_match.start():
+        raise CatalogError(f"Material locale missing closing brace: {path}")
+
+    json_text = text[start_match.start() : end_index + 1]
     try:
-        values = ast.literal_eval(text[start_match.start() : end + 1])
-    except (SyntaxError, ValueError) as exc:
-        raise CatalogError(f"Could not parse Material locale: {path}: {exc}") from exc
-    if not isinstance(values, dict):
-        raise CatalogError(f"Material locale is not a mapping: {path}")
+        data = json.loads(json_text)
+    except json.JSONDecodeError as exc:
+        raise CatalogError(f"Invalid JSON in Material locale {path}: {exc}") from exc
+
+    values: dict[str, str] = {}
+    for key in MATERIAL_KEYS:
+        node = data
+        for part in key.split("."):
+            if isinstance(node, dict) and part in node:
+                node = node[part]
+            else:
+                node = None
+                break
+        if isinstance(node, str):
+            values[key] = node
+
     return values
 
 
-def load_custom_catalog() -> dict[str, dict[str, Any]]:
-    try:
-        data = json.loads(CUSTOM_CATALOG.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise CatalogError(f"Could not read {CUSTOM_CATALOG}: {exc}") from exc
-    if not isinstance(data, dict):
-        raise CatalogError(f"{CUSTOM_CATALOG}: top level must be an object")
-    return data
-
-
-def _check_nonempty(errors: list[str], code: str, field: str, value: Any) -> None:
+def _check_nonempty(errors: list[str], code: str, key: str, value: object) -> None:
     if not isinstance(value, str) or not value.strip():
-        errors.append(f"{code}: {field} must be a non-empty string")
+        errors.append(f"{code}: {key} must be a non-empty string")
 
 
-def build_catalog() -> dict[str, Any]:
-    """Validate all sources and return the compact browser catalog."""
+def audit_catalog() -> dict:
+    if not MKDOCS_CONFIG.is_file():
+        raise CatalogError(f"Missing config file: {MKDOCS_CONFIG}")
+
     config_text = MKDOCS_CONFIG.read_text(encoding="utf-8")
     configured = configured_languages(config_text)
     codes = list(configured)
@@ -169,46 +159,35 @@ def build_catalog() -> dict[str, Any]:
     languages_dir = material_languages_dir()
     errors: list[str] = []
 
-    missing_codes = sorted(set(codes) - set(custom))
-    extra_codes = sorted(set(custom) - set(codes))
-    if missing_codes:
-        errors.append(f"catalog is missing configured languages: {', '.join(missing_codes)}")
-    if extra_codes:
-        errors.append(f"catalog has unconfigured languages: {', '.join(extra_codes)}")
+    languages_entry = custom.get("languages")
+    if not isinstance(languages_entry, dict):
+        raise CatalogError("Catalog root missing object field: languages")
 
-    browser_languages: dict[str, Any] = {}
+    home_pages: dict[str, str] = {}
+    browser_languages: dict[str, dict[str, str]] = {}
+
     for code in codes:
-        entry = custom.get(code)
+        if code not in languages_entry:
+            errors.append(f"Catalog missing configured language entry: {code}")
+            continue
+
+        entry = languages_entry[code]
         if not isinstance(entry, dict):
+            errors.append(f"Language entry is not an object: {code}")
             continue
 
-        material_locale = entry.get("material_locale")
-        _check_nonempty(errors, code, "material_locale", material_locale)
-        if not isinstance(material_locale, str) or not material_locale:
-            continue
-        try:
-            material_ui = load_material_locale(material_locale, languages_dir)
-        except CatalogError as exc:
-            errors.append(str(exc))
-            continue
-        overrides = entry.get("ui_overrides", {})
-        if not isinstance(overrides, dict):
-            errors.append(f"{code}: ui_overrides must be an object")
-            overrides = {}
-        unknown_overrides = sorted(set(overrides) - set(material_ui))
-        if unknown_overrides:
-            errors.append(
-                f"{code}: ui_overrides has unknown Material keys: "
-                + ", ".join(unknown_overrides)
-            )
-        effective_ui = {**material_ui, **overrides}
+        name = entry.get("name")
+        _check_nonempty(errors, code, "name", name)
 
-        ui: dict[str, str] = {}
-        for key in REQUIRED_UI_KEYS:
-            value = effective_ui.get(key)
-            _check_nonempty(errors, code, f"Material UI key {key}", value)
-            if isinstance(value, str):
-                ui[key] = value
+        prefix = configured[code].get("prefix", "")
+        suffix = configured[code].get("suffix", "")
+        home_pages[code] = f"{prefix}/" if prefix else "index.html"
+
+        browser_languages[code] = {
+            "name": name if isinstance(name, str) else code,
+            "prefix": prefix,
+            "suffix": suffix,
+        }
 
         nav = entry.get("nav")
         if not isinstance(nav, dict):
@@ -225,112 +204,78 @@ def build_catalog() -> dict[str, Any]:
 
         controls: dict[str, dict[str, str]] = {}
         for group, fields in CUSTOM_GROUPS.items():
-            values = entry.get(group)
-            if not isinstance(values, dict):
-                errors.append(f"{code}: {group} must be an object")
-                values = {}
-            controls[group] = {}
+            section = entry.get(group)
+            if not isinstance(section, dict):
+                errors.append(f"{code}: missing object section {group}")
+                section = {}
+            parsed_section: dict[str, str] = {}
             for field in fields:
-                value = values.get(field)
-                _check_nonempty(errors, code, f"{group}.{field}", value)
-                if isinstance(value, str):
-                    controls[group][field] = value
+                val = section.get(field)
+                _check_nonempty(errors, code, f"{group}.{field}", val)
+                if isinstance(val, str):
+                    parsed_section[field] = val
+            controls[group] = parsed_section
 
-        # Chinese characters in a non-CJK catalog almost always mean a label
-        # was copied but not translated. Japanese and Traditional Chinese are
-        # excluded because Han characters are part of those target languages.
+        ui = load_material_locale(code, languages_dir)
+        effective_ui = entry.get("ui")
+        if isinstance(effective_ui, dict):
+            for k, v in effective_ui.items():
+                if isinstance(v, str) and v.strip():
+                    ui[k] = v
+
         if code not in {"zh", "zhtw", "ja"}:
             custom_values = list(nav.values()) + list(ui.values())
             for values in controls.values():
                 custom_values.extend(values.values())
             leaked = [value for value in custom_values if isinstance(value, str) and HAN_RE.search(value)]
             if leaked:
-                errors.append(f"{code}: Chinese text remains in custom UI: {leaked[0]!r}")
+                errors.append(f"{code}: contains un-translated Chinese characters: {leaked[:3]}")
 
-        browser_languages[code] = {
-            "locale": effective_ui.get("language", material_locale),
+        browser_languages[code]["catalog"] = {
             "direction": effective_ui.get("direction", "ltr"),
             "nav": {label: nav[label] for label in nav_labels if label in nav},
             "ui": ui,
             **controls,
         }
 
-        # Every path produced by the language switcher must have a source
-        # Markdown file. This catches naming drift such as a translated
-        # reference-answer file retaining its old non-ASCII filename.
-        language_config = configured[code]
-        prefix = language_config.get("prefix")
-        if not prefix:
-            errors.append(f"{code}: mkdocs language config has no prefix")
-            continue
-        book_dir = ROOT / prefix.rstrip("/")
-        suffix = language_config.get("suffix", "")
-        prose_slugs = ["introduction", *(f"chapter{n}" for n in range(1, 11)), "afterword", "reference-answers"]
-        for slug in prose_slugs:
-            source = book_dir / f"{slug}{suffix}.md"
-            if not source.is_file():
-                errors.append(
-                    f"{code}: switcher URL has no source file: {source.relative_to(ROOT)}"
-                )
-        readme_suffix = language_config.get("readmeSuffix")
-        if readme_suffix:
-            for number in range(1, 11):
-                source = ROOT / f"chapter{number}" / f"README.{readme_suffix}.md"
-                if not source.is_file():
-                    errors.append(
-                        f"{code}: experiment-index URL has no source file: {source.relative_to(ROOT)}"
-                    )
+    extra_codes = [code for code in languages_entry if code not in codes]
+    if extra_codes:
+        errors.append(f"Catalog contains unconfigured languages: {', '.join(extra_codes)}")
 
     if errors:
-        raise CatalogError("Static-site i18n validation failed:\n  - " + "\n  - ".join(errors))
-
-    default = "zh"
-    if default not in browser_languages:
-        raise CatalogError(f"Default language {default!r} is not configured")
-
-    # Languages with a translated site homepage (root index.<code>.md).
-    # The language switcher maps home <-> home for these editions and keeps
-    # the introduction-page fallback for the rest. The default edition's
-    # homepage is the root index.md itself.
-    home_pages = [code for code in codes if (ROOT / f"index.{code}.md").is_file()]
+        bullet_list = "\n  - ".join(errors)
+        raise CatalogError(f"i18n catalog validation failed with {len(errors)} error(s):\n  - {bullet_list}")
 
     return {
-        "default": default,
         "languages": browser_languages,
         "canonicalNav": nav_labels,
         "homePages": home_pages,
     }
 
 
-def write_browser_catalog(catalog: dict[str, Any]) -> None:
+def build_catalog() -> str:
+    catalog = audit_catalog()
+    raw = json.dumps(catalog, ensure_ascii=False, indent=2)
+    return f"window.__BOOK_I18N__ = {raw};\n"
+
+
+def write_catalog() -> Path:
+    text = build_catalog()
     GENERATED_CATALOG.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps(catalog, ensure_ascii=False, separators=(",", ":"))
-    GENERATED_CATALOG.write_text(
-        "// Generated by scripts/site_i18n.py; do not edit.\n"
-        f"window.SITE_I18N={payload};\n",
-        encoding="utf-8",
-    )
-
-
-def on_config(config: Any, **_: Any) -> Any:
-    """MkDocs hook: fail the build on drift and emit the browser catalog."""
-    try:
-        write_browser_catalog(build_catalog())
-    except CatalogError as exc:
-        from mkdocs.exceptions import ConfigurationError
-
-        raise ConfigurationError(str(exc)) from exc
-    return config
+    GENERATED_CATALOG.write_text(text, encoding="utf-8")
+    return GENERATED_CATALOG
 
 
 def main() -> int:
     try:
-        catalog = build_catalog()
+        path = write_catalog()
     except CatalogError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
+
+    catalog = audit_catalog()
     print(
-        "Static-site i18n catalog is complete: "
+        f"Wrote {path} covering "
         f"{len(catalog['languages'])} languages, "
         f"{len(catalog['canonicalNav'])} navigation labels each."
     )

--- a/scripts/site_i18n.py
+++ b/scripts/site_i18n.py
@@ -1,22 +1,43 @@
-"""i18n catalog generation and audit helper for MkDocs site translation."""
+#!/usr/bin/env python3
+"""Validate and build the static site's browser-side translation catalog.
+
+The site contains all book editions in one MkDocs build. MkDocs Material can
+only use one ``theme.language`` per build, so its generated chrome is Chinese
+and translated editions localize it in the browser. This hook combines:
+
+* Material for MkDocs' own locale catalogs (search, actions, footer, etc.); and
+* ``extras/site-nav-i18n.json`` (book navigation and custom controls).
+
+Run ``python scripts/site_i18n.py`` after installing ``requirements-docs.txt``
+to audit every language. During ``mkdocs build`` the same validation runs and
+the hook emits ``_web/extras/site-i18n.generated.js`` for the browser.
+"""
 
 from __future__ import annotations
 
+import ast
 import json
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
-ROOT = Path(__file__).resolve().parents[1]
+
+ROOT = Path(__file__).resolve().parent.parent
 MKDOCS_CONFIG = ROOT / "mkdocs.yml"
 CUSTOM_CATALOG = ROOT / "extras" / "site-nav-i18n.json"
 GENERATED_CATALOG = ROOT / "_web" / "extras" / "site-i18n.generated.js"
 
 # Material strings that the configured theme features can render. Search
-# keys match standard Material translation tokens. Custom keys cover custom
-# header/footer/control elements added by theme overrides.
-MATERIAL_KEYS = [
-    "actions.select.language",
+# result strings are updated dynamically, while the rest occur in the initial
+# document or in tooltips/dialogs.
+REQUIRED_UI_KEYS = (
+    "action.edit",
+    "action.skip",
+    "action.view",
+    "clipboard.copy",
+    "clipboard.copied",
+    "footer",
     "footer.next",
     "footer.previous",
     "header",
@@ -24,39 +45,35 @@ MATERIAL_KEYS = [
     "search",
     "search.placeholder",
     "search.share",
+    "search.reset",
     "search.result.initializer",
     "search.result.placeholder",
     "search.result.none",
     "search.result.one",
     "search.result.other",
+    "search.result.more.one",
+    "search.result.more.other",
     "search.result.term.missing",
     "select.language",
-
-    # Material search configuration tokens used by search JS
-    "search.config.pipeline",
-    "search.config.separator",
-]
+    "source",
+    "source.file.contributors",
+    "source.file.date.created",
+    "source.file.date.updated",
+    "tabs",
+    "toc",
+    "top",
+)
 
 CUSTOM_GROUPS = {
-    "header": ["title", "tagline", "badge", "backToBook"],
-    "home": ["heroTitle", "heroDesc", "startReading", "starOnGithub", "chapterCount"],
-    "footer": ["builtWith", "copyrightNotice", "terms"],
+    "sidebar": ("show", "hide"),
+    "palette": ("light", "dark"),
 }
 
-HAN_RE = re.compile(r"[\u4e00-\u9fff]")
+HAN_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff]")
 
 
-class CatalogError(Exception):
-    pass
-
-
-def load_custom_catalog() -> dict:
-    if not CUSTOM_CATALOG.is_file():
-        raise CatalogError(f"Missing catalog file: {CUSTOM_CATALOG}")
-    try:
-        return json.loads(CUSTOM_CATALOG.read_text(encoding="utf-8"))
-    except Exception as exc:
-        raise CatalogError(f"Malformed catalog JSON: {CUSTOM_CATALOG}: {exc}") from exc
+class CatalogError(RuntimeError):
+    """Raised when the checked-in translation catalog is incomplete."""
 
 
 def configured_languages(config_text: str) -> dict[str, dict[str, str]]:
@@ -66,7 +83,7 @@ def configured_languages(config_text: str) -> dict[str, dict[str, str]]:
         raise CatalogError("mkdocs.yml: could not find extra.languages")
     languages: dict[str, dict[str, str]] = {}
     for code, attributes in re.findall(
-        r"(?m)^\s{4}(\w[\w-]*):\s*\n(?P<attrs>(?:\s{6}\w+:\s*.*(?:\n|$))+)",
+        r"(?m)^    ([a-zA-Z][a-zA-Z0-9_-]*):\s*\{([^}]*)\}\s*$",
         match.group("body"),
     ):
         parsed: dict[str, str] = {}
@@ -120,42 +137,36 @@ def load_material_locale(locale: str, languages_dir: Path) -> dict[str, str]:
     text = path.read_text(encoding="utf-8")
     start_match = re.search(r'\{\s*\n\s*"language"\s*:', text)
     if not start_match:
-        raise CatalogError(f"Material locale missing language dict: {path}")
-
-    end_index = text.rfind("}")
-    if end_index == -1 or end_index < start_match.start():
-        raise CatalogError(f"Material locale missing closing brace: {path}")
-
-    json_text = text[start_match.start() : end_index + 1]
+        raise CatalogError(f"Could not parse Material locale: {path}")
+    end = text.find("}[key]", start_match.start())
+    if end < 0:
+        raise CatalogError(f"Could not parse Material locale: {path}")
     try:
-        data = json.loads(json_text)
-    except json.JSONDecodeError as exc:
-        raise CatalogError(f"Invalid JSON in Material locale {path}: {exc}") from exc
-
-    values: dict[str, str] = {}
-    for key in MATERIAL_KEYS:
-        node = data
-        for part in key.split("."):
-            if isinstance(node, dict) and part in node:
-                node = node[part]
-            else:
-                node = None
-                break
-        if isinstance(node, str):
-            values[key] = node
-
+        values = ast.literal_eval(text[start_match.start() : end + 1])
+    except (SyntaxError, ValueError) as exc:
+        raise CatalogError(f"Could not parse Material locale: {path}: {exc}") from exc
+    if not isinstance(values, dict):
+        raise CatalogError(f"Material locale is not a mapping: {path}")
     return values
 
 
-def _check_nonempty(errors: list[str], code: str, key: str, value: object) -> None:
+def load_custom_catalog() -> dict[str, dict[str, Any]]:
+    try:
+        data = json.loads(CUSTOM_CATALOG.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CatalogError(f"Could not read {CUSTOM_CATALOG}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise CatalogError(f"{CUSTOM_CATALOG}: top level must be an object")
+    return data
+
+
+def _check_nonempty(errors: list[str], code: str, field: str, value: Any) -> None:
     if not isinstance(value, str) or not value.strip():
-        errors.append(f"{code}: {key} must be a non-empty string")
+        errors.append(f"{code}: {field} must be a non-empty string")
 
 
-def audit_catalog() -> dict:
-    if not MKDOCS_CONFIG.is_file():
-        raise CatalogError(f"Missing config file: {MKDOCS_CONFIG}")
-
+def build_catalog() -> dict[str, Any]:
+    """Validate all sources and return the compact browser catalog."""
     config_text = MKDOCS_CONFIG.read_text(encoding="utf-8")
     configured = configured_languages(config_text)
     codes = list(configured)
@@ -164,35 +175,46 @@ def audit_catalog() -> dict:
     languages_dir = material_languages_dir()
     errors: list[str] = []
 
-    languages_entry = custom.get("languages")
-    if not isinstance(languages_entry, dict):
-        raise CatalogError("Catalog root missing object field: languages")
+    missing_codes = sorted(set(codes) - set(custom))
+    extra_codes = sorted(set(custom) - set(codes))
+    if missing_codes:
+        errors.append(f"catalog is missing configured languages: {', '.join(missing_codes)}")
+    if extra_codes:
+        errors.append(f"catalog has unconfigured languages: {', '.join(extra_codes)}")
 
-    home_pages: dict[str, str] = {}
-    browser_languages: dict[str, dict[str, str]] = {}
-
+    browser_languages: dict[str, Any] = {}
     for code in codes:
-        if code not in languages_entry:
-            errors.append(f"Catalog missing configured language entry: {code}")
-            continue
-
-        entry = languages_entry[code]
+        entry = custom.get(code)
         if not isinstance(entry, dict):
-            errors.append(f"Language entry is not an object: {code}")
             continue
 
-        name = entry.get("name")
-        _check_nonempty(errors, code, "name", name)
+        material_locale = entry.get("material_locale")
+        _check_nonempty(errors, code, "material_locale", material_locale)
+        if not isinstance(material_locale, str) or not material_locale:
+            continue
+        try:
+            material_ui = load_material_locale(material_locale, languages_dir)
+        except CatalogError as exc:
+            errors.append(str(exc))
+            continue
+        overrides = entry.get("ui_overrides", {})
+        if not isinstance(overrides, dict):
+            errors.append(f"{code}: ui_overrides must be an object")
+            overrides = {}
+        unknown_overrides = sorted(set(overrides) - set(material_ui))
+        if unknown_overrides:
+            errors.append(
+                f"{code}: ui_overrides has unknown Material keys: "
+                + ", ".join(unknown_overrides)
+            )
+        effective_ui = {**material_ui, **overrides}
 
-        prefix = configured[code].get("prefix", "")
-        suffix = configured[code].get("suffix", "")
-        home_pages[code] = f"{prefix}/" if prefix else "index.html"
-
-        browser_languages[code] = {
-            "name": name if isinstance(name, str) else code,
-            "prefix": prefix,
-            "suffix": suffix,
-        }
+        ui: dict[str, str] = {}
+        for key in REQUIRED_UI_KEYS:
+            value = effective_ui.get(key)
+            _check_nonempty(errors, code, f"Material UI key {key}", value)
+            if isinstance(value, str):
+                ui[key] = value
 
         nav = entry.get("nav")
         if not isinstance(nav, dict):
@@ -209,78 +231,112 @@ def audit_catalog() -> dict:
 
         controls: dict[str, dict[str, str]] = {}
         for group, fields in CUSTOM_GROUPS.items():
-            section = entry.get(group)
-            if not isinstance(section, dict):
-                errors.append(f"{code}: missing object section {group}")
-                section = {}
-            parsed_section: dict[str, str] = {}
+            values = entry.get(group)
+            if not isinstance(values, dict):
+                errors.append(f"{code}: {group} must be an object")
+                values = {}
+            controls[group] = {}
             for field in fields:
-                val = section.get(field)
-                _check_nonempty(errors, code, f"{group}.{field}", val)
-                if isinstance(val, str):
-                    parsed_section[field] = val
-            controls[group] = parsed_section
+                value = values.get(field)
+                _check_nonempty(errors, code, f"{group}.{field}", value)
+                if isinstance(value, str):
+                    controls[group][field] = value
 
-        ui = load_material_locale(code, languages_dir)
-        effective_ui = entry.get("ui")
-        if isinstance(effective_ui, dict):
-            for k, v in effective_ui.items():
-                if isinstance(v, str) and v.strip():
-                    ui[k] = v
-
+        # Chinese characters in a non-CJK catalog almost always mean a label
+        # was copied but not translated. Japanese and Traditional Chinese are
+        # excluded because Han characters are part of those target languages.
         if code not in {"zh", "zhtw", "ja"}:
             custom_values = list(nav.values()) + list(ui.values())
             for values in controls.values():
                 custom_values.extend(values.values())
             leaked = [value for value in custom_values if isinstance(value, str) and HAN_RE.search(value)]
             if leaked:
-                errors.append(f"{code}: contains un-translated Chinese characters: {leaked[:3]}")
+                errors.append(f"{code}: Chinese text remains in custom UI: {leaked[0]!r}")
 
-        browser_languages[code]["catalog"] = {
+        browser_languages[code] = {
+            "locale": effective_ui.get("language", material_locale),
             "direction": effective_ui.get("direction", "ltr"),
             "nav": {label: nav[label] for label in nav_labels if label in nav},
             "ui": ui,
             **controls,
         }
 
-    extra_codes = [code for code in languages_entry if code not in codes]
-    if extra_codes:
-        errors.append(f"Catalog contains unconfigured languages: {', '.join(extra_codes)}")
+        # Every path produced by the language switcher must have a source
+        # Markdown file. This catches naming drift such as a translated
+        # reference-answer file retaining its old non-ASCII filename.
+        language_config = configured[code]
+        prefix = language_config.get("prefix")
+        if not prefix:
+            errors.append(f"{code}: mkdocs language config has no prefix")
+            continue
+        book_dir = ROOT / prefix.rstrip("/")
+        suffix = language_config.get("suffix", "")
+        prose_slugs = ["introduction", *(f"chapter{n}" for n in range(1, 11)), "afterword", "reference-answers"]
+        for slug in prose_slugs:
+            source = book_dir / f"{slug}{suffix}.md"
+            if not source.is_file():
+                errors.append(
+                    f"{code}: switcher URL has no source file: {source.relative_to(ROOT)}"
+                )
+        readme_suffix = language_config.get("readmeSuffix")
+        if readme_suffix:
+            for number in range(1, 11):
+                source = ROOT / f"chapter{number}" / f"README.{readme_suffix}.md"
+                if not source.is_file():
+                    errors.append(
+                        f"{code}: experiment-index URL has no source file: {source.relative_to(ROOT)}"
+                    )
 
     if errors:
-        bullet_list = "\n  - ".join(errors)
-        raise CatalogError(f"i18n catalog validation failed with {len(errors)} error(s):\n  - {bullet_list}")
+        raise CatalogError("Static-site i18n validation failed:\n  - " + "\n  - ".join(errors))
+
+    default = "zh"
+    if default not in browser_languages:
+        raise CatalogError(f"Default language {default!r} is not configured")
+
+    # Languages with a translated site homepage (root index.<code>.md).
+    # The language switcher maps home <-> home for these editions and keeps
+    # the introduction-page fallback for the rest. The default edition's
+    # homepage is the root index.md itself.
+    home_pages = [code for code in codes if (ROOT / f"index.{code}.md").is_file()]
 
     return {
+        "default": default,
         "languages": browser_languages,
         "canonicalNav": nav_labels,
         "homePages": home_pages,
     }
 
 
-def build_catalog() -> str:
-    catalog = audit_catalog()
-    raw = json.dumps(catalog, ensure_ascii=False, indent=2)
-    return f"window.__BOOK_I18N__ = {raw};\n"
-
-
-def write_catalog() -> Path:
-    text = build_catalog()
+def write_browser_catalog(catalog: dict[str, Any]) -> None:
     GENERATED_CATALOG.parent.mkdir(parents=True, exist_ok=True)
-    GENERATED_CATALOG.write_text(text, encoding="utf-8")
-    return GENERATED_CATALOG
+    payload = json.dumps(catalog, ensure_ascii=False, separators=(",", ":"))
+    GENERATED_CATALOG.write_text(
+        "// Generated by scripts/site_i18n.py; do not edit.\n"
+        f"window.SITE_I18N={payload};\n",
+        encoding="utf-8",
+    )
+
+
+def on_config(config: Any, **_: Any) -> Any:
+    """MkDocs hook: fail the build on drift and emit the browser catalog."""
+    try:
+        write_browser_catalog(build_catalog())
+    except CatalogError as exc:
+        from mkdocs.exceptions import ConfigurationError
+
+        raise ConfigurationError(str(exc)) from exc
+    return config
 
 
 def main() -> int:
     try:
-        path = write_catalog()
+        catalog = build_catalog()
     except CatalogError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
-
-    catalog = audit_catalog()
     print(
-        f"Wrote {path} covering "
+        "Static-site i18n catalog is complete: "
         f"{len(catalog['languages'])} languages, "
         f"{len(catalog['canonicalNav'])} navigation labels each."
     )

--- a/scripts/site_i18n.py
+++ b/scripts/site_i18n.py
@@ -87,9 +87,14 @@ def canonical_nav_labels(config_text: str) -> list[str]:
         raise CatalogError("mkdocs.yml: could not find nav")
 
     labels: list[str] = []
-    pattern = re.compile(r'''(?m)^\s*-\s+(?:"([^"\n]+)"|'([^'\n]+)'|([^:\n]+)):(?:\s|$)''')
+    pattern = re.compile(r'''(?m)^\s*-\s+(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|''|\\.)*)'|([^:\n]+)):(?:\s|$)''')
     for double_q, single_q, unquoted in pattern.findall(match.group("body")):
-        label = (double_q or single_q or unquoted or "").strip().strip("\"'")
+        if double_q:
+            label = double_q.replace(r'\"', '"').replace(r'\\', '\\').strip()
+        elif single_q:
+            label = single_q.replace(r"\'", "'").replace("''", "'").replace(r'\\', '\\').strip()
+        else:
+            label = (unquoted or "").strip().strip("\"'")
         if label and label not in labels:
             labels.append(label)
     if not labels:

--- a/tests/test_site_i18n.py
+++ b/tests/test_site_i18n.py
@@ -43,3 +43,20 @@ nav:
     labels = canonical_nav_labels(config)
 
     assert labels == ["Overview", "Experiments"]
+
+def test_canonical_nav_labels_multiple_colons_and_escaped_quotes():
+    """Prove that quoted nav labels with multiple colons and escaped quotes are properly parsed."""
+    config = r"""
+nav:
+  - "Part 1: Chapter 2: Deep Dive: Context": index.md
+  - 'Section A: Part B: Overview: Details': intro.md
+  - "Chapter 1: \"Agent\" Architecture: Overview": chapter1.md
+  - 'Chapter 2: \'Context\' & \'Prompts\': Details': chapter2.md
+  - 'Chapter 3: ''Memory'' Management': chapter3.md
+"""
+    labels = canonical_nav_labels(config)
+    assert "Part 1: Chapter 2: Deep Dive: Context" in labels
+    assert "Section A: Part B: Overview: Details" in labels
+    assert 'Chapter 1: "Agent" Architecture: Overview' in labels
+    assert "Chapter 2: 'Context' & 'Prompts': Details" in labels
+    assert "Chapter 3: 'Memory' Management" in labels

--- a/tests/test_site_i18n.py
+++ b/tests/test_site_i18n.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from site_i18n import canonical_nav_labels
+
+
+def test_canonical_nav_labels_preserves_colons_in_quoted_strings():
+    """Prove that double-quoted and single-quoted nav labels containing colons
+
+    (e.g., "第1章: Agent基础知识", 'Chapter 2: Context Engineering') are preserved in full,
+    locking out catalog validation failures where nav labels are truncated at colons.
+    """
+    config = """
+nav:
+  - 首页: index.md
+  - "第1章: Agent基础知识":
+      - book/chapter1/index.md
+      - 配套实验: chapter1/README.md
+  - 'Chapter 2: Context Engineering':
+      - book/chapter2/index.md
+"""
+    labels = canonical_nav_labels(config)
+
+    assert "第1章: Agent基础知识" in labels
+    assert "Chapter 2: Context Engineering" in labels
+    assert "首页" in labels
+    assert "配套实验" in labels
+
+
+def test_canonical_nav_labels_unquoted():
+    """Prove that unquoted nav labels without colons are correctly parsed and appended,
+
+    locking out missing nav entry errors.
+    """
+    config = """
+nav:
+  - Overview: index.md
+  - Experiments:
+      - chapter1/README.md
+"""
+    labels = canonical_nav_labels(config)
+
+    assert labels == ["Overview", "Experiments"]


### PR DESCRIPTION
### Summary

Fixes label truncation in `scripts.site_i18n.canonical_nav_labels` when parsing double or single-quoted MkDocs navigation titles containing colons.

### Root Cause
The nav label extraction regex split on colons without accounting for quoted strings (e.g. `- "第1章: Agent基础知识":`), truncating titles at the internal colon (`"第1章`) and failing catalog validation.

### Fix
Updates string parsing logic to handle quoted titles correctly and preserve internal colons.

### Verification
Added test cases in `tests/test_site_i18n.py` covering quoted navigation labels with colons.