### PR TITLE
fix(active-tool-selection): search for closing tag after opening tag in parse_request

### DIFF
--- a/chapter4/active-tool-selection/semantic_router.py
+++ b/chapter4/active-tool-selection/semantic_router.py
@@ -255,11 +255,13 @@ class StructuredRequestParser:
         
         Returns dict with 'server' and 'tool' fields, or None if not found.
         """
-        if '<tool_request>' not in text or '</tool_request>' not in text:
+        if '<tool_request>' not in text:
             return None
         
         start = text.find('<tool_request>')
-        end = text.find('</tool_request>')
+        end = text.find('</tool_request>', start + len('<tool_request>'))
+        if end == -1:
+            return None
         request_text = text[start + len('<tool_request>'):end].strip()
         
         result = {}

--- a/chapter4/active-tool-selection/tests/test_parse_request_closing_tag.py
+++ b/chapter4/active-tool-selection/tests/test_parse_request_closing_tag.py
@@ -1,0 +1,19 @@
+from semantic_router import StructuredRequestParser
+
+
+def test_parse_request_preceding_closing_tag_mention():
+    text = (
+        "Note: Do not format as </tool_request> without an opening tag.\n\n"
+        "<tool_request>\n"
+        "server: GitHub for repository operations\n"
+        "tool: search repositories by keywords\n"
+        "</tool_request>\n"
+    )
+    parsed = StructuredRequestParser.parse_request(text)
+    assert parsed is not None, "Failed to parse tool request when </tool_request> is mentioned in preceding text"
+    assert parsed["server"] == "GitHub for repository operations"
+    assert parsed["tool"] == "search repositories by keywords"
+
+
+if __name__ == "__main__":
+    test_parse_request_preceding_closing_tag_mention()


### PR DESCRIPTION
StructuredRequestParser.parse_request failed to parse tool requests when prose preceding the tool request mentioned </tool_request>. This fix searches for </tool_request> starting after the opening <tool_request> tag.