### PR TITLE
fix(elo-leaderboard): preserve column schema in compare_win_rates on empty results

### DIFF
--- a/chapter6/elo-leaderboard/leaderboard.py
+++ b/chapter6/elo-leaderboard/leaderboard.py
@@ -120,7 +120,10 @@ def compare_win_rates(elo_system: EloRatingSystem, empirical_df: pd.DataFrame) -
                         'error': error
                     })
     
-    comparison_df = pd.DataFrame(comparisons)
+    cols = ['model_a', 'model_b', 'empirical', 'predicted', 'error']
+    if not comparisons:
+        return pd.DataFrame(columns=cols)
+    comparison_df = pd.DataFrame(comparisons, columns=cols)
     return comparison_df
 
 

--- a/chapter6/elo-leaderboard/tests/test_ch6_compare_win_rates_empty.py
+++ b/chapter6/elo-leaderboard/tests/test_ch6_compare_win_rates_empty.py
@@ -1,0 +1,17 @@
+"""Regression test for compare_win_rates when comparisons list is empty."""
+import numpy as np
+import pandas as pd
+from elo_rating import EloRatingSystem
+from leaderboard import compare_win_rates
+
+
+def test_compare_win_rates_empty_has_required_columns():
+    """compare_win_rates must return a DataFrame with required columns when no valid comparisons exist."""
+    elo = EloRatingSystem()
+    empirical_df = pd.DataFrame(np.nan, index=["model_a", "model_b"], columns=["model_a", "model_b"])
+    df_comp = compare_win_rates(elo, empirical_df)
+    assert list(df_comp.columns) == ["model_a", "model_b", "empirical", "predicted", "error"]
+    assert len(df_comp) == 0
+    # Accessing columns on empty result must not raise KeyError
+    assert "error" in df_comp
+    assert df_comp["error"].empty


### PR DESCRIPTION
compare_win_rates produced a DataFrame without standard columns when no comparisons were generated, causing KeyError downstream. This ensures the output DataFrame retains expected column names even on empty input.