### PR TITLE
fix(context): separate terminal completion from task success

### DIFF
--- a/chapter1/context/README.md
+++ b/chapter1/context/README.md
@@ -267,11 +267,17 @@ Observed results (these are not the expected-behavior labels below):
 | no tool definitions | 1 | 0 | no | no; the model explicitly declined to invent rates |
 | no tool results | 5 | 7 | yes | no; the model eventually reported that observations were hidden |
 
-Here `success` in an individual raw arm means that the API/agent loop returned
-a final response, not that the task or the manuscript hypothesis passed. The
-canonical behavioral booleans are under `analysis.manuscript_behavior_claims`;
-`all_manuscript_behavior_claims_observed` is false. This distinction prevents a
-graceful refusal in an ablated arm from being mislabeled as task success.
+In an individual raw arm, `completed` means that the API/agent loop returned a
+terminal response. It does not mean that the requested task was correct. The
+legacy `success` field is retained as an alias for `completed` so older result
+readers continue to work; new readers should use `completed` explicitly.
+`task_success` is the task-specific correctness result. For this experiment it
+is computed by the canonical numeric rubric, while the generic agent cannot
+infer correctness from arbitrary natural-language prompts. The canonical
+behavioral booleans are under `analysis.manuscript_behavior_claims`;
+`all_manuscript_behavior_claims_observed` is false. This separation prevents a
+graceful refusal or hallucinated tool markup in an ablated arm from being
+mislabeled as task success, without forcing any ablation outcome in advance.
 
 The ablation studies systematically remove context components to understand their importance.
 
@@ -330,7 +336,8 @@ Manual provider/API smoke scripts live under `tests/manual/` and require the cor
 
 #### Performance Metrics
 
-- **Success Rate**: Whether the task was completed correctly
+- **Terminal Response Rate**: Whether the agent returned a terminal response
+- **Task Success**: Correctness under the task-specific rubric (when one is available)
 - **Execution Time**: Total time to complete the task
 - **Iterations**: Number of agent-model interactions
 - **Tool Calls**: Number of external tool invocations
@@ -768,7 +775,8 @@ python -m pytest tests
 
 #### 性能指标
 
-- **Success Rate**：任务是否正确完成
+- **Terminal Response Rate**：Agent 是否返回了终止响应
+- **Task Success**：在存在任务专用评分标准时，任务是否正确完成
 - **Execution Time**：完成任务总耗时
 - **Iterations**：Agent 与模型交互次数
 - **Tool Calls**：外部工具调用次数

--- a/chapter1/context/agent.py
+++ b/chapter1/context/agent.py
@@ -699,6 +699,17 @@ Important: When you have gathered all necessary information and computed the fin
 
         Returns:
             Task execution result
