### PR TITLE
fix(system-hint): handle None error in tool result logging

### DIFF
--- a/chapter2/system-hint/agent.py
+++ b/chapter2/system-hint/agent.py
@@ -15,12 +15,8 @@ from typing import List, Dict, Any, Optional, Tuple
 from dataclasses import dataclass, field
 from enum import Enum
 from datetime import datetime, timedelta
-import requests
 from openai import OpenAI
 import traceback
-import tempfile
-import shutil
-from pathlib import Path
 
 try:
     from dotenv import load_dotenv
@@ -589,7 +585,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                             "file_path": file_path,
                             "is_binary": True
                         }
-            except Exception as e:
+            except Exception:
                 # If we can't read it as binary, probably permission issue
                 raise
             
@@ -650,7 +646,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                         "lines": len(content.splitlines()),
                         "partial_read": False
                     }
-        except Exception as e:
+        except Exception:
             raise
     
     def _tool_write_file(self, file_path: str, content: str) -> Dict[str, Any]:
@@ -672,7 +668,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                 "bytes_written": len(content.encode('utf-8')),
                 "lines_written": len(content.splitlines())
             }
-        except Exception as e:
+        except Exception:
             raise
     
     def _tool_code_interpreter(self, code: str) -> Dict[str, Any]:
@@ -702,7 +698,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                 "stdout": stdout,
                 "stderr": stderr,
             }
-        except Exception as e:
+        except Exception:
             raise
     
     def _tool_execute_command(self, command: str, working_dir: Optional[str] = None) -> Dict[str, Any]:
@@ -756,7 +752,7 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
             }
         except subprocess.TimeoutExpired:
             raise TimeoutError(f"Command timed out after 30 seconds: {command}")
-        except Exception as e:
+        except Exception:
             raise
     
     def _tool_rewrite_todo_list(self, items: List[str]) -> Dict[str, Any]:
@@ -949,15 +945,16 @@ Important: When you have completed all tasks, clearly state "FINAL ANSWER:" foll
                                     elif 'file_path' in result:
                                         logger.info(f"  ✅ Success: File operation on {result['file_path']}")
                                     else:
-                                        logger.info(f"  ✅ Success: Operation completed")
+                                        logger.info("  ✅ Success: Operation completed")
                                 elif result.get('success') is False:
                                     # Handle explicit failures (like binary file detection)
                                     if result.get('is_binary'):
                                         logger.info(f"  ⚠️ Binary file detected: {result.get('file_path', 'unknown')}")
                                     else:
-                                        logger.info(f"  ⚠️ Failed: {result.get('error', 'Unknown error')[:100]}")
+                                        err_msg = str(result.get('error') or 'Unknown error')
+                                        logger.info(f"  ⚠️ Failed: {err_msg[:100]}")
                                 else:
-                                    logger.info(f"  ✅ Success: Operation completed")
+                                    logger.info("  ✅ Success: Operation completed")
                             else:
                                 result_preview = str(result).replace('\n', ' ')[:150]
                                 logger.info(f"  ✅ Result: {result_preview}")

--- a/tests/test_ch1_ch2_system_hint_tool_error_null.py
+++ b/tests/test_ch1_ch2_system_hint_tool_error_null.py
@@ -1,0 +1,83 @@
+import pytest
+"""
+Test suite verifying choke-point fix for SystemHintAgent handling
+None / empty / non-string error fields in tool results.
+"""
+
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "chapter2" / "system-hint"))
+from agent import SystemHintAgent
+
+
+def _create_mock_agent(execute_return_value):
+    agent = SystemHintAgent(api_key="mock_key", verbose=True)
+
+    mock_tool_call = MagicMock()
+    mock_tool_call.id = "call_123"
+    mock_tool_call.function.name = "custom_tool"
+    mock_tool_call.function.arguments = '{"param": "val"}'
+
+    mock_message = MagicMock()
+    mock_message.content = None
+    mock_message.tool_calls = [mock_tool_call]
+    mock_message.model_dump.return_value = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_123",
+                "type": "function",
+                "function": {"name": "custom_tool", "arguments": '{"param": "val"}'},
+            }
+        ],
+    }
+    mock_choice = MagicMock(message=mock_message)
+    mock_response = MagicMock(choices=[mock_choice])
+
+    agent._execute_tool = MagicMock(return_value=execute_return_value)
+
+    mock_message_end = MagicMock(content="FINAL ANSWER: Done", tool_calls=None)
+    mock_message_end.model_dump.return_value = {
+        "role": "assistant",
+        "content": "FINAL ANSWER: Done",
+    }
+    mock_choice_end = MagicMock(message=mock_message_end)
+    mock_response_end = MagicMock(choices=[mock_choice_end])
+
+    agent.client.chat.completions.create = MagicMock(
+        side_effect=[mock_response, mock_response_end]
+    )
+
+    return agent
+
+
+def test_system_hint_agent_handles_none_error_in_tool_result(caplog):
+    agent = _create_mock_agent(({"success": False, "error": None}, None, 15.0))
+    with caplog.at_level(logging.INFO):
+        result = agent.execute_task("Perform test task")
+
+    assert "error" not in result or "TypeError" not in result["error"]
+    assert result.get("success") is True
+    assert any("⚠️ Failed: Unknown error" in record.message for record in caplog.records)
+
+
+def test_system_hint_agent_handles_empty_string_error_in_tool_result(caplog):
+    agent = _create_mock_agent(({"success": False, "error": ""}, None, 15.0))
+    with caplog.at_level(logging.INFO):
+        result = agent.execute_task("Perform test task")
+
+    assert result.get("success") is True
+    assert any("⚠️ Failed: Unknown error" in record.message for record in caplog.records)
+
+
+def test_system_hint_agent_handles_valid_error_string(caplog):
+    agent = _create_mock_agent(({"success": False, "error": "Disk read timeout"}, None, 15.0))
+    with caplog.at_level(logging.INFO):
+        result = agent.execute_task("Perform test task")
+
+    assert result.get("success") is True
+    assert any("⚠️ Failed: Disk read timeout" in record.message for record in caplog.records)


### PR DESCRIPTION
SystemHintAgent logged an exception when tool result dictionaries contained error: None. This fix safely coerces error entries to string error messages only when truthy or non-None.