### PR TITLE
fix(intuitor): preserve negative fraction value when space follows minus sign

### DIFF
--- a/chapter7/Intuitor/evaluate_from_cache.py
+++ b/chapter7/Intuitor/evaluate_from_cache.py
@@ -93,11 +93,11 @@ def normalize_number(text: str) -> Optional[str]:
             pass
 
     # Plain a/b (e.g. boxed "6/2") before taking the first digit run alone.
-    slash = re.fullmatch(r'\s*(-?\d+(?:\.\d+)?)\s*/\s*(-?\d+(?:\.\d+)?)\s*', text)
+    slash = re.fullmatch(r'\s*(-?\s*\d+(?:\.\d+)?)\s*/\s*(-?\s*\d+(?:\.\d+)?)\s*', text)
     if slash:
         try:
-            num = float(slash.group(1))
-            den = float(slash.group(2))
+            num = float(slash.group(1).replace(" ", ""))
+            den = float(slash.group(2).replace(" ", ""))
             if den != 0:
                 return _format_normalized_number(num / den)
         except ValueError:

--- a/chapter7/Intuitor/test_normalize_negative_currency.py
+++ b/chapter7/Intuitor/test_normalize_negative_currency.py
@@ -24,3 +24,8 @@ def test_negative_latex_frac():
 def test_extract_gsm8k_multiple_hash_markers():
     assert extract_answer_from_gsm8k_format("#### step 1 #### 42") == "42"
     assert extract_and_normalize_answer("#### step 1 #### 42") == "42"
+
+
+def test_negative_fraction_with_space():
+    assert normalize_number("- 1/2") == "-0.5"
+    assert extract_and_normalize_answer(r"\boxed{- 1/2}") == "-0.5"

--- a/chapter7/Intuitor/test_normalize_negative_currency.py
+++ b/chapter7/Intuitor/test_normalize_negative_currency.py
@@ -18,3 +18,8 @@ def test_boxed_negative_dollar_amount():
 def test_negative_latex_frac():
     assert normalize_number(r"-\frac{6}{2}") == "-3"
     assert normalize_number(r"-\dfrac{6}{2}") == "-3"
+
+
+def test_negative_fraction_with_space():
+    assert normalize_number("- 1/2") == "-0.5"
+    assert extract_and_normalize_answer(r"\boxed{- 1/2}") == "-0.5"


### PR DESCRIPTION
normalize_number returned "-1" instead of "-0.5" for "- 1/2" because fraction matching rejected spaces after the minus sign. This updates fraction parsing to allow optional whitespace following the negative sign.