### PR TITLE
fix(epub-links): handle bare chapter targets and blob file URLs in Lua filter

### DIFF
--- a/epub_external_links.lua
+++ b/epub_external_links.lua
@@ -4,12 +4,14 @@
 -- at the corresponding directory on GitHub before Pandoc packages the book.
 
 function Link(link)
-  local project_path = link.target:match("^%.%./(chapter%d+.*)$")
-  if project_path then
-    local clean_path = project_path:gsub("/+$", "")
+  local chapter, remainder = link.target:match("^%.%./(chapter%d+)(.*)$")
+  if chapter and (remainder == "" or remainder:match("^[/#?]")) then
+    local project_path = chapter .. remainder
+    local path, suffix = project_path:match("^([^?#]*)(.*)$")
+    local clean_path = path:gsub("/+$", "")
     local is_file = clean_path:match("%.%w+$") ~= nil
     local type_path = is_file and "blob" or "tree"
-    link.target = "https://github.com/bojieli/ai-agent-book/" .. type_path .. "/main/" .. clean_path
+    link.target = "https://github.com/bojieli/ai-agent-book/" .. type_path .. "/main/" .. clean_path .. suffix
     return link
   end
 end

--- a/epub_external_links.lua
+++ b/epub_external_links.lua
@@ -4,9 +4,12 @@
 -- at the corresponding directory on GitHub before Pandoc packages the book.
 
 function Link(link)
-  local project_path = link.target:match("^%.%./(chapter%d+/.*)$")
+  local project_path = link.target:match("^%.%./(chapter%d+.*)$")
   if project_path then
-    link.target = "https://github.com/bojieli/ai-agent-book/tree/main/" .. project_path
+    local clean_path = project_path:gsub("/+$", "")
+    local is_file = clean_path:match("%.%w+$") ~= nil
+    local type_path = is_file and "blob" or "tree"
+    link.target = "https://github.com/bojieli/ai-agent-book/" .. type_path .. "/main/" .. clean_path
     return link
   end
 end

--- a/tests/test_epub_external_links.py
+++ b/tests/test_epub_external_links.py
@@ -4,6 +4,10 @@ import subprocess
 import tempfile
 
 
+import pytest
+
+HAS_LUA = shutil.which("texlua") is not None or shutil.which("lua") is not None
+pytestmark = pytest.mark.skipif(not HAS_LUA, reason="texlua or lua executable not found in PATH")
 ROOT = Path(__file__).parents[1]
 
 

--- a/tests/test_epub_external_links.py
+++ b/tests/test_epub_external_links.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def run_lua_link(target: str) -> str:
+    lua_script_path = (ROOT / "epub_external_links.lua").as_posix()
+    lua_code = f"""
+dofile("{lua_script_path}")
+local link = {{ target = "{target}" }}
+Link(link)
+print(link.target)
+"""
+    with tempfile.NamedTemporaryFile("w", suffix=".lua", delete=False) as f:
+        f.write(lua_code)
+        f_path = f.name
+    try:
+        lua_bin = shutil.which("texlua") or shutil.which("lua") or "texlua"
+        res = subprocess.run(
+            [lua_bin, f_path], capture_output=True, text=True, check=True
+        )
+        return res.stdout.strip()
+    finally:
+        Path(f_path).unlink(missing_ok=True)
+
+
+def test_epub_external_links_transforms_chapter_dirs_without_trailing_slash():
+    """Contract: Lua Link filter must match chapter targets without a trailing slash (e.g. '../chapter8')
+    and convert them to tree URLs on GitHub main branch.
+    """
+    url = run_lua_link("../chapter8")
+    assert url == "https://github.com/bojieli/ai-agent-book/tree/main/chapter8"
+
+
+def test_epub_external_links_uses_blob_for_file_links():
+    """Contract: Lua Link filter must detect file targets with file extensions and use GitHub 'blob' path
+    instead of 'tree' path.
+    """
+    url = run_lua_link("../chapter7/AdaptThink/TRAINING_REPORT.md")
+    assert url == "https://github.com/bojieli/ai-agent-book/blob/main/chapter7/AdaptThink/TRAINING_REPORT.md"

--- a/tests/test_epub_external_links.py
+++ b/tests/test_epub_external_links.py
@@ -42,3 +42,22 @@ def test_epub_external_links_uses_blob_for_file_links():
     """
     url = run_lua_link("../chapter7/AdaptThink/TRAINING_REPORT.md")
     assert url == "https://github.com/bojieli/ai-agent-book/blob/main/chapter7/AdaptThink/TRAINING_REPORT.md"
+
+
+def test_epub_external_links_markdown_and_subdir_targets():
+    """Contract: Lua Link filter handles markdown file targets, chapter dirs with trailing slash, and non-chapter targets correctly."""
+    # Markdown file target uses /blob/
+    url_md = run_lua_link("../chapter7/README.md")
+    assert url_md == "https://github.com/bojieli/ai-agent-book/blob/main/chapter7/README.md"
+
+    # Directory target with trailing slash uses /tree/ and strips trailing slash
+    url_dir_slash = run_lua_link("../chapter8/")
+    assert url_dir_slash == "https://github.com/bojieli/ai-agent-book/tree/main/chapter8"
+
+    # Chapter sub-directory target uses /tree/
+    url_subdir = run_lua_link("../chapter7/speech-sft-experiment")
+    assert url_subdir == "https://github.com/bojieli/ai-agent-book/tree/main/chapter7/speech-sft-experiment"
+
+    # Non-matching link target remains unchanged
+    url_external = run_lua_link("https://example.com")
+    assert url_external == "https://example.com"

--- a/tests/test_epub_external_links.py
+++ b/tests/test_epub_external_links.py
@@ -65,3 +65,14 @@ def test_epub_external_links_markdown_and_subdir_targets():
     # Non-matching link target remains unchanged
     url_external = run_lua_link("https://example.com")
     assert url_external == "https://example.com"
+
+
+def test_epub_external_links_preserves_fragments_and_requires_chapter_boundary():
+    url = run_lua_link("../chapter7/AdaptThink/TRAINING_REPORT.md#results")
+    assert url == (
+        "https://github.com/bojieli/ai-agent-book/blob/main/"
+        "chapter7/AdaptThink/TRAINING_REPORT.md#results"
+    )
+
+    invalid = run_lua_link("../chapter7-not-a-directory")
+    assert invalid == "../chapter7-not-a-directory"


### PR DESCRIPTION
### Summary

Fixes Lua Pandoc filter `epub_external_links.lua:Link` to handle bare chapter targets and generate correct GitHub `/blob/` file URLs.

### Root Cause
Bare chapter link targets (e.g. `../chapter8`) failed the target regex match due to missing trailing slashes, leaving broken relative paths in EPUB outputs. File links (`.md`) were also rewritten to GitHub `/tree/` URLs instead of `/blob/` URLs.

### Fix
Handles bare chapter targets and rewrites file targets to `/blob/` URLs.

### Verification
Added tests in `tests/test_epub_external_links.py` verifying bare chapter targets and file blob URL transformations.