### PR TITLE
fix(context): support numeric string and formatted amounts in convert_currency

### DIFF
--- a/chapter1/context/agent.py
+++ b/chapter1/context/agent.py
@@ -143,7 +143,8 @@ class ToolRegistry:
         try:
             if isinstance(amount, str):
                 clean_amt = amount.replace(",", "").strip()
-                for sym in ["$", "US$", "U.S.$", "S$", "A$", "C$", "€", "£", "₹"]:
+                symbols_to_strip = sorted(["$", "US$", "U.S.$", "S$", "A$", "C$", "€", "£", "₹"], key=len, reverse=True)
+                for sym in symbols_to_strip:
                     clean_amt = clean_amt.replace(sym, "")
                 amount = float(clean_amt.strip())
             else:

--- a/chapter1/context/agent.py
+++ b/chapter1/context/agent.py
@@ -5,10 +5,8 @@ Designed to demonstrate the importance of context through ablation studies.
 """
 
 import json
-import os
-import re
 import logging
-from typing import List, Dict, Any, Optional, Tuple
+from typing import List, Dict, Any, Optional
 from dataclasses import dataclass, field
 from enum import Enum
 import requests
@@ -143,6 +141,13 @@ class ToolRegistry:
             Dictionary with conversion result
         """
         try:
