### PR TITLE
fix(active-tool-selection): handle empty servers list in SemanticRouter

### DIFF
--- a/chapter4/active-tool-selection/semantic_router.py
+++ b/chapter4/active-tool-selection/semantic_router.py
@@ -33,8 +33,14 @@ class SemanticRouter:
     
     def _build_server_index(self):
         """Build TF-IDF index for servers."""
+        if not self.servers:
+            self.server_embeddings = None
+            return
         server_descriptions = [f"{s.name} {s.description}" for s in self.servers]
-        self.server_embeddings = self.server_vectorizer.fit_transform(server_descriptions)
+        try:
+            self.server_embeddings = self.server_vectorizer.fit_transform(server_descriptions)
+        except ValueError:
+            self.server_embeddings = None
     
     def _build_tool_indices(self):
         """Build TF-IDF indices for tools within each server."""
@@ -135,9 +141,10 @@ class SemanticRouter:
         Returns:
             List of (server, similarity_score) tuples
         """
+        if not self.servers or self.server_embeddings is None:
+            return []
         # Vectorize the request
         request_vector = self.server_vectorizer.transform([request])
-        
         # Calculate similarities with all servers
         similarities = cosine_similarity(request_vector, self.server_embeddings)[0]
         

--- a/tests/test_ch4_semantic_router_empty_servers.py
+++ b/tests/test_ch4_semantic_router_empty_servers.py
@@ -1,5 +1,5 @@
 import pytest
-pytest.importorskip(numpy)
+pytest.importorskip("numpy")
 """Regression test for SemanticRouter initialization with empty servers list."""
 import sys
 from pathlib import Path

--- a/tests/test_ch4_semantic_router_empty_servers.py
+++ b/tests/test_ch4_semantic_router_empty_servers.py
@@ -1,0 +1,37 @@
+import pytest
+pytest.importorskip(numpy)
+"""Regression test for SemanticRouter initialization with empty servers list."""
+import sys
+from pathlib import Path
+
+# Add active-tool-selection to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "chapter4" / "active-tool-selection"))
+
+from semantic_router import SemanticRouter
+
+
+def test_semantic_router_empty_servers():
+    router = SemanticRouter([])
+    assert router.servers == []
+    assert router.server_embeddings is None
+    assert router.route_request("find a tool") == []
+    assert router.retrieve("find a tool", top_k=5) == []
+    assert router._route_to_servers("find a tool", top_k=5) == []
+    
+    details = router.get_routing_details("find a tool")
+    assert details["final_tools"] == []
+    assert details["stage1_servers"] == []
+    assert details["stage2_tools"] == {}
+
+
+def test_semantic_router_servers_with_only_stop_words():
+    class MockServer:
+        name = "the"
+        description = "a an in on at"
+        tools = []
+
+    router = SemanticRouter([MockServer()])
+    assert router.server_embeddings is None
+    assert router.route_request("query") == []
+    assert router.retrieve("query", top_k=3) == []
+    assert router._route_to_servers("query", top_k=3) == []


### PR DESCRIPTION
Initialising SemanticRouter with servers=[] failed during embedding matrix construction due to empty array shapes. This update handles empty server lists gracefully by returning empty routing matches.