+
+        Result semantics:
+          - ``completed`` means the loop received a non-empty terminal text
+            response. It does not claim that the requested task was correct.
+          - ``task_success`` is ``None`` here because correctness is
+            task-specific and cannot be inferred from arbitrary natural
+            language prompts. Callers with a known rubric should compute it
+            from the final answer and trajectory.
+          - ``success`` is retained as a backwards-compatible alias for
+            ``completed``. New consumers should use ``completed`` or their
+            task-specific ``task_success`` value instead.
         """
         if max_iterations is None:
             try:
@@ -879,7 +890,10 @@ Important: When you have gathered all necessary information and computed the fin
                 return {
                     "error": "Request timed out. The model is taking too long to respond. Try a simpler task or different provider.",
                     "trajectory": self.trajectory,
-                    "iterations": iteration
+                    "iterations": iteration,
+                    "completed": False,
+                    "task_success": False,
+                    "success": False,
                 }
             except Exception as e:
                 logger.error(f"Error during task execution: {str(e)}")
@@ -896,19 +910,29 @@ Important: When you have gathered all necessary information and computed the fin
                     return {
                         "error": "Request timed out. The model is taking too long to respond. Try a simpler task or different provider.",
                         "trajectory": self.trajectory,
-                        "iterations": iteration
+                        "iterations": iteration,
+                        "completed": False,
+                        "task_success": False,
+                        "success": False,
                     }
                 return {
                     "error": str(e),
                     "trajectory": self.trajectory,
-                    "iterations": iteration
+                    "iterations": iteration,
+                    "completed": False,
+                    "task_success": False,
+                    "success": False,
                 }
-        
+        completed = bool(final_answer and str(final_answer).strip())
         return {
             "final_answer": final_answer,
             "trajectory": self.trajectory,
             "iterations": iteration,
-            "success": final_answer is not None,
+            "completed": completed,
+            "task_success": None,
+            # Backwards-compatible alias. This is terminal-response status,
+            # not a correctness judgment.
+            "success": completed,
             "provider": self.provider,
             "model": self.model,
             "base_url": self.base_url,

--- a/chapter1/context/main.py
+++ b/chapter1/context/main.py
@@ -28,6 +28,11 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+
+def _completed(result: Dict[str, Any]) -> bool:
+    """Return terminal-response status with compatibility for old results."""
+    return bool(result.get("completed", result.get("success", False)))
+
 # Load .env so API keys configured there are available via os.getenv.
 # (config.py calls load_dotenv() too, but main.py only imports agent, which
 #  does not import config, so we must trigger it here.)
@@ -125,6 +130,7 @@ Present a detailed financial analysis with all conversions and calculations."""
         start_time = time.time()
         result = agent.execute_task(task)
         execution_time = time.time() - start_time
+        completed = _completed(result)
 
         # Analyze the result
         test_result = {
@@ -134,7 +140,12 @@ Present a detailed financial analysis with all conversions and calculations."""
             "execution_time": round(execution_time, 2),
             "iterations": result.get("iterations", 0),
             "num_tool_calls": len(result["trajectory"].tool_calls),
-            "success": result.get("success", False),
+            # This legacy suite has no task-specific correctness rubric. Keep
+            # ``success`` as a compatibility alias, but report completion
+            # separately so a refusal is not presented as task success.
+            "completed": completed,
+            "success": completed,
+            "task_success": None,
             "has_final_answer": result.get("final_answer") is not None,
             "error": result.get("error"),
             "reasoning_steps": len(result["trajectory"].reasoning_steps),
@@ -143,7 +154,7 @@ Present a detailed financial analysis with all conversions and calculations."""
         
         # Log summary
         logger.info(f"Test completed in {test_result['execution_time']}s")
-        logger.info(f"Success: {test_result['success']}")
+        logger.info(f"Terminal response completed: {test_result['completed']}")
         logger.info(f"Tool calls made: {test_result['num_tool_calls']}")
         logger.info(f"Iterations: {test_result['iterations']}")
         
@@ -206,7 +217,9 @@ Present a detailed financial analysis with all conversions and calculations."""
                         "case_name": case_name,
                         "context_mode": context_mode.value,
                         "error": str(e),
-                        "success": False
+                        "completed": False,
+                        "success": False,
+                        "task_success": False,
                     })
 
         return results
@@ -223,7 +236,10 @@ Present a detailed financial analysis with all conversions and calculations."""
         """
         analysis = {
             "total_tests": len(results),
-            "successful_tests": sum(1 for r in results if r.get("success", False)),
+            "completed_tests": sum(1 for r in results if _completed(r)),
+            # Compatibility key for existing report consumers. It now counts
+            # terminal responses, not verified task successes.
+            "successful_tests": sum(1 for r in results if _completed(r)),
             "context_mode_impact": {}
         }
         
@@ -234,7 +250,8 @@ Present a detailed financial analysis with all conversions and calculations."""
             for result in results:
                 if result["context_mode"] != "full":
                     mode_analysis = {
-                        "success_maintained": result.get("success", False),
+                        "completion_maintained": _completed(result),
+                        "success_maintained": _completed(result),
                         "execution_time_delta": result.get("execution_time", 0) - baseline.get("execution_time", 0),
                         "iteration_delta": result.get("iterations", 0) - baseline.get("iterations", 0),
                         "tool_call_delta": result.get("num_tool_calls", 0) - baseline.get("num_tool_calls", 0),
@@ -242,7 +259,7 @@ Present a detailed financial analysis with all conversions and calculations."""
                     }
                     
                     # Identify failure reasons
-                    if not result.get("success", False):
+                    if not _completed(result):
                         if result["context_mode"] == "no_tool_calls":
                             mode_analysis["failure_reason"] = "Cannot execute tools without tool call capability"
                         elif result["context_mode"] == "no_tool_results":
@@ -269,7 +286,7 @@ Present a detailed financial analysis with all conversions and calculations."""
             table_data.append([
                 result.get("case_name", "default"),
                 result["context_mode"],
-                "✓" if result.get("success", False) else "✗",
+                "✓" if _completed(result) else "✗",
                 f"{result.get('execution_time', 0)}s",
                 result.get("iterations", 0),
                 result.get("num_tool_calls", 0),
@@ -277,7 +294,7 @@ Present a detailed financial analysis with all conversions and calculations."""
                 "Yes" if result.get("has_final_answer", False) else "No"
             ])
 
-        headers = ["Case", "Context Mode", "Success", "Time", "Iterations", "Tool Calls", "Reasoning Steps", "Final Answer"]
+        headers = ["Case", "Context Mode", "Completed", "Time", "Iterations", "Tool Calls", "Reasoning Steps", "Final Answer"]
 
         print("\n" + "="*80)
         print("ABLATION STUDY RESULTS")
@@ -314,7 +331,7 @@ Present a detailed financial analysis with all conversions and calculations."""
                 r = by_key.get((mode, case))
                 if r is None:
                     row.append("-")
-                elif r.get("success", False):
+                elif _completed(r):
                     row.append(f"✓ {r.get('iterations', 0)}it/{r.get('num_tool_calls', 0)}tc")
                 else:
                     row.append(f"✗ {r.get('iterations', 0)}it/{r.get('num_tool_calls', 0)}tc")
@@ -322,7 +339,7 @@ Present a detailed financial analysis with all conversions and calculations."""
 
         headers = ["Context Mode"] + cases
         print("\n" + "="*80)
-        print("COMPARISON MATRIX (rows = context mode, cols = case; cell = success it=iterations tc=tool calls)")
+        print("COMPARISON MATRIX (rows = context mode, cols = case; cell = completion it=iterations tc=tool calls)")
         print("="*80)
         print(tabulate(table_data, headers=headers, tablefmt="grid"))
     
@@ -342,16 +359,16 @@ Present a detailed financial analysis with all conversions and calculations."""
         iterations = [r.get("iterations", 0) for r in results]
         tool_calls = [r.get("num_tool_calls", 0) for r in results]
         exec_times = [r.get("execution_time", 0) for r in results]
-        success = [1 if r.get("success", False) else 0 for r in results]
+        success = [1 if _completed(r) else 0 for r in results]
         
         # Create subplots
         fig, axes = plt.subplots(2, 2, figsize=(12, 10))
         fig.suptitle("Ablation Study: Impact of Context Components", fontsize=16)
         
-        # Plot 1: Success Rate
+        # Plot 1: terminal-response completion rate
         axes[0, 0].bar(modes, success, color=['green' if s else 'red' for s in success])
-        axes[0, 0].set_title("Task Success by Context Mode")
-        axes[0, 0].set_ylabel("Success (1) / Failure (0)")
+        axes[0, 0].set_title("Terminal Responses by Context Mode")
+        axes[0, 0].set_ylabel("Completed (1) / No response (0)")
         axes[0, 0].tick_params(axis='x', rotation=45)
         
         # Plot 2: Iterations Required
@@ -391,7 +408,10 @@ Present a detailed financial analysis with all conversions and calculations."""
 # Context Ablation Study Report
 
 ## Executive Summary
-This ablation study explores the critical importance of different context components in AI agent behavior.
+This ablation study explores the effect of different context components on AI
+agent behavior. This legacy suite reports terminal-response completion and
+tool-use behavior; it does not claim task correctness without a task-specific
+rubric.
 
 ## Test Configuration
 - **Provider**: {provider}
@@ -414,29 +434,34 @@ This ablation study explores the critical importance of different context compon
 - **Critical for**: Complex tasks requiring logical decomposition
 
 ### 3. Lack of Tool Call Commands (NO_TOOL_CALLS)
-**Impact**: Agent cannot execute any external tools, rendering it unable to complete the task.
-- **Behavior**: Complete failure - agent can only describe what it would do, not actually do it
+**Impact**: Agent cannot execute any external tools.
+- **Behavior**: The model may return a refusal or describe the missing tools;
+  a terminal response is not evidence that the financial task was completed.
 - **Performance**: {no_tool_calls_perf}
 - **Critical for**: Any task requiring external data or computation
 
 ### 4. Lack of Tool Call Results (NO_TOOL_RESULTS)
 **Impact**: Agent operates blind to the outcomes of its actions.
-- **Behavior**: Cannot adapt based on results, leading to incorrect conclusions
+- **Behavior**: The model may stop with a warning, repeat actions, or produce an
+  incorrect conclusion; correctness must be checked by a task-specific rubric.
 - **Performance**: {no_tool_results_perf}
 - **Critical for**: Tasks requiring iterative refinement or result validation
 
 ## Statistical Summary
 - **Total Tests Run**: {total_tests}
-- **Successful Completions**: {successful_tests}
+- **Terminal Responses**: {successful_tests}
 - **Average Execution Time (Full Context)**: {avg_exec_time}s
 - **Average Tool Calls (Full Context)**: {avg_tool_calls}
 
 ## Conclusion
-The ablation study clearly demonstrates that each context component plays a vital role:
-1. **Tool calls** are fundamental - without them, the agent cannot interact with the world
-2. **Tool results** provide essential feedback for decision-making
-3. **Reasoning** enables strategic planning and efficient execution
-4. **History** prevents redundancy and maintains task coherence
+The ablation study records how each context component changes execution behavior:
+1. **Tool calls** determine whether the agent can interact with external tools
+2. **Tool results** provide feedback for decision-making
+3. **Reasoning** can affect planning and execution efficiency
+4. **History** can prevent redundant actions and maintain task coherence
+
+Task-level claims require a separate evaluator, such as the canonical numeric
+rubric used by `run_experiment_1_1.py`.
 
 ## Recommendations
 - Always maintain complete context for production agents
@@ -448,7 +473,7 @@ The ablation study clearly demonstrates that each context component plays a vita
         def get_perf_string(mode):
             mode_result = next((r for r in results if r["context_mode"] == mode), None)
             if mode_result:
-                return f"{'SUCCESS' if mode_result.get('success', False) else 'FAILURE'} - {mode_result.get('iterations', 0)} iterations, {mode_result.get('execution_time', 0)}s"
+                return f"{'COMPLETED' if _completed(mode_result) else 'NO TERMINAL RESPONSE'} - {mode_result.get('iterations', 0)} iterations, {mode_result.get('execution_time', 0)}s"
             return "N/A"
         
         # Calculate baseline metrics
@@ -513,7 +538,7 @@ def run_single_task(api_key: str, task: str, context_mode: str = "full", provide
     print("TASK EXECUTION RESULT")
     print("="*60)
     print(f"Context Mode: {context_mode}")
-    print(f"Success: {result.get('success', False)}")
+    print(f"Terminal response completed: {_completed(result)}")
     print(f"Iterations: {result.get('iterations', 0)}")
     print(f"Tool Calls: {len(result['trajectory'].tool_calls)}")
     
@@ -530,7 +555,10 @@ def run_single_task(api_key: str, task: str, context_mode: str = "full", provide
     with open(output_file, 'w') as f:
         # Convert trajectory to serializable format
         serializable_result = {
-            "success": result.get("success", False),
+            "completed": _completed(result),
+            "task_success": result.get("task_success"),
+            # Backwards-compatible alias for older result readers.
+            "success": _completed(result),
             "iterations": result.get("iterations", 0),
             "final_answer": result.get("final_answer"),
             "error": result.get("error"),
@@ -777,11 +805,11 @@ def run_ablation_study(api_key: str, provider: str = "siliconflow", model: str =
     print("\n" + "="*80)
     print("ANALYSIS SUMMARY")
     print("="*80)
-    print(f"Success Rate: {analysis['successful_tests']}/{analysis['total_tests']}")
+    print(f"Terminal Response Rate: {analysis['completed_tests']}/{analysis['total_tests']}")
     print("\nContext Mode Impacts:")
     for mode, impact in analysis["context_mode_impact"].items():
         print(f"\n{mode.upper()}:")
-        print(f"  - Success Maintained: {impact['success_maintained']}")
+        print(f"  - Completion Maintained: {impact['completion_maintained']}")
         print(f"  - Execution Time Delta: {impact['execution_time_delta']:.2f}s")
         print(f"  - Iteration Delta: {impact['iteration_delta']}")
         print(f"  - Tool Call Delta: {impact['tool_call_delta']}")
@@ -886,7 +914,7 @@ def interactive_mode(api_key: str, provider: str = "siliconflow", model: str = N
                         result = agent.execute_task(sample['task'])
                         
                         print(f"\n{'='*40}")
-                        print(f"Success: {result.get('success', False)}")
+                        print(f"Terminal response completed: {_completed(result)}")
                         print(f"Iterations: {result.get('iterations', 0)}")
                         print(f"Tool Calls: {len(result['trajectory'].tool_calls)}")
                         
@@ -1021,7 +1049,7 @@ def interactive_mode(api_key: str, provider: str = "siliconflow", model: str = N
                 result = agent.execute_task(user_input)
                 
                 print(f"\n{'='*40}")
-                print(f"Success: {result.get('success', False)}")
+                print(f"Terminal response completed: {_completed(result)}")
                 print(f"Iterations: {result.get('iterations', 0)}")
                 print(f"Tool Calls: {len(result['trajectory'].tool_calls)}")
                 

--- a/chapter1/context/run_experiment_1_1.py
+++ b/chapter1/context/run_experiment_1_1.py
@@ -234,12 +234,25 @@ def normalized_number_text(value: str | None) -> str:
     return (value or "").replace(",", "").replace("$", "").replace(" ", "")
 
 
+def canonical_answer_correct(final_answer: str | None) -> bool:
+    """Evaluate the known numeric rubric for the canonical Experiment 1-1 task.
+
+    This is deliberately kept outside ``ContextAwareAgent``.  A generic agent
+    cannot infer correctness from an arbitrary natural-language task, while
+    this experiment has an explicit answer rubric.
+    """
+    normalized = normalized_number_text(final_answer)
+    return bool(final_answer) and all(number in normalized for number in EXPECTED_NUMBERS)
+
+
 def summarize_arm(mode: ContextMode, result: Dict[str, Any], elapsed: float) -> Dict[str, Any]:
     trajectory = result["trajectory"]
     tool_calls = [tool_call_dict(call) for call in trajectory.tool_calls]
     signatures = call_signatures(tool_calls)
     repeats = len(signatures) - len(set(signatures))
     final_answer = result.get("final_answer")
+    completed = bool(result.get("completed", result.get("success", False)))
+    task_success = canonical_answer_correct(final_answer)
     arm = {
         "mode": mode.value,
         "provider": result.get("provider"),
@@ -248,7 +261,11 @@ def summarize_arm(mode: ContextMode, result: Dict[str, Any], elapsed: float) -> 
         "using_openrouter": result.get("using_openrouter", False),
         "started_at": None,
         "elapsed_seconds": round(elapsed, 6),
-        "success": result.get("success", False),
+        # ``success`` is retained for compatibility with existing evidence;
+        # it means terminal response/completion, not task correctness.
+        "success": completed,
+        "completed": completed,
+        "task_success": task_success,
         "iterations": result.get("iterations", 0),
         "error": result.get("error"),
         "final_answer": final_answer,
@@ -262,10 +279,8 @@ def summarize_arm(mode: ContextMode, result: Dict[str, Any], elapsed: float) -> 
     arm["behavior"] = {
         "tool_action_count": len(tool_calls),
         "has_repeated_tool_action": repeats > 0,
-        "hit_iteration_ceiling": result.get("iterations") >= 5 and not result.get("success"),
-        "canonical_answer_correct": all(
-            number in normalized_number_text(final_answer) for number in EXPECTED_NUMBERS
-        ),
+        "hit_iteration_ceiling": result.get("iterations") >= 5 and not completed,
+        "canonical_answer_correct": task_success,
     }
     return arm
 
@@ -310,7 +325,7 @@ def analyze(arms: List[Dict[str, Any]]) -> Dict[str, Any]:
     )
     behavior = {
         "full_baseline_correct": by_mode.get("full", {}).get("behavior", {}).get(
-            "canonical_answer_correct", False
+            "canonical_answer_correct", by_mode.get("full", {}).get("task_success", False)
         ),
         "without_tool_definitions_no_tool_action": by_mode.get(
             "no_tool_calls", {}

--- a/chapter1/context/test_experiment_1_1.py
+++ b/chapter1/context/test_experiment_1_1.py
@@ -1,4 +1,9 @@
-from run_experiment_1_1 import evaluate_context_contract
+from agent import AgentTrajectory, ContextMode
+from run_experiment_1_1 import (
+    canonical_answer_correct,
+    evaluate_context_contract,
+    summarize_arm,
+)
 
 
 def turn(messages, *, tools=True, reasoning="reason"):
@@ -67,3 +72,54 @@ def test_no_tool_results_requires_literal_hidden_observations():
 def test_no_tool_definitions_requires_absent_request_fields():
     result = evaluate_context_contract("no_tool_calls", [turn([SYSTEM, USER], tools=False)])
     assert result["passed"] is True
+
+
+def _arm_result(final_answer, *, mode=ContextMode.NO_TOOL_CALLS, iterations=1):
+    completed = final_answer is not None
+    return {
+        "trajectory": AgentTrajectory(context_mode=mode),
+        "final_answer": final_answer,
+        "completed": completed,
+        "success": completed,
+        "iterations": iterations,
+        "provider": "test",
+        "model": "test-model",
+    }
+
+
+def test_canonical_answer_rubric_rejects_refusal_and_hallucinated_markup():
+    refusal = "I cannot compute the exchange rates without tools."
+    hallucinated = "<request_tool>currency_converter(...)</request_tool>"
+    assert canonical_answer_correct(refusal) is False
+    assert canonical_answer_correct(hallucinated) is False
+
+
+def test_summarize_arm_separates_completion_from_task_success():
+    result = summarize_arm(
+        ContextMode.NO_TOOL_CALLS,
+        _arm_result("I cannot compute the exchange rates without tools."),
+        elapsed=0.1,
+    )
+
+    # The model did return a terminal response, but it did not complete the
+    # canonical financial task. A mode-independent evaluator must preserve
+    # that distinction instead of forcing the mode to fail.
+    assert result["completed"] is True
+    assert result["success"] is True  # compatibility alias
+    assert result["task_success"] is False
+    assert result["behavior"]["canonical_answer_correct"] is False
+
+
+def test_summarize_arm_accepts_correct_answer_even_in_an_ablated_arm():
+    answer = "Annual total: $9,602,895.73; quarterly average: $2,400,723.93"
+    result = summarize_arm(
+        ContextMode.NO_TOOL_RESULTS,
+        _arm_result(answer, mode=ContextMode.NO_TOOL_RESULTS),
+        elapsed=0.1,
+    )
+
+    # Correctness is an observed task result. The experiment may separately
+    # report that tool feedback was hidden; it must not manufacture failure.
+    assert result["completed"] is True
+    assert result["task_success"] is True
+    assert result["behavior"]["canonical_answer_correct"] is True

--- a/chapter1/context/test_main_result_semantics.py
+++ b/chapter1/context/test_main_result_semantics.py
@@ -1,0 +1,11 @@
+from main import _completed
+
+
+def test_completed_field_is_authoritative_over_legacy_success_alias():
+    assert _completed({"completed": False, "success": True}) is False
+    assert _completed({"completed": True, "success": False}) is True
+
+
+def test_completed_falls_back_for_old_result_artifacts():
+    assert _completed({"success": True}) is True
+    assert _completed({"success": False}) is False

--- a/chapter1/context/tests/test_malformed_tool_json.py
+++ b/chapter1/context/tests/test_malformed_tool_json.py
@@ -50,8 +50,25 @@ def test_execute_task_survives_malformed_tool_arguments_json():
     result = agent.execute_task("compute", max_iterations=5)
 
     assert result.get("error") is None
+    assert result["completed"] is True
+    assert result["task_success"] is None
+    assert result["success"] is True  # backwards-compatible completion alias
     assert "recovered" in (result.get("final_answer") or result.get("answer") or "")
     tool_roles = [m for m in agent.conversation_history if m.get("role") == "tool"]
     assert tool_roles
     assert "Invalid tool arguments" in tool_roles[0]["content"]
     assert agent.client.chat.completions.create.call_count == 2
+
+
+def test_execute_task_does_not_complete_on_empty_terminal_content():
+    agent = ContextAwareAgent("test-key", ContextMode.NO_TOOL_CALLS, verbose=False)
+    empty_turn = SimpleNamespace(choices=[_choice(content="")])
+    agent.client = MagicMock()
+    agent.client.chat.completions.create = MagicMock(return_value=empty_turn)
+
+    result = agent.execute_task("say something", max_iterations=5)
+
+    assert result["final_answer"] is None
+    assert result["completed"] is False
+    assert result["task_success"] is None
+    assert result["success"] is False


### PR DESCRIPTION
## Summary

Fixes #683 without hard-coding ablation modes to fail. The generic agent cannot infer task correctness from arbitrary natural-language prompts, so terminal response status and task-level correctness are now separate.

## Changes

- Add `completed` to `ContextAwareAgent.execute_task()` for terminal-response status.
- Add `task_success` (unknown for generic tasks; false on execution errors) and retain `success` only as a backwards-compatible alias for `completed`. Empty terminal content is not considered completed.
- Add an explicit canonical numeric rubric in `run_experiment_1_1.py`; refusal and hallucinated tool markup are `completed=true`, `task_success=false`, while correctness remains an observed result rather than a mode-forced outcome.
- Update the legacy ablation suite, reports, plots, JSON output, and docs to label terminal completion accurately and avoid presenting refusals as task success.
- Add regression coverage for refusal, hallucinated tool markup, correct answers in ablated arms, empty terminal content, compatibility aliases, and result reporting.

## Validation

- `python -m pytest -q chapter1/context/test_experiment_1_1.py chapter1/context/test_main_result_semantics.py chapter1/context/tests` — 21 passed.
- `python -m py_compile chapter1/context/agent.py chapter1/context/main.py chapter1/context/run_experiment_1_1.py`
- `python -m pytest -q` cannot collect the entire repository in this environment because an existing test module exits when `KIMI_API_KEY` is absent; this is unrelated to the change.