### PR TITLE
fix(ch2): clean nested HTML tags and unescape entities in webpage titles

### DIFF
--- a/chapter2/context-compression/test_web_tools_null_content.py
+++ b/chapter2/context-compression/test_web_tools_null_content.py
@@ -36,3 +36,24 @@ def test_search_web_handles_null_page_content():
     res = tool.search_web("test query", num_results=1)
     assert res['num_results'] == 1
     assert res['results'][0]['content_length'] == 0
+
+def test_fetch_webpage_title_with_nested_elements():
+    """
+    Ensure fetch_webpage extracts title text correctly when title tag has nested HTML elements.
+    """
+    html_content = "<html><head><title>Report <span>2026</span></title></head><body><p>Test content</p></body></html>"
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html_content
+    mock_resp.raise_for_status = MagicMock()
+
+    import requests
+    requests.get = MagicMock(return_value=mock_resp)
+
+    tool = WebTools.__new__(WebTools)
+    tool.page_cache = {}
+    tool.html_converter = MagicMock()
+    tool.html_converter.handle.return_value = "Test content"
+
+    res = tool.fetch_webpage("http://example.com/report")
+    assert res['title'] == "Report 2026"

--- a/chapter2/context-compression/web_tools.py
+++ b/chapter2/context-compression/web_tools.py
@@ -3,6 +3,8 @@ Web tools for searching and fetching web pages
 """
 
 import json
+import html
+import re
 import logging
 import requests
 from typing import List, Dict, Any, Optional
@@ -159,9 +161,16 @@ class WebTools:
             if len(cleaned_text) > Config.MAX_WEBPAGE_LENGTH:
                 cleaned_text = cleaned_text[:Config.MAX_WEBPAGE_LENGTH] + "\n\n[Content truncated...]"
             
+            title = 'No title'
+            if soup.title:
+                raw_title = soup.title.get_text()
+                cleaned_title = html.unescape(re.sub(r'<[^>]+>', '', raw_title)).strip()
+                if cleaned_title:
+                    title = cleaned_title
+
             result = {
                 'url': url,
-                'title': soup.title.string if soup.title else 'No title',
+                'title': title,
                 'content': cleaned_text,
                 'content_length': len(cleaned_text),
                 'success': True,


### PR DESCRIPTION
WebTools.fetch_webpage returned raw HTML tags and unescaped entities when extracting webpage titles containing nested markup or HTML entities. This update strips nested HTML tags and unescapes entities from webpage titles.