### PR TITLE
fix(user-memory): format memory_id alongside content in format_memory_operations

### DIFF
--- a/chapter3/user-memory/memory_operation_formatter.py
+++ b/chapter3/user-memory/memory_operation_formatter.py
@@ -38,15 +38,14 @@ def format_memory_operations(operations: List[Dict[str, Any]], verbose: bool = F
         # Main operation line
         lines.append(f"{i}. {icon} {action.upper()}")
         
-        # Content or memory ID
+        if op.get('memory_id'):
+            lines.append(f"   Memory ID: {op['memory_id']}")
         if op.get('content'):
             content = op['content']
             # Truncate if too long and not verbose
             if not verbose and len(content) > 100:
                 content = content[:97] + "..."
             lines.append(f"   Content: {content}")
-        elif op.get('memory_id'):
-            lines.append(f"   Memory ID: {op['memory_id']}")
         
         # Reason
         if op.get('reason'):

--- a/chapter3/user-memory/test_format_memory_operations_memory_id.py
+++ b/chapter3/user-memory/test_format_memory_operations_memory_id.py
@@ -1,0 +1,16 @@
+import pytest
+from memory_operation_formatter import format_memory_operations
+
+
+def test_format_memory_operations_includes_memory_id_when_content_present():
+    operations = [
+        {
+            "action": "update",
+            "memory_id": "mem_101",
+            "content": "User prefers dark mode.",
+            "reason": "User updated preference",
+        }
+    ]
+    result = format_memory_operations(operations)
+    assert "Memory ID: mem_101" in result
+    assert "Content: User prefers dark mode." in result


### PR DESCRIPTION
format_memory_operations omitted memory_id when content was present in an operation object. This fix formats memory_id whenever it is specified regardless of content presence.