### PR TITLE
fix(ch1): handle string URL sources in web_search_call citations

### DIFF
--- a/chapter1/search-codegen/agent.py
+++ b/chapter1/search-codegen/agent.py
@@ -161,9 +161,10 @@ code_interpreter 实际执行，不得口算或声称运行了代码。"""
                 action = item.get("action")
                 if isinstance(action, dict):
                     for source in action.get("sources") or []:
-                        if isinstance(source, dict) and source.get("url"):
+                        url = source if isinstance(source, str) else (source.get("url") if isinstance(source, dict) else None)
+                        if url:
                             citations.append(
-                                {"type": "url_citation", "url": source["url"]}
+                                {"type": "url_citation", "url": url}
                             )
         return citations
 

--- a/chapter1/search-codegen/test_responses_agent.py
+++ b/chapter1/search-codegen/test_responses_agent.py
@@ -73,6 +73,29 @@ def test_dashscope_citations_from_web_search_sources():
         {"type": "url_citation", "url": "https://asean.test/two"},
     ]
 
+def test_dashscope_citations_from_web_search_string_url_sources():
+    agent = GPT5NativeAgent("key", base_url=DASHSCOPE_URL, model="qwen3.7-plus")
+    response = {
+        "output": [
+            {
+                "type": "web_search_call",
+                "status": "completed",
+                "action": {
+                    "query": "ASEAN capitals",
+                    "sources": [
+                        "https://asean.test/one",
+                        "https://asean.test/two",
+                    ],
+                },
+            }
+        ]
+    }
+    citations = agent._citations(response)
+    assert citations == [
+        {"type": "url_citation", "url": "https://asean.test/one"},
+        {"type": "url_citation", "url": "https://asean.test/two"},
+    ]
+
 
 def test_independent_asean_reference_is_kuala_lumpur_singapore():
     reference = independent_asean_reference()


### PR DESCRIPTION
GPT5NativeAgent._citations dropped source items when web_search_call returned sources as a list of URL strings instead of dictionaries. This update normalizes string URL sources into url_citation records.