### PR TITLE
fix(intuitor): normalize fractions with latex formatting and units

### DIFF
--- a/chapter7/Intuitor/evaluate_from_cache.py
+++ b/chapter7/Intuitor/evaluate_from_cache.py
@@ -80,20 +80,25 @@ def normalize_number(text: str) -> Optional[str]:
     # 确保是字符串
     text = str(text)
 
+    # Strip LaTeX formatting, currency, thin spaces, and units before fraction parsing.
+    cleaned = re.sub(r'\\(?:text|mathrm|mathbf)\s*\{[^}]*\}', '', text)
+    cleaned = cleaned.replace("\\$", "").replace("$", "").replace("\\,", "").replace("\\text", "")
+    cleaned = cleaned.replace(",", "")
+
     # Evaluate \frac{a}{b} before brace stripping (else "\frac{6}{2}" becomes "frac62").
-    frac = re.search(r'(-)?\s*\\(?:d)?frac\s*\{([^{}]+)\}\s*\{([^{}]+)\}', text)
+    frac = re.search(r'(-)?\s*\\(?:d)?frac\s*\{([^{}]+)\}\s*\{([^{}]+)\}', cleaned)
     if frac:
         try:
             sign = -1.0 if frac.group(1) else 1.0
-            num = float(frac.group(2).replace(",", "").replace("$", "").replace("\\$", "").strip())
-            den = float(frac.group(3).replace(",", "").replace("$", "").replace("\\$", "").strip())
+            num = float(frac.group(2).strip())
+            den = float(frac.group(3).strip())
             if den != 0:
                 return _format_normalized_number(sign * (num / den))
         except ValueError:
             pass
 
-    # Plain a/b (e.g. boxed "6/2") before taking the first digit run alone.
-    slash = re.fullmatch(r'\s*(-?\d+(?:\.\d+)?)\s*/\s*(-?\d+(?:\.\d+)?)\s*', text)
+    # Plain a/b (e.g. boxed "6/2" or "6/2 kg") before taking the first digit run alone.
+    slash = re.search(r'(-?\d+(?:\.\d+)?)\s*/\s*(-?\d+(?:\.\d+)?)', cleaned)
     if slash:
         try:
             num = float(slash.group(1))

--- a/chapter7/Intuitor/evaluate_from_cache.py
+++ b/chapter7/Intuitor/evaluate_from_cache.py
@@ -80,8 +80,8 @@ def normalize_number(text: str) -> Optional[str]:
     # 确保是字符串
     text = str(text)
 
-    # Strip LaTeX formatting, currency, thin spaces, and units before fraction parsing.
-    cleaned = re.sub(r'\\(?:text|mathrm|mathbf)\s*\{[^}]*\}', '', text)
+    # Unwrap LaTeX formatting before parsing; the wrapped content may itself be numeric.
+    cleaned = re.sub(r'\\(?:text|mathrm|mathbf)\s*\{([^}]*)\}', r'\1', text)
     cleaned = cleaned.replace("\\$", "").replace("$", "").replace("\\,", "").replace("\\text", "")
     cleaned = cleaned.replace(",", "")
 
@@ -90,8 +90,12 @@ def normalize_number(text: str) -> Optional[str]:
     if frac:
         try:
             sign = -1.0 if frac.group(1) else 1.0
-            num = float(frac.group(2).strip())
-            den = float(frac.group(3).strip())
+            num_match = re.match(r'\s*(-?\s*\d+(?:\.\d+)?)', frac.group(2))
+            den_match = re.match(r'\s*(-?\s*\d+(?:\.\d+)?)', frac.group(3))
+            if not num_match or not den_match:
+                raise ValueError("fraction component does not start with a number")
+            num = float(num_match.group(1).replace(" ", ""))
+            den = float(den_match.group(1).replace(" ", ""))
             if den != 0:
                 return _format_normalized_number(sign * (num / den))
         except ValueError:
@@ -322,4 +326,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/chapter7/Intuitor/tests/test_normalize_frac_formatting.py
+++ b/chapter7/Intuitor/tests/test_normalize_frac_formatting.py
@@ -1,0 +1,20 @@
+"""Regression: LaTeX fractions and division with formatting/units must evaluate correctly."""
+
+from evaluate_from_cache import extract_and_normalize_answer, normalize_number
+
+
+def test_frac_thin_space_evaluates():
+    assert normalize_number(r"\frac{1\,000}{2}") == "500"
+    assert normalize_number(r"\dfrac{1\,500}{3}") == "500"
+    assert normalize_number(r"-\frac{1\,000}{2}") == "-500"
+
+
+def test_frac_text_units_evaluates():
+    assert normalize_number(r"\frac{100\text{ kg}}{2}") == "50"
+    assert normalize_number(r"\frac{100}{2\text{ kg}}") == "50"
+
+
+def test_slash_division_with_units_and_formatting():
+    assert normalize_number("6/2 kg") == "3"
+    assert normalize_number("$6/2$") == "3"
+    assert normalize_number("1,000 / 2") == "500"

--- a/chapter7/Intuitor/tests/test_normalize_frac_formatting.py
+++ b/chapter7/Intuitor/tests/test_normalize_frac_formatting.py
@@ -12,6 +12,12 @@ def test_frac_thin_space_evaluates():
 def test_frac_text_units_evaluates():
     assert normalize_number(r"\frac{100\text{ kg}}{2}") == "50"
     assert normalize_number(r"\frac{100}{2\text{ kg}}") == "50"
+    assert normalize_number(r"\frac{\text{100 kg}}{2}") == "50"
+
+
+def test_frac_numeric_format_wrappers_evaluate():
+    assert normalize_number(r"\frac{\mathrm{1,000}}{2}") == "500"
+    assert normalize_number(r"\frac{\mathbf{6}}{2}") == "3"
 
 
 def test_slash_division_with_units_and_formatting():


### PR DESCRIPTION
When normalizing numeric answers, fractions containing LaTeX formatting macros like \mathrm, thin spaces, or commas failed to parse and returned invalid results. This cleans formatting artifacts before fraction regex extraction.