### PR TITLE
fix(site): filter ignored_commits when determining creation date

### DIFF
--- a/scripts/site_source_paths.py
+++ b/scripts/site_source_paths.py
@@ -74,7 +74,12 @@ def git_commit_range(
         return latest, latest
 
     creation_lines = _git_log(common + ["--diff-filter=A", "--", relative])
-    created = _parse_commit(creation_lines[-1]) if creation_lines else _fallback_commit()
+    valid_creation_commits = [
+        commit
+        for commit in map(_parse_commit, creation_lines)
+        if not any(commit[0].startswith(prefix) for prefix in ignored_commits)
+    ]
+    created = valid_creation_commits[-1] if valid_creation_commits else latest
     return latest, created
 
 

--- a/tests/test_git_revision_dates.py
+++ b/tests/test_git_revision_dates.py
@@ -84,7 +84,51 @@ def test_git_commit_range_returns_distinct_creation_and_update_dates(tmp_path: P
     assert created[1] == 1704067200
     assert latest[0] != created[0]
 
+def test_git_commit_range_ignores_commits_for_creation_date(tmp_path: Path):
+    """Verify git_commit_range filters ignored_commits when determining creation date.
 
+    Contract: If the initial creation commit of a file matches an ignored commit hash,
+    git_commit_range must ignore it and return the earliest non-ignored commit date.
+    Locks out returning an ignored commit as the file creation date.
+    """
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.name", "Test"],
+        check=True,
+    )
+
+    page = tmp_path / "page.md"
+    page.write_text("created\n", encoding="utf-8")
+    _commit(tmp_path, "create", "1704067200 +0000")
+
+    creation_hash = subprocess.run(
+        ["git", "-C", str(tmp_path), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    page.write_text("updated\n", encoding="utf-8")
+    _commit(tmp_path, "update", "1706745600 +0000")
+
+    latest_hash = subprocess.run(
+        ["git", "-C", str(tmp_path), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    latest, created = git_commit_range(
+        page, tmp_path, ignored_commits=(creation_hash,)
+    )
+
+    assert created[0] == latest_hash
+    assert created[0] != creation_hash
+    assert created[1] == 1706745600
 def _commit(repository: Path, message: str, date: str) -> None:
     subprocess.run(["git", "-C", str(repository), "add", "page.md"], check=True)
     subprocess.run(

--- a/tests/test_git_revision_dates.py
+++ b/tests/test_git_revision_dates.py
@@ -129,6 +129,36 @@ def test_git_commit_range_ignores_commits_for_creation_date(tmp_path: Path):
     assert created[0] == latest_hash
     assert created[0] != creation_hash
     assert created[1] == 1706745600
+
+def test_git_commit_range_handles_all_ignored_commits(tmp_path: Path):
+    """Contract: If all commits for a file are ignored, git_commit_range must return fallback commit."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.name", "Test"],
+        check=True,
+    )
+
+    page = tmp_path / "page.md"
+    page.write_text("created\n", encoding="utf-8")
+    _commit(tmp_path, "create", "1704067200 +0000")
+
+    commit_hash = subprocess.run(
+        ["git", "-C", str(tmp_path), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    latest, created = git_commit_range(
+        page, tmp_path, ignored_commits=(commit_hash,)
+    )
+
+    assert latest[0] == ""
+    assert created[0] == ""
 def _commit(repository: Path, message: str, date: str) -> None:
     subprocess.run(["git", "-C", str(repository), "add", "page.md"], check=True)
     subprocess.run(


### PR DESCRIPTION
### Summary

Filters `ignored_commits` when determining page creation dates in `scripts.site_source_paths:git_commit_range`.

### Root Cause
Used by the `git_revision_dates.py` MkDocs plugin, `git_commit_range` took `ignored_commits` but indexed `creation_lines[-1]` directly without filtering, returning ignored reformat commits as page creation dates.

### Fix
Filters `creation_lines` against `ignored_commits` before selecting the earliest commit.

### Verification
Added unit tests in `tests/test_git_revision_dates.py` asserting ignored commit filtering.