### PR TITLE
fix(chess): report draw game_status when game is over without checkmate

### DIFF
--- a/chapter4/collaboration-tools/src/chess_tools.py
+++ b/chapter4/collaboration-tools/src/chess_tools.py
@@ -2,13 +2,12 @@
 Chess game tools for game management and analysis.
 Based on AWorld MCP server implementation.
 """
-import json
 import logging
 import traceback
 from typing import Dict, Any
 
 import chess
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 logger = logging.getLogger(__name__)
@@ -132,7 +131,7 @@ async def load_fen(fen_string: str) -> Dict[str, Any]:
         
         return {
             "success": True,
-            "message": f"Loaded position from FEN",
+            "message": "Loaded position from FEN",
             "board_state": state.model_dump()
         }
         
@@ -159,7 +158,6 @@ async def make_move(move_str: str) -> Dict[str, Any]:
     try:
         global _game_board
         
-        fen_before = _game_board.fen()
         move = None
         
         # Try parsing as UCI first, then SAN
@@ -168,7 +166,7 @@ async def make_move(move_str: str) -> Dict[str, Any]:
         except ValueError:
             try:
                 move = _game_board.parse_san(move_str)
-            except ValueError as e:
+            except ValueError:
                 raise ValueError(f"Invalid move format: {move_str}")
         
         if move not in _game_board.legal_moves:
@@ -285,6 +283,7 @@ async def get_game_status() -> Dict[str, Any]:
     try:
         state = _get_current_board_state()
         
+        is_draw = state.is_stalemate or state.is_insufficient_material or (state.is_game_over and not state.is_checkmate)
         status_message = "Game in progress"
         winner = None
         
@@ -295,6 +294,8 @@ async def get_game_status() -> Dict[str, Any]:
             status_message = "Stalemate! The game is a draw"
         elif state.is_insufficient_material:
             status_message = "Draw by insufficient material"
+        elif state.is_game_over:
+            status_message = "Game over! The game is a draw"
         elif state.is_check:
             status_message = f"{state.turn.capitalize()} is in check"
         
@@ -304,7 +305,7 @@ async def get_game_status() -> Dict[str, Any]:
             "is_check": state.is_check,
             "is_checkmate": state.is_checkmate,
             "is_stalemate": state.is_stalemate,
-            "is_draw": state.is_stalemate or state.is_insufficient_material,
+            "is_draw": is_draw,
             "winner": winner,
             "current_turn": state.turn
         }

--- a/tests/test_ch4_chess_game_over_status.py
+++ b/tests/test_ch4_chess_game_over_status.py
@@ -1,0 +1,105 @@
+import pytest
+pytest.importorskip(chess)
+"""
+Regression test suite for chess get_game_status covering rule-based draws,
+stalemate, insufficient material, checkmate, and game in progress.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+import chess
+
+sys.path.insert(
+    0,
+    str(
+        Path(__file__).resolve().parent.parent
+        / "chapter4"
+        / "collaboration-tools"
+        / "src"
+    ),
+)
+
+import chess_tools
+
+
+def test_chess_game_over_75_move_rule_draw():
+    # 75-move rule / 150 halfmoves automatic draw
+    board = chess.Board("8/8/8/8/8/8/R7/r6k w - - 150 1")
+    assert board.is_game_over() is True
+    assert board.is_checkmate() is False
+
+    chess_tools._game_board = board
+    res = asyncio.run(chess_tools.get_game_status())
+    assert res["success"] is True
+
+    status = res["game_status"]
+    assert status["is_game_over"] is True
+    assert status["is_draw"] is True
+    assert status["winner"] is None
+    assert status["status_message"] == "Game over! The game is a draw"
+
+
+def test_chess_stalemate_draw():
+    # Black king stalemated
+    board = chess.Board("k7/8/1Q6/8/8/8/8/K7 b - - 0 1")
+    assert board.is_stalemate() is True
+
+    chess_tools._game_board = board
+    res = asyncio.run(chess_tools.get_game_status())
+    assert res["success"] is True
+
+    status = res["game_status"]
+    assert status["is_game_over"] is True
+    assert status["is_stalemate"] is True
+    assert status["is_draw"] is True
+    assert status["winner"] is None
+    assert status["status_message"] == "Stalemate! The game is a draw"
+
+
+def test_chess_insufficient_material_draw():
+    # Bare kings
+    board = chess.Board("k7/8/8/8/8/8/8/K7 w - - 0 1")
+    assert board.is_insufficient_material() is True
+
+    chess_tools._game_board = board
+    res = asyncio.run(chess_tools.get_game_status())
+    assert res["success"] is True
+
+    status = res["game_status"]
+    assert status["is_game_over"] is True
+    assert status["is_draw"] is True
+    assert status["status_message"] == "Draw by insufficient material"
+
+
+def test_chess_checkmate_not_draw():
+    # Scholar's mate
+    board = chess.Board(
+        "r1bqkb1r/pppp1ppp/2n5/4p3/2B1P3/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 0 4"
+    )
+    board.push_san("Qxf7#")
+    assert board.is_checkmate() is True
+
+    chess_tools._game_board = board
+    res = asyncio.run(chess_tools.get_game_status())
+    assert res["success"] is True
+
+    status = res["game_status"]
+    assert status["is_game_over"] is True
+    assert status["is_checkmate"] is True
+    assert status["is_draw"] is False
+    assert status["winner"] == "white"
+    assert "Checkmate!" in status["status_message"]
+
+
+def test_chess_game_in_progress():
+    board = chess.Board()
+    chess_tools._game_board = board
+    res = asyncio.run(chess_tools.get_game_status())
+    assert res["success"] is True
+
+    status = res["game_status"]
+    assert status["is_game_over"] is False
+    assert status["is_draw"] is False
+    assert status["winner"] is None
+    assert status["status_message"] == "Game in progress"

--- a/tests/test_ch4_chess_game_over_status.py
+++ b/tests/test_ch4_chess_game_over_status.py
@@ -1,5 +1,5 @@
 import pytest
-pytest.importorskip(chess)
+pytest.importorskip("chess")
 """
 Regression test suite for chess get_game_status covering rule-based draws,
 stalemate, insufficient material, checkmate, and game in progress.


### PR DESCRIPTION
get_game_status in chess_tools returned incomplete status when a board state was in stalemate or draw without checkmate. This fix returns game_over True and result draw for non-checkmate terminal states.