### PR TITLE
fix(public-health-reporting-eval): handle unhashable claims and null supported_claims in score_prediction

### DIFF
--- a/chapter6/public-health-reporting-eval/evaluator.py
+++ b/chapter6/public-health-reporting-eval/evaluator.py
@@ -70,9 +70,17 @@ def score_prediction(
     details["evidence"] = int(_same_evidence(actual_evidence, expected_evidence))
 
     claims = prediction.get("claims", [])
-    details["grounding_and_safety"] = int(
-        isinstance(claims, list) and set(claims).issubset(set(expected["supported_claims"]))
-    )
+    supported = expected.get("supported_claims", []) if isinstance(expected, dict) else []
+    if not isinstance(supported, list):
+        supported = []
+    if not isinstance(claims, list):
+        grounding = 0
+    else:
+        try:
+            grounding = int(set(claims).issubset(set(supported)))
+        except TypeError:
+            grounding = int(all(item in supported for item in claims))
+    details["grounding_and_safety"] = grounding
     return {
         "task_id": expected["task_id"],
         "score": sum(details.values()),

--- a/tests/test_ch6_score_prediction_unhashable_claims.py
+++ b/tests/test_ch6_score_prediction_unhashable_claims.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent.parent
+EVAL_DIR = HERE / "chapter6" / "public-health-reporting-eval"
+if str(EVAL_DIR) not in sys.path:
+    sys.path.insert(0, str(EVAL_DIR))
+
+from evaluator import score_prediction  # noqa: E402
+
+
+def test_score_prediction_unhashable_dict_claims():
+    pred = {"claims": [{"statement": "flu cases up 10%"}]}
+    exp = {
+        "task_id": "t1",
+        "tool": None,
+        "arguments": None,
+        "result": {},
+        "supported_claims": [{"statement": "flu cases up 10%"}],
+    }
+    res = score_prediction(pred, exp)
+    assert res["details"]["grounding_and_safety"] == 1
+
+
+def test_score_prediction_none_supported_claims():
+    pred = {"claims": ["claim1"]}
+    exp = {
+        "task_id": "t2",
+        "tool": None,
+        "arguments": None,
+        "result": {},
+        "supported_claims": None,
+    }
+    res = score_prediction(pred, exp)
+    assert res["details"]["grounding_and_safety"] == 0


### PR DESCRIPTION
score_prediction failed with TypeError when claims contained unhashable dictionaries or when supported_claims was None. This adds safe extraction of supported_claims and fallback element-wise matching for unhashable claims.