### PR TITLE
fix(coding-agent): handle integer zero cell_id in notebook_edit_tool

### DIFF
--- a/chapter5/coding-agent/tools/notebook_edit_tool.py
+++ b/chapter5/coding-agent/tools/notebook_edit_tool.py
@@ -58,10 +58,10 @@ class NotebookEditTool(BaseTool):
                     new_cell["execution_count"] = None
                 
                 # Find insertion point
-                if cell_id:
+                if cell_id is not None:
                     # Insert after cell with given ID
                     for i, cell in enumerate(cells):
-                        if cell.get('id') == cell_id:
+                        if str(cell.get('id')) == str(cell_id):
                             cells.insert(i + 1, new_cell)
                             break
                     else:
@@ -74,9 +74,9 @@ class NotebookEditTool(BaseTool):
                 
             elif edit_mode == "delete":
                 # Delete cell
-                if cell_id:
+                if cell_id is not None:
                     for i, cell in enumerate(cells):
-                        if cell.get('id') == cell_id:
+                        if str(cell.get('id')) == str(cell_id):
                             cells.pop(i)
                             break
                     else:
@@ -90,9 +90,9 @@ class NotebookEditTool(BaseTool):
                 if new_source is None:
                     return {"error": "new_source required for replace mode"}
                 # Replace cell contents
-                if cell_id:
+                if cell_id is not None:
                     for cell in cells:
-                        if cell.get('id') == cell_id:
+                        if str(cell.get('id')) == str(cell_id):
                             cell["source"] = new_source.splitlines(keepends=True)
                             if cell_type:
                                 cell["cell_type"] = cell_type

--- a/tests/test_ch5_notebook_edit_zero_cell_id.py
+++ b/tests/test_ch5_notebook_edit_zero_cell_id.py
@@ -1,0 +1,49 @@
+import pytest
+import json
+import sys
+from pathlib import Path
+
+ch5_tools_dir = Path(__file__).resolve().parent.parent / "chapter5" / "coding-agent"
+if str(ch5_tools_dir) not in sys.path:
+    sys.path.insert(0, str(ch5_tools_dir))
+
+from tools.notebook_edit_tool import NotebookEditTool  # noqa: E402
+from system_state import SystemState  # noqa: E402
+
+
+@pytest.fixture
+def temp_notebook(tmp_path):
+    nb_path = tmp_path / "test_zero_id.ipynb"
+    nb_data = {
+        "cells": [
+            {
+                "id": "0",
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "outputs": [],
+                "source": ["print('original')\n"],
+            }
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    nb_path.write_text(json.dumps(nb_data), encoding="utf-8")
+    return nb_path
+
+
+def test_notebook_edit_accepts_integer_zero_cell_id(temp_notebook):
+    state = SystemState()
+    tool = NotebookEditTool(state)
+    result = tool.execute({
+        "notebook_path": str(temp_notebook),
+        "cell_id": 0,
+        "new_source": "print('updated')",
+        "edit_mode": "replace",
+    })
+    assert result.success is True, f"Execution failed: {result.data}"
+    assert result.data.get("action") == "replaced"
+    
+    nb_content = json.loads(temp_notebook.read_text(encoding="utf-8"))
+    assert "".join(nb_content["cells"][0]["source"]) == "print('updated')"


### PR DESCRIPTION
NotebookEditTool._execute_impl evaluated if cell_id: as False when cell_id was integer 0, causing valid 0-index notebook cell edit requests to be rejected. This fix checks cell_id is not None instead.