### PR TITLE
fix(werewolf): report UNDECIDED when all players die simultaneously

### DIFF
--- a/chapter10/voice-werewolf/test_simultaneous_deaths_consensus.py
+++ b/chapter10/voice-werewolf/test_simultaneous_deaths_consensus.py
@@ -1,0 +1,20 @@
+import pytest
+from werewolf.game import Judge
+from werewolf.agent import PlayerAgent
+from werewolf.roles import Role, Faction
+
+def test_simultaneous_deaths_returns_undecided_faction():
+    """Contract proved: Judge._check_winner returns Faction.UNDECIDED when all wolves and good players die simultaneously.
+    Bug locked out: returning Faction.GOOD when zero good players survive alongside zero wolves."""
+    # Setup players: 1 Werewolf and 1 Witch (Good)
+    p_wolf = PlayerAgent("P1", Role.WEREWOLF, offline=True)
+    p_witch = PlayerAgent("P2", Role.WITCH, offline=True)
+    judge = Judge([p_wolf, p_witch])
+    
+    # Both players die in night phase
+    p_wolf.alive = False
+    p_witch.alive = False
+    
+    # Check winner must report UNDECIDED, not GOOD when zero good players survive
+    winner = judge._check_winner()
+    assert winner == Faction.UNDECIDED

--- a/chapter10/voice-werewolf/werewolf/game.py
+++ b/chapter10/voice-werewolf/werewolf/game.py
@@ -421,6 +421,8 @@ class Judge:
         否则返回 None（继续游戏）。"""
         w = len(self.wolves(alive_only=True))
         g = len([p for p in self.alive() if p.role != Role.WEREWOLF])
+        if w == 0 and g == 0:
+            return Faction.UNDECIDED
         if w == 0:
             return Faction.GOOD
         if w >= g:  # 狼人数不少于好人数 → 狼人胜（屠边简化规则）


### PR DESCRIPTION
### Summary

Fixes game resolution logic in `chapter10.voice-werewolf.werewolf.game:Judge._check_winner` when night actions eliminate all wolves and good players simultaneously.

### Root Cause
When all players die in the same night (`w == 0` and `g == 0`), `_check_winner` evaluated `w == 0` first and incorrectly declared `Faction.GOOD` as winner.

### Fix
Checks if both `w == 0` and `g == 0` and returns `Faction.UNDECIDED`.

### Verification
Added unit test in `chapter10/voice-werewolf/tests/test_simultaneous_deaths_consensus.py` asserting `Faction.UNDECIDED` on simultaneous elimination.