### PR TITLE
fix(multi-role-transfer): handle unhashable target_role in transfer_to_agent

### DIFF
--- a/chapter10/multi-role-transfer/orchestrator.py
+++ b/chapter10/multi-role-transfer/orchestrator.py
@@ -187,14 +187,14 @@ class MultiRoleOrchestrator:
             if name == "transfer_to_agent":
                 target = args.get("target_role", "")
                 reason = args.get("reason", "")
-                if target == self.current_role:
+                if isinstance(target, str) and target == self.current_role:
                     # 拒绝自我移交：让模型改用自己的工具或选别的角色
                     result = (
                         f"移交失败：你已经是 {target} 角色，不能移交给自己。"
                         "请直接使用你自己的工具完成当前部分，或移交给其他角色。"
                     )
                     self._log(f"{C.RED}└── transfer 被拒: 不能移交给自己 ({target}){C.RESET}")
-                elif target in ROLES:
+                elif isinstance(target, str) and target in ROLES:
                     pending_transfer = Handoff(self.current_role, target, reason)
                     self.activity.append((self.current_role, "transfer", target))
                     result = f"已移交给 {target}。对方将继承完整对话历史并继续处理。"

--- a/chapter10/multi-role-transfer/tests/test_tool_dispatch_errors.py
+++ b/chapter10/multi-role-transfer/tests/test_tool_dispatch_errors.py
@@ -7,6 +7,7 @@
 """
 
 import json
+import sys
 from types import SimpleNamespace
 
 from orchestrator import MultiRoleOrchestrator

--- a/chapter10/multi-role-transfer/tests/test_tool_dispatch_errors.py
+++ b/chapter10/multi-role-transfer/tests/test_tool_dispatch_errors.py
@@ -7,7 +7,6 @@
 """
 
 import json
-import sys
 from types import SimpleNamespace
 
 from orchestrator import MultiRoleOrchestrator

--- a/tests/test_ch10_multi_role_transfer_unhashable_target.py
+++ b/tests/test_ch10_multi_role_transfer_unhashable_target.py
@@ -8,7 +8,11 @@ ch10_mrt = Path(__file__).resolve().parent.parent / "chapter10" / "multi-role-tr
 if str(ch10_mrt) not in sys.path:
     sys.path.insert(0, str(ch10_mrt))
 
+tools_backup = sys.modules.pop("tools", None)
 from orchestrator import MultiRoleOrchestrator
+sys.modules.pop("tools", None)
+if tools_backup is not None:
+    sys.modules["tools"] = tools_backup
 
 FINAL_TEXT = "处理完毕。"
 

--- a/tests/test_ch10_multi_role_transfer_unhashable_target.py
+++ b/tests/test_ch10_multi_role_transfer_unhashable_target.py
@@ -1,0 +1,52 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+import pytest
+
+ch10_mrt = Path(__file__).resolve().parent.parent / "chapter10" / "multi-role-transfer"
+if str(ch10_mrt) not in sys.path:
+    sys.path.insert(0, str(ch10_mrt))
+
+from orchestrator import MultiRoleOrchestrator
+
+FINAL_TEXT = "处理完毕。"
+
+
+def _tool_call_msg(name, arguments):
+    tc = SimpleNamespace(
+        id="call_1",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=None, tool_calls=[tc]))]
+    )
+
+
+def _final_msg():
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=FINAL_TEXT, tool_calls=None))]
+    )
+
+
+def _fake_client(responses):
+    queue = list(responses)
+    return SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=lambda **kw: queue.pop(0)))
+    )
+
+
+def test_unhashable_target_role_in_transfer_to_agent_returns_error_string_not_crash():
+    """Regression test: when transfer_to_agent receives an unhashable target_role (e.g. list or dict),
+    the orchestrator must not crash with TypeError: unhashable type, but return a failure message."""
+    bad_args = json.dumps({"target_role": ["research"], "reason": "test"})
+    orch = MultiRoleOrchestrator(
+        client=_fake_client([_tool_call_msg("transfer_to_agent", bad_args), _final_msg()]),
+        verbose=False,
+        start_role="triage",
+    )
+    final = orch.run("处理任务")
+    assert final == FINAL_TEXT
+    tool_results = [m["content"] for m in orch.history if m["role"] == "tool"]
+    assert any("移交失败" in r for r in tool_results)


### PR DESCRIPTION
MultiRoleOrchestrator._run_one_llm_turn raised a TypeError when processing transfer_to_agent tool calls with non-string or unhashable target_role arguments. This update validates that target_role is a string before evaluating role membership.