### PR TITLE
fix(elo-leaderboard): convert string dates to timestamps in prepare_animation_data

### DIFF
--- a/chapter6/elo-leaderboard/animation.py
+++ b/chapter6/elo-leaderboard/animation.py
@@ -19,6 +19,10 @@ def prepare_animation_data(history_df: pd.DataFrame, top_n: int = 15) -> dict:
     Returns:
         Dictionary with animation data
     """
+    # Convert date column to Timestamp to support ISO date strings and date objects
+    if history_df is not None and len(history_df) > 0 and 'date' in history_df.columns:
+        history_df = history_df.copy()
+        history_df['date'] = pd.to_datetime(history_df['date'])
     # Get all unique dates
     dates = sorted(history_df['date'].unique())
     if len(dates) == 0:

--- a/chapter6/elo-leaderboard/tests/test_ch6_animation_string_date.py
+++ b/chapter6/elo-leaderboard/tests/test_ch6_animation_string_date.py
@@ -1,0 +1,32 @@
+"""Regression test for prepare_animation_data with string or date objects in history_df."""
+import pandas as pd
+from animation import prepare_animation_data
+
+
+def test_prepare_animation_data_string_date():
+    """prepare_animation_data must handle string dates without raising AttributeError."""
+    history = pd.DataFrame([
+        {
+            "date": "2024-08-01",
+            "model": "model_a",
+            "rating": 1050.0,
+            "rank": 1,
+            "matches": 10,
+            "wins": 7.0,
+        },
+        {
+            "date": "2024-08-01",
+            "model": "model_b",
+            "rating": 950.0,
+            "rank": 2,
+            "matches": 10,
+            "wins": 3.0,
+        },
+    ])
+    data = prepare_animation_data(history, top_n=2)
+    assert data["total_frames"] == 1
+    assert data["start_date"] == "2024-08-01"
+    assert data["end_date"] == "2024-08-01"
+    assert len(data["frames"]) == 1
+    assert data["frames"][0]["date"] == "2024-08-01"
+    assert data["frames"][0]["timestamp"] == 1722470400


### PR DESCRIPTION
When rating history DataFrames contain ISO string dates, calling prepare_animation_data raised an AttributeError when invoking strftime. This converts the date column to pandas DatetimeIndex timestamps prior to formatting.