### PR TITLE
fix(code-for-logic): support silent residents in CSP solver

### DIFF
--- a/chapter5/code-for-logic/csp_solver.py
+++ b/chapter5/code-for-logic/csp_solver.py
@@ -68,8 +68,9 @@ def solve(names, structs):
 
     # 对每位说话者加一条双条件约束：t[X] == (X 的话为真)
     for speaker in names:
-        stmt = structs[speaker]
-
+        stmt = structs.get(speaker)
+        if stmt is None:
+            continue
         def make_constraint(speaker=speaker, stmt=stmt):
             def constraint(*values):
                 t = dict(zip(names, values))

--- a/chapter5/code-for-logic/test_silent_resident.py
+++ b/chapter5/code-for-logic/test_silent_resident.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+# Ensure csp_solver module can be resolved regardless of working directory
+sys.path.insert(0, str(Path(__file__).parent))
+
+from csp_solver import solve, solve_labeled
+
+
+def test_csp_solver_handles_silent_resident():
+    """Verify solve handles residents in names that make no statements.
+
+    Contract: In Knights and Knaves puzzles, residents listed in `names` may be
+    silent (spoken about by others without making statements themselves).
+    `solve` must skip adding speaker-statement constraints for silent residents
+    rather than raising KeyError.
+    """
+    names = ["A", "B"]
+    # A speaks about B ("B is a knave"), but B makes no statement.
+    structs = {"A": ["is", "B", "knave"]}
+
+    solutions = solve(names, structs)
+    assert len(solutions) == 2
+    # If A is knight (True), B must be knave (False); if A is knave (False), B must be knight (True).
+    assert {"A": True, "B": False} in solutions
+    assert {"A": False, "B": True} in solutions
+
+    labeled = solve_labeled(names, structs)
+    assert {"A": "knight", "B": "knave"} in labeled
+    assert {"A": "knave", "B": "knight"} in labeled


### PR DESCRIPTION
When Knights and Knaves puzzles include silent residents who make no statements themselves, calling solve raised a KeyError accessing structs[speaker]. This uses get() to safely skip constraint generation for silent speakers.