### PR TITLE
fix(intuitor): extract answer after last hash marker in GSM8K format

### DIFF
--- a/chapter7/Intuitor/evaluate_from_cache.py
+++ b/chapter7/Intuitor/evaluate_from_cache.py
@@ -57,7 +57,7 @@ def extract_answer_from_gsm8k_format(text: str) -> Optional[str]:
     if "####" in text:
         parts = text.split("####")
         if len(parts) > 1:
-            return parts[1].strip()
+            return parts[-1].strip()
     
     return None
 

--- a/chapter7/Intuitor/test_normalize_negative_currency.py
+++ b/chapter7/Intuitor/test_normalize_negative_currency.py
@@ -1,5 +1,6 @@
 """Regression: negative currency formats and negative fractions must preserve negative sign."""
 
+from evaluate_from_cache import extract_answer_from_gsm8k_format
 from evaluate_from_cache import extract_and_normalize_answer, normalize_number
 
 
@@ -18,3 +19,8 @@ def test_boxed_negative_dollar_amount():
 def test_negative_latex_frac():
     assert normalize_number(r"-\frac{6}{2}") == "-3"
     assert normalize_number(r"-\dfrac{6}{2}") == "-3"
+
+
+def test_extract_gsm8k_multiple_hash_markers():
+    assert extract_answer_from_gsm8k_format("#### step 1 #### 42") == "42"
+    assert extract_and_normalize_answer("#### step 1 #### 42") == "42"


### PR DESCRIPTION
extract_answer_from_gsm8k_format returned intermediate reasoning text when inputs contained multiple #### markers. This fix extracts the answer after the final #### marker.