### PR TITLE
fix(perception-tools): honor num_results=0 in search_web

### DIFF
--- a/chapter4/perception-tools/src/search_tools.py
+++ b/chapter4/perception-tools/src/search_tools.py
@@ -61,6 +61,29 @@ async def search_web(
     try:
         if not query or not query.strip():
             raise ValueError("Search query cannot be empty")
+
+        if num_results <= 0:
+            metadata = SearchMetadata(
+                query=query,
+                search_engine="none",
+                total_results=0,
+                search_time=0.0,
+                language="en",
+                country=region,
+            )
+            action_response = ActionResponse(
+                success=True,
+                message={
+                    "query": query,
+                    "results": [],
+                    "count": 0,
+                },
+                metadata=metadata.model_dump(),
+            )
+            return TextContent(
+                type="text",
+                text=json.dumps(action_response.model_dump()),
+            )
         
         validated_num_results = max(1, min(num_results, 10))
         

--- a/chapter4/perception-tools/src/test_search_web_num_results_zero.py
+++ b/chapter4/perception-tools/src/test_search_web_num_results_zero.py
@@ -53,3 +53,14 @@ async def test_search_web_num_results_zero_returns_no_results():
     assert message["results"] == []
     assert message["count"] == 0
     assert payload["metadata"]["total_results"] == 0
+
+
+@pytest.mark.asyncio
+async def test_search_web_num_results_negative_returns_no_results():
+    result = await search_web("Python", num_results=-5)
+    payload = json.loads(result.text if hasattr(result, "text") else result)
+    assert payload["success"] is True
+    message = payload["message"]
+    assert message["results"] == []
+    assert message["count"] == 0
+    assert payload["metadata"]["total_results"] == 0

--- a/chapter4/perception-tools/src/test_search_web_num_results_zero.py
+++ b/chapter4/perception-tools/src/test_search_web_num_results_zero.py
@@ -1,0 +1,55 @@
+"""Regression test for search_web num_results=0 handling.
+
+Proves contract: Requesting zero search results short-circuits external search
+providers and returns success with empty result list and count 0.
+Locks out bug where max(1, min(num_results, 10)) clamped num_results=0 to 1.
+"""
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+def _stub():
+    for name in ["dotenv", "mcp", "mcp.types", "mcp.server", "mcp.server.fastmcp"]:
+        sys.modules.setdefault(name, types.ModuleType(name))
+    sys.modules["dotenv"].load_dotenv = lambda *a, **k: None
+
+    class TextContent:
+        def __init__(self, type=None, text=None):
+            self.type = type
+            self.text = text
+
+    sys.modules["mcp.types"].TextContent = TextContent
+
+    class FastMCP:
+        def __init__(self, *a, **k):
+            pass
+
+        def tool(self, *a, **k):
+            def deco(fn):
+                return fn
+
+            return deco
+
+    sys.modules["mcp.server.fastmcp"].FastMCP = FastMCP
+
+
+_stub()
+
+from search_tools import search_web  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_search_web_num_results_zero_returns_no_results():
+    result = await search_web("Python", num_results=0)
+    payload = json.loads(result.text if hasattr(result, "text") else result)
+    assert payload["success"] is True
+    message = payload["message"]
+    assert message["results"] == []
+    assert message["count"] == 0
+    assert payload["metadata"]["total_results"] == 0


### PR DESCRIPTION
### Summary

Honors `num_results=0` or negative parameters in `chapter4.perception_tools.src.search_tools:search_web` by returning an empty `ActionResponse` immediately.

### Root Cause
Parameter clamping `max(1, min(num_results, 10))` forced `num_results=0` requests to execute external DuckDuckGo searches and return 1 result.

### Fix
Adds early check for `num_results <= 0` returning `ActionResponse(results=[], count=0)`.

### Verification
Added test in `chapter4/perception-tools/src/test_search_web_num_results_zero.py` verifying 0 results returned with no network calls.