### PR TITLE
fix(scripts): normalize leading slash in source_path_for_page URIs

### DIFF
--- a/scripts/site_source_paths.py
+++ b/scripts/site_source_paths.py
@@ -15,7 +15,7 @@ Commit = tuple[str, int]
 def source_path_for_page(src_uri: str, root: Path = REPO_ROOT) -> Path:
     """Return the tracked source represented by an assembled page URI."""
     relative = PurePosixPath(src_uri)
-    parts = relative.parts
+    parts = [p for p in relative.parts if p != "/"]
 
     # build_site.sh promotes book/chapterN.md to book/chapterN/index.md so
     # navigation.indexes can make the chapter section itself clickable.

--- a/tests/test_git_revision_dates.py
+++ b/tests/test_git_revision_dates.py
@@ -30,6 +30,17 @@ def test_promoted_chapter_index_maps_back_to_chapter_source(tmp_path: Path):
     source.touch()
 
     assert source_path_for_page("book/chapter10/index.md", tmp_path) == source
+def test_source_path_for_page_strips_leading_slashes(tmp_path: Path):
+    """Contract: Leading slashes in page URIs must be normalized to relative repository paths.
+
+    If a page URI carries a leading slash (e.g. /book/chapter1/index.md), source_path_for_page
+    must strip it so path joining resolves under root instead of filesystem root /.
+    """
+    source = tmp_path / "book" / "chapter1.md"
+    source.parent.mkdir(parents=True)
+    source.touch()
+
+    assert source_path_for_page("/book/chapter1/index.md", tmp_path) == source
 
 
 def test_original_source_map_uses_tracked_sources_and_skips_missing_files(tmp_path: Path):


### PR DESCRIPTION
source_path_for_page failed directory resolution and reset paths to the filesystem root when page URIs contained a leading slash. This update strips leading slashes before resolving relative source paths.