### PR TITLE
fix(cot-distillation): accept fullwidth colon in verified final answer

### DIFF
--- a/chapter7/cot-distillation/test_load_verified_messages_colon.py
+++ b/chapter7/cot-distillation/test_load_verified_messages_colon.py
@@ -1,0 +1,32 @@
+"""Regression: load_verified_messages must accept fullwidth colon and case-insensitive Final Answer."""
+
+import json
+from pathlib import Path
+from train_student import load_verified_messages
+
+
+def test_load_verified_messages_fullwidth_colon(tmp_path: Path):
+    sample = {
+        "messages": [
+            {"role": "user", "content": "What is 2 + 2?"},
+            {"role": "assistant", "content": "<think>\n2+2=4\n</think>\n\nFinal Answer：4"},
+        ]
+    }
+    dataset = tmp_path / "dataset.jsonl"
+    dataset.write_text(json.dumps(sample) + "\n", encoding="utf-8")
+    rows = load_verified_messages(dataset)
+    assert len(rows) == 1
+    assert rows[0][1]["content"].endswith("Final Answer：4")
+
+
+def test_load_verified_messages_lowercase_colon(tmp_path: Path):
+    sample = {
+        "messages": [
+            {"role": "user", "content": "What is 2 + 2?"},
+            {"role": "assistant", "content": "<think>\n2+2=4\n</think>\n\nfinal answer: 4"},
+        ]
+    }
+    dataset = tmp_path / "dataset.jsonl"
+    dataset.write_text(json.dumps(sample) + "\n", encoding="utf-8")
+    rows = load_verified_messages(dataset)
+    assert len(rows) == 1

--- a/chapter7/cot-distillation/train_student.py
+++ b/chapter7/cot-distillation/train_student.py
@@ -14,6 +14,7 @@ import importlib.metadata
 import importlib.util
 import json
 import os
+import re
 import platform
 import subprocess
 from dataclasses import dataclass
@@ -45,7 +46,7 @@ def load_verified_messages(path: Path) -> list[list[dict[str, str]]]:
                 raise ValueError(f"{path}:{line_number}: expected user then assistant")
             if not all(isinstance(m.get("content"), str) and m["content"].strip() for m in messages):
                 raise ValueError(f"{path}:{line_number}: empty message content")
-            if "Final Answer:" not in messages[1]["content"]:
+            if not re.search(r"Final Answer[:：]", messages[1]["content"], re.IGNORECASE):
                 raise ValueError(f"{path}:{line_number}: assistant lacks verified Final Answer")
             rows.append(messages)
     if not rows:


### PR DESCRIPTION
load_verified_messages rejected assistant responses that used fullwidth colons after Final Answer. This updates the check to accept both standard and fullwidth colons case-insensitively.