### PR TITLE
fix(werewolf): prevent killed witch from using poison in same night

### DIFF
--- a/chapter10/voice-werewolf/test_witch_killed_no_poison.py
+++ b/chapter10/voice-werewolf/test_witch_killed_no_poison.py
@@ -1,0 +1,29 @@
+import pytest
+from werewolf.game import Judge
+from werewolf.agent import PlayerAgent
+from werewolf.roles import Role, Faction
+
+
+def test_witch_killed_by_wolves_cannot_use_poison_in_same_night():
+    """Contract proved: Judge._witch_act prevents a Witch who was killed by wolves at night and not saved from using poison in the same night.
+    Bug locked out: allowing a dead witch killed by wolves to poison another player on the night she dies."""
+    players = [
+        PlayerAgent("P1", Role.WEREWOLF, offline=True),
+        PlayerAgent("P2", Role.WEREWOLF, offline=True),
+        PlayerAgent("P3", Role.SEER, offline=True),
+        PlayerAgent("P4", Role.WITCH, offline=True),
+        PlayerAgent("P5", Role.VILLAGER, offline=True),
+    ]
+
+    judge = Judge(players, seed=42)
+    witch = judge.by_name("P4")
+
+    # Override witch target selection to attempt poisoning P3 if asked
+    witch._offline_choose_target = lambda candidates, allow_none: "P3"
+
+    # Wolves killed P4 (the witch)
+    killed = "P4"
+    poisoned, saved = judge._witch_act(killed)
+
+    assert saved is False
+    assert poisoned is None, "A witch killed by wolves at night cannot use poison in the same night"

--- a/chapter10/voice-werewolf/werewolf/game.py
+++ b/chapter10/voice-werewolf/werewolf/game.py
@@ -313,8 +313,8 @@ class Judge:
         else:
             self.private_send(witch, "女巫夜间信息", f"第{self.round_no}回合是平安夜（无人被狼人击杀，或你无从得知）")
 
-        # 毒药：是否毒一人
-        if self.witch_poison_available:
+        # 毒药：被狼人击杀且未救活的女巫今晚无法使用毒药
+        if self.witch_poison_available and not (killed == witch.name and not saved):
             candidates = [p.name for p in self.alive() if p.name != witch.name]
             dec = witch.choose_target(
                 "你是否使用【毒药】毒死一名你怀疑是狼人的玩家？（毒则填玩家名，不毒填 none）",


### PR DESCRIPTION
In werewolf game simulation, when wolves target and kill the witch during night phase, the witch could still use poison on another player before dying. This updates poison availability to check whether the witch was killed and left unsaved.