### PR TITLE
fix(autonomous-phone-registration): handle null value in FieldSpec.validate

### DIFF
--- a/chapter10/autonomous-phone-registration/models.py
+++ b/chapter10/autonomous-phone-registration/models.py
@@ -28,33 +28,33 @@ class FieldSpec:
         allowed = {f.name for f in cls.__dataclass_fields__.values()}
         return cls(**{k: v for k, v in value.items() if k in allowed})
 
-    def validate(self, value: str) -> tuple[bool, str]:
-        value = value.strip()
-        if self.required and not value:
+    def validate(self, value: Optional[str]) -> tuple[bool, str]:
+        val = (str(value) if value is not None else "").strip()
+        if self.required and not val:
             return False, "该项为必填项，不能留空"
-        if not value:
+        if not val:
             return True, ""
-        if self.options and value not in self.options:
+        if self.options and val not in self.options:
             lowered = {o.casefold(): o for o in self.options}
-            if value.casefold() not in lowered:
+            if val.casefold() not in lowered:
                 return False, f"请选择以下选项之一：{', '.join(self.options)}"
         if self.pattern:
             try:
-                if re.fullmatch(self.pattern, value) is None:
+                if re.fullmatch(self.pattern, val) is None:
                     return False, self.format_hint or f"格式应匹配 {self.pattern}"
             except re.error:
                 # A malformed pattern from a web page must not crash the call.
                 pass
         kind = self.input_type.lower()
-        if kind == "email" and re.fullmatch(r"[^@\s]+@[^@\s]+\.[^@\s]+", value) is None:
+        if kind == "email" and re.fullmatch(r"[^@\s]+@[^@\s]+\.[^@\s]+", val) is None:
             return False, self.format_hint or "请输入有效邮箱，例如 name@example.com"
-        if kind in {"tel", "phone"} and re.fullmatch(r"[+()\d][+()\d .-]{5,24}", value) is None:
+        if kind in {"tel", "phone"} and re.fullmatch(r"[+()\d][+()\d .-]{5,24}", val) is None:
             return False, self.format_hint or "请输入包含区号的有效电话号码"
-        if kind == "date" and re.fullmatch(r"\d{4}-\d{2}-\d{2}", value) is None:
+        if kind == "date" and re.fullmatch(r"\d{4}-\d{2}-\d{2}", val) is None:
             return False, self.format_hint or "日期格式应为 YYYY-MM-DD"
         if kind == "number":
             try:
-                float(value)
+                float(val)
             except ValueError:
                 return False, self.format_hint or "请输入数字"
         return True, ""

--- a/tests/test_ch10_field_spec_validate_none.py
+++ b/tests/test_ch10_field_spec_validate_none.py
@@ -1,0 +1,54 @@
+import pytest
+import sys
+from pathlib import Path
+
+ch10_dir = Path(__file__).resolve().parent.parent / "chapter10" / "autonomous-phone-registration"
+if str(ch10_dir) not in sys.path:
+    sys.path.insert(0, str(ch10_dir))
+
+from models import FieldSpec
+
+
+def test_validate_none_value_when_required():
+    field = FieldSpec(name="username", label="用户名", required=True)
+    valid, msg = field.validate(None)
+    assert valid is False
+    assert "必填" in msg
+
+
+def test_validate_none_value_when_optional():
+    field = FieldSpec(name="middle_name", label="中间名", required=False)
+    valid, msg = field.validate(None)
+    assert valid is True
+    assert msg == ""
+
+
+def test_validate_whitespace_when_required():
+    field = FieldSpec(name="email", label="邮箱", required=True)
+    valid, msg = field.validate("   ")
+    assert valid is False
+    assert "必填" in msg
+
+
+def test_validate_valid_email_and_none_optional():
+    email_field = FieldSpec(name="email", label="邮箱", input_type="email", required=False)
+    valid, msg = email_field.validate(None)
+    assert valid is True
+
+    valid_email, _ = email_field.validate("test@example.com")
+    assert valid_email is True
+
+    invalid_email, _ = email_field.validate("invalid-email")
+    assert invalid_email is False
+
+
+def test_validate_options_with_none():
+    option_field = FieldSpec(name="gender", label="性别", options=["Male", "Female"], required=False)
+    valid, msg = option_field.validate(None)
+    assert valid is True
+
+    valid_opt, _ = option_field.validate("Male")
+    assert valid_opt is True
+
+    invalid_opt, _ = option_field.validate("Other")
+    assert invalid_opt is False


### PR DESCRIPTION
Passing value=None to FieldSpec.validate raised an AttributeError on string operation calls. This fix handles None values by validating required status and normalizing optional fields.