### PR TITLE
fix(elo-leaderboard): default calibration_rating to INIT_RATING when calibration_model is specified

### DIFF
--- a/chapter6/elo-leaderboard/bradley_terry.py
+++ b/chapter6/elo-leaderboard/bradley_terry.py
@@ -120,7 +120,8 @@ def compute_mle_elo(df: pd.DataFrame,
     
     # Calibrate to reference model if provided
     if calibration_model and calibration_model in models.index:
-        elo_scores += calibration_rating - elo_scores[models[calibration_model]]
+        target_rating = INIT_RATING if calibration_rating is None else calibration_rating
+        elo_scores += target_rating - elo_scores[models[calibration_model]]
     
     return pd.Series(elo_scores, index=models.index).sort_values(ascending=False)
 

--- a/tests/test_ch6_bradley_terry_calibration.py
+++ b/tests/test_ch6_bradley_terry_calibration.py
@@ -1,5 +1,5 @@
 import pytest
-pytest.importorskip(pandas)
+pytest.importorskip("pandas")
 """
 Test suite for compute_mle_elo calibration model and calibration rating handling.
 """

--- a/tests/test_ch6_bradley_terry_calibration.py
+++ b/tests/test_ch6_bradley_terry_calibration.py
@@ -1,0 +1,76 @@
+import pytest
+pytest.importorskip(pandas)
+"""
+Test suite for compute_mle_elo calibration model and calibration rating handling.
+"""
+
+import sys
+from pathlib import Path
+import pandas as pd
+
+HERE = Path(__file__).resolve().parent.parent
+ELO_DIR = HERE / "chapter6" / "elo-leaderboard"
+if str(ELO_DIR) not in sys.path:
+    sys.path.insert(0, str(ELO_DIR))
+
+from bradley_terry import compute_mle_elo  # noqa: E402
+
+
+def test_compute_mle_elo_calibration_model_default_none_rating():
+    df = pd.DataFrame(
+        [
+            {"model_a": "gpt-4", "model_b": "claude-3", "winner": "model_a"},
+            {"model_a": "gpt-4", "model_b": "claude-3", "winner": "model_b"},
+        ]
+    )
+    res = compute_mle_elo(df, calibration_model="gpt-4")
+    assert "gpt-4" in res.index
+    assert res["gpt-4"] == 1000.0
+
+
+def test_compute_mle_elo_explicit_calibration_rating():
+    df = pd.DataFrame(
+        [
+            {"model_a": "gpt-4", "model_b": "claude-3", "winner": "model_a"},
+            {"model_a": "gpt-4", "model_b": "claude-3", "winner": "model_b"},
+        ]
+    )
+    res = compute_mle_elo(df, calibration_model="gpt-4", calibration_rating=1200.0)
+    assert "gpt-4" in res.index
+    assert abs(res["gpt-4"] - 1200.0) < 1e-6
+
+
+def test_compute_mle_elo_custom_init_rating_and_calibration():
+    df = pd.DataFrame(
+        [
+            {"model_a": "gpt-4", "model_b": "claude-3", "winner": "model_a"},
+            {"model_a": "gpt-4", "model_b": "claude-3", "winner": "model_b"},
+        ]
+    )
+    res = compute_mle_elo(df, INIT_RATING=1500, calibration_model="gpt-4")
+    assert "gpt-4" in res.index
+    assert res["gpt-4"] == 1500.0
+
+
+def test_compute_mle_elo_calibration_model_not_in_df():
+    df = pd.DataFrame(
+        [
+            {"model_a": "gpt-4", "model_b": "claude-3", "winner": "model_a"},
+            {"model_a": "gpt-4", "model_b": "claude-3", "winner": "model_b"},
+        ]
+    )
+    res = compute_mle_elo(df, calibration_model="non_existent_model")
+    assert "gpt-4" in res.index
+    assert "claude-3" in res.index
+
+
+def test_compute_mle_elo_no_calibration():
+    df = pd.DataFrame(
+        [
+            {"model_a": "gpt-4", "model_b": "claude-3", "winner": "model_a"},
+            {"model_a": "gpt-4", "model_b": "claude-3", "winner": "model_b"},
+        ]
+    )
+    res = compute_mle_elo(df, calibration_model=None)
+    assert "gpt-4" in res.index
+    assert "claude-3" in res.index


### PR DESCRIPTION
compute_mle_elo raised an UnboundLocalError when calibration_model was supplied without a calibration_rating parameter. This fix sets calibration_rating to INIT_RATING when omitted.