### PR TITLE
fix(retrieval-pipeline): preserve top score for duplicate doc_ids in weighted fusion

### DIFF
--- a/chapter3/retrieval-pipeline/fusion.py
+++ b/chapter3/retrieval-pipeline/fusion.py
@@ -33,6 +33,12 @@ RankedList = Sequence[Tuple[str, float]]
 DEFAULT_RRF_K = 60
 
 
+def _ranked_to_score_map(ranked: RankedList) -> Dict[str, float]:
+    scores: Dict[str, float] = {}
+    for doc_id, score in ranked:
+        if doc_id not in scores:
+            scores[doc_id] = score
+    return scores
 def min_max_normalize(scores: Dict[str, float]) -> Dict[str, float]:
     """Min-max normalize a mapping of doc_id -> score into the [0, 1] range.
 
@@ -104,7 +110,7 @@ def weighted_score_fusion(
     """
     weights = weights or {}
     normalized_by_source = {
-        source: min_max_normalize(dict(ranked))
+        source: min_max_normalize(_ranked_to_score_map(ranked))
         for source, ranked in ranked_lists.items()
     }
 

--- a/chapter3/retrieval-pipeline/test_weighted_fusion_dedup.py
+++ b/chapter3/retrieval-pipeline/test_weighted_fusion_dedup.py
@@ -1,0 +1,15 @@
+import pytest
+from fusion import weighted_score_fusion
+
+def test_weighted_score_fusion_preserves_top_score_on_duplicate_doc_id():
+    """Verify weighted score fusion preserves top score when duplicate doc_ids exist in ranked list."""
+    ranked_lists = {
+        "dense": [("doc1", 0.95), ("doc2", 0.80), ("doc1", 0.10)],
+        "sparse": [("doc1", 10.0), ("doc2", 5.0)]
+    }
+
+    results = weighted_score_fusion(ranked_lists)
+
+    assert results[0][0] == "doc1"
+    assert results[1][0] == "doc2"
+    assert results[0][1] > results[1][1]


### PR DESCRIPTION
Weighted fusion overwrote higher doc_id scores when duplicate document IDs were returned across search results during min-max normalization. This update retains the maximum normalized score when deduplicating document IDs.