+            if isinstance(amount, str):
+                clean_amt = amount.replace(",", "").strip()
+                for sym in ["$", "US$", "U.S.$", "S$", "A$", "C$", "€", "£", "₹"]:
+                    clean_amt = clean_amt.replace(sym, "")
+                amount = float(clean_amt.strip())
+            else:
+                amount = float(amount)
             exchange_rates = {
                 "USD": 1.0,
                 "EUR": 0.92,
@@ -858,8 +863,8 @@ Important: When you have gathered all necessary information and computed the fin
                 # Note: We do NOT modify the system prompt anymore.
                 # The context is already built into the conversation through tool history
                     
-            except TimeoutError as e:
-                logger.error(f"Request timed out after 60 seconds")
+            except TimeoutError:
+                logger.error("Request timed out after 60 seconds")
                 return {
                     "error": "Request timed out. The model is taking too long to respond. Try a simpler task or different provider.",
                     "trajectory": self.trajectory,

--- a/chapter1/context/agent.py
+++ b/chapter1/context/agent.py
@@ -143,7 +143,17 @@ class ToolRegistry:
         try:
             if isinstance(amount, str):
                 clean_amt = amount.replace(",", "").strip()
-                symbols_to_strip = sorted(["$", "US$", "U.S.$", "S$", "A$", "C$", "€", "£", "₹"], key=len, reverse=True)
+                symbols_to_strip = sorted(
+                    [
+                        "USD$", "U.S.$", "US$", "$",
+                        "SGD$", "SG$", "S$",
+                        "AUD$", "AU$", "A$",
+                        "CAD$", "CA$", "C$",
+                        "€", "£", "₹",
+                    ],
+                    key=len,
+                    reverse=True,
+                )
                 for sym in symbols_to_strip:
                     clean_amt = clean_amt.replace(sym, "")
                 amount = float(clean_amt.strip())

--- a/chapter1/context/tests/test_agent.py
+++ b/chapter1/context/tests/test_agent.py
@@ -77,6 +77,19 @@ class TestToolRegistry(unittest.TestCase):
         result_formatted = tools.convert_currency("$1,000.00", "USD", "EUR")
         self.assertEqual(result_formatted["converted_amount"], 920.0)
         self.assertEqual(result_formatted["original_amount"], 1000.0)
+
+        result_us_dollar = tools.convert_currency("US$100", "USD", "EUR")
+        self.assertEqual(result_us_dollar["converted_amount"], 92.0)
+        self.assertEqual(result_us_dollar["original_amount"], 100.0)
+
+        result_comma_large = tools.convert_currency("1,234,567.89", "USD", "EUR")
+        self.assertEqual(result_comma_large["original_amount"], 1234567.89)
+
+        result_euro_sym = tools.convert_currency("€ 500.25", "EUR", "USD")
+        self.assertIn("converted_amount", result_euro_sym)
+
+        result_invalid_str = tools.convert_currency("invalid_str", "USD", "EUR")
+        self.assertIn("error", result_invalid_str)
     
     def test_pdf_parser_structure(self):
         """Test PDF parser structure (without actual PDF)"""

--- a/chapter1/context/tests/test_agent.py
+++ b/chapter1/context/tests/test_agent.py
@@ -82,6 +82,10 @@ class TestToolRegistry(unittest.TestCase):
         self.assertEqual(result_us_dollar["converted_amount"], 92.0)
         self.assertEqual(result_us_dollar["original_amount"], 100.0)
 
+        result_currency_code = tools.convert_currency("USD$1,000", "USD$", "EUR")
+        self.assertEqual(result_currency_code["converted_amount"], 920.0)
+        self.assertEqual(result_currency_code["original_amount"], 1000.0)
+
         result_comma_large = tools.convert_currency("1,234,567.89", "USD", "EUR")
         self.assertEqual(result_comma_large["original_amount"], 1234567.89)
 

--- a/chapter1/context/tests/test_agent.py
+++ b/chapter1/context/tests/test_agent.py
@@ -5,7 +5,6 @@ Validates installation and basic functionality
 """
 
 import sys
-import json
 from agent import ContextAwareAgent, ContextMode, ToolRegistry
 import unittest
 from unittest.mock import MagicMock, patch
@@ -56,12 +55,28 @@ class TestToolRegistry(unittest.TestCase):
         result_c = tools.convert_currency(100, "C$", "USD")
         self.assertEqual(result_c["from_currency"], "CAD")
         self.assertIn("converted_amount", result_c)
-
         # Invalid currency
         result = tools.convert_currency(100, "XXX", "YYY")
         self.assertIn("error", result)
         result_invalid_s = tools.convert_currency(100, "S$INVALID", "USD")
         self.assertIn("error", result_invalid_s)
+
+    def test_convert_currency_string_and_formatted_amounts(self):
+        """
+        Prove that convert_currency accepts string and formatted numeric amounts.
+        
+        LLM tool calls frequently pass numeric arguments as strings (e.g., "100", "$1,000.00").
+        Previously, passing a string raised a TypeError during float division. This test locks
+        out regressions by asserting that numeric strings and formatted currency strings convert correctly.
+        """
+        tools = ToolRegistry()
+        result_str = tools.convert_currency("100", "USD", "EUR")
+        self.assertEqual(result_str["converted_amount"], 92.0)
+        self.assertEqual(result_str["original_amount"], 100.0)
+
+        result_formatted = tools.convert_currency("$1,000.00", "USD", "EUR")
+        self.assertEqual(result_formatted["converted_amount"], 920.0)
+        self.assertEqual(result_formatted["original_amount"], 1000.0)
     
     def test_pdf_parser_structure(self):
         """Test PDF parser structure (without actual PDF)"""
@@ -190,7 +205,7 @@ def run_integration_test():
             result = agent.execute_task(simple_task, max_iterations=3)
             signal.alarm(0)  # Cancel alarm
             
-            print(f"\n✅ Integration test completed!")
+            print("\n✅ Integration test completed!")
             print(f"Success: {result.get('success', False)}")
             print(f"Tool calls: {len(result['trajectory'].tool_calls)}")
             


### PR DESCRIPTION
### Summary

Supports numeric strings and formatted currency values in `chapter1.context.agent:ToolRegistry.convert_currency`.

### Root Cause
When LLMs passed string amounts (e.g. `"100"` or `"$1,000.00"`), `convert_currency` failed with `TypeError: unsupported operand type(s) for /: 'str' and 'float'`.

### Fix
Strips currency symbols (`$`, `€`, `US$`, etc.) and commas, coercing numeric strings to float.

### Verification
Added test cases in `chapter1/context/tests/test_agent.py` for formatted string inputs.