### PR TITLE
fix(system-hint): return empty content on line-based read of empty files

### DIFF
--- a/chapter2/system-hint/agent.py
+++ b/chapter2/system-hint/agent.py
@@ -597,18 +597,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                     total_lines = len(all_lines)
                     
                     # Calculate line range
-                    if begin_line is not None:
-                        try:
-                            begin_line = int(begin_line)
-                        except (ValueError, TypeError):
-                            pass
-                    if number_lines is not None:
-                        try:
-                            number_lines = int(number_lines)
-                        except (ValueError, TypeError):
-                            pass
-
-                    start_line = (begin_line - 1) if isinstance(begin_line, int) else 0
+                    start_line = (begin_line - 1) if begin_line is not None else 0
                     if start_line < 0:
                         start_line = 0
                     if total_lines == 0 and start_line == 0:

--- a/chapter2/system-hint/agent.py
+++ b/chapter2/system-hint/agent.py
@@ -15,12 +15,8 @@ from typing import List, Dict, Any, Optional, Tuple
 from dataclasses import dataclass, field
 from enum import Enum
 from datetime import datetime, timedelta
-import requests
 from openai import OpenAI
 import traceback
-import tempfile
-import shutil
-from pathlib import Path
 
 try:
     from dotenv import load_dotenv
@@ -589,7 +585,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                             "file_path": file_path,
                             "is_binary": True
                         }
-            except Exception as e:
+            except Exception:
                 # If we can't read it as binary, probably permission issue
                 raise
             
@@ -601,9 +597,32 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                     total_lines = len(all_lines)
                     
                     # Calculate line range
-                    start_line = (begin_line - 1) if begin_line is not None else 0
+                    if begin_line is not None:
+                        try:
+                            begin_line = int(begin_line)
+                        except (ValueError, TypeError):
+                            pass
+                    if number_lines is not None:
+                        try:
+                            number_lines = int(number_lines)
+                        except (ValueError, TypeError):
+                            pass
+
+                    start_line = (begin_line - 1) if isinstance(begin_line, int) else 0
                     if start_line < 0:
                         start_line = 0
+                    if total_lines == 0 and start_line == 0:
+                        return {
+                            "success": True,
+                            "file_path": file_path,
+                            "content": "",
+                            "size_bytes": 0,
+                            "total_lines": 0,
+                            "begin_line": 1,
+                            "end_line": 0,
+                            "lines_read": 0,
+                            "partial_read": True
+                        }
                     if start_line >= total_lines:
                         return {
                             "success": False,
@@ -650,7 +669,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                         "lines": len(content.splitlines()),
                         "partial_read": False
                     }
-        except Exception as e:
+        except Exception:
             raise
     
     def _tool_write_file(self, file_path: str, content: str) -> Dict[str, Any]:
@@ -672,7 +691,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                 "bytes_written": len(content.encode('utf-8')),
                 "lines_written": len(content.splitlines())
             }
-        except Exception as e:
+        except Exception:
             raise
     
     def _tool_code_interpreter(self, code: str) -> Dict[str, Any]:
@@ -702,7 +721,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                 "stdout": stdout,
                 "stderr": stderr,
             }
-        except Exception as e:
+        except Exception:
             raise
     
     def _tool_execute_command(self, command: str, working_dir: Optional[str] = None) -> Dict[str, Any]:
@@ -756,7 +775,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
             }
         except subprocess.TimeoutExpired:
             raise TimeoutError(f"Command timed out after 30 seconds: {command}")
-        except Exception as e:
+        except Exception:
             raise
     
     def _tool_rewrite_todo_list(self, items: List[str]) -> Dict[str, Any]:
@@ -949,7 +968,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                                     elif 'file_path' in result:
                                         logger.info(f"  ✅ Success: File operation on {result['file_path']}")
                                     else:
-                                        logger.info(f"  ✅ Success: Operation completed")
+                                        logger.info("  ✅ Success: Operation completed")
                                 elif result.get('success') is False:
                                     # Handle explicit failures (like binary file detection)
                                     if result.get('is_binary'):
@@ -957,7 +976,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                                     else:
                                         logger.info(f"  ⚠️ Failed: {result.get('error', 'Unknown error')[:100]}")
                                 else:
-                                    logger.info(f"  ✅ Success: Operation completed")
+                                    logger.info("  ✅ Success: Operation completed")
                             else:
                                 result_preview = str(result).replace('\n', ' ')[:150]
                                 logger.info(f"  ✅ Result: {result_preview}")

--- a/chapter2/system-hint/test_basic.py
+++ b/chapter2/system-hint/test_basic.py
@@ -4,6 +4,9 @@ Basic test to verify System-Hint Agent functionality
 
 import os
 import sys
+
+import pytest
+
 from agent import SystemHintAgent, SystemHintConfig, TodoStatus
 
 def test_basic_functionality():
@@ -165,6 +168,17 @@ def test_read_file_empty_file_line_range():
     finally:
         if os.path.exists(empty_file):
             os.remove(empty_file)
+
+
+def test_read_file_rejects_invalid_line_arguments(tmp_path):
+    """Invalid schema inputs must not silently become a read from line one."""
+    config = SystemHintConfig(enable_detailed_errors=True)
+    agent = SystemHintAgent(api_key="test-key", provider="kimi", config=config, verbose=False)
+    agent.current_directory = str(tmp_path)
+    agent._tool_write_file("sample.txt", "one\ntwo\n")
+
+    with pytest.raises(TypeError):
+        agent._tool_read_file("sample.txt", begin_line="invalid")
 
 if __name__ == "__main__":
     print("="*60)

--- a/chapter2/system-hint/test_basic.py
+++ b/chapter2/system-hint/test_basic.py
@@ -41,14 +41,15 @@ def test_basic_functionality():
     try:
         # Test write_file
         result = agent._tool_write_file(test_file, "Test content")
-        assert result["success"] == True
+        assert result["success"]
         print("✅ write_file tool works")
         
         # Test read_file
         result = agent._tool_read_file(test_file)
-        assert result["success"] == True
+        assert result["success"]
         assert "Test content" in result["content"]
         print("✅ read_file tool works")
+        
         
         # Clean up
         os.remove(test_file)
@@ -59,7 +60,7 @@ def test_basic_functionality():
     # Test code interpreter
     try:
         result = agent._tool_code_interpreter("result = 2 + 2")
-        assert result["success"] == True
+        assert result["success"]
         assert result["result"] == 4
         print("✅ code_interpreter tool works")
     except Exception as e:
@@ -69,7 +70,7 @@ def test_basic_functionality():
     try:
         # Test rewrite_todo_list
         result = agent._tool_rewrite_todo_list(["Task 1", "Task 2", "Task 3"])
-        assert result["success"] == True
+        assert result["success"]
         assert result["new_items"] == 3
         print("✅ rewrite_todo_list tool works")
         
@@ -78,7 +79,7 @@ def test_basic_functionality():
             {"id": 1, "status": "completed"},
             {"id": 2, "status": "in_progress"}
         ])
-        assert result["success"] == True
+        assert result["success"]
         assert result["updated_items"] == 2
         print("✅ update_todo_status tool works")
         
@@ -129,7 +130,7 @@ def test_command_execution():
     try:
         # Test simple command
         result = agent._tool_execute_command("echo 'Hello, World!'")
-        assert result["success"] == True
+        assert result["success"]
         assert "Hello, World!" in result["output"]
         print("✅ Command execution works")
         
@@ -144,6 +145,26 @@ def test_command_execution():
         print(f"⚠️ Command execution test skipped: {e}")
     
     return True
+def test_read_file_empty_file_line_range():
+    """
+    Prove that line-based read_file on empty (0-line) files succeeds with empty content.
+    
+    When an LLM agent requested line-based reads (e.g., begin_line=1, number_lines=10) on an
+    empty file, start_line (0) was compared against total_lines (0) with >=, causing the tool to
+    return an error stating begin_line 1 is beyond file length. This test locks out regressions
+    by asserting that line-based reads on empty files return success=True and content="".
+    """
+    config = SystemHintConfig(enable_detailed_errors=True)
+    agent = SystemHintAgent(api_key="test-key", provider="kimi", config=config, verbose=False)
+    empty_file = "empty_test.txt"
+    try:
+        agent._tool_write_file(empty_file, "")
+        res_empty = agent._tool_read_file(empty_file, begin_line=1, number_lines=10)
+        assert res_empty.get("success") is True, f"Failed empty file read: {res_empty}"
+        assert res_empty.get("content") == ""
+    finally:
+        if os.path.exists(empty_file):
+            os.remove(empty_file)
 
 if __name__ == "__main__":
     print("="*60)
@@ -153,6 +174,7 @@ if __name__ == "__main__":
     # Run basic tests
     if test_basic_functionality():
         test_command_execution()
+        test_read_file_empty_file_line_range()
         print("\n✨ All tests completed successfully!")
     else:
         print("\n❌ Some tests failed")


### PR DESCRIPTION
### Summary

Allows line-based reading (`begin_line=1` or `number_lines=N`) on 0-line empty files in `chapter2.system-hint.agent:SystemHintAgent._tool_read_file`.

### Root Cause
Line-based reading on an empty (0-line) file triggered an out-of-bounds check (`start_line >= total_lines`, `0 >= 0`) and failed with `success: False` claiming line 1 is beyond file length.

### Fix
Permits `begin_line=1` reads on 0-line files, returning `success: True` and `content: ""`.

### Verification
Added test cases in `chapter2/system-hint/test_basic.py` covering empty file reads.