### PR TITLE
fix(coding-agent): support multiline regex matching in GrepTool content mode

### DIFF
--- a/chapter5/coding-agent/tests/test_grep_multiline_content.py
+++ b/chapter5/coding-agent/tests/test_grep_multiline_content.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+# Ensure coding-agent modules can be resolved regardless of working directory
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from system_state import SystemState
+from tools.grep_tool import GrepTool
+
+
+def test_grep_tool_supports_multiline_content_matching(tmp_path):
+    """Verify GrepTool content mode supports multiline regex matching.
+
+    Contract: When multiline=True is provided, GrepTool output_mode="content" must
+    match patterns that span multiple lines and return the matching lines with context,
+    rather than iterating line-by-line and returning "No matches found."
+    """
+    file_path = tmp_path / "sample.py"
+    file_path.write_text("def foo():\n    return 42\n", encoding="utf-8")
+
+    state = SystemState()
+    tool = GrepTool(state)
+
+    result = tool.execute({
+        "pattern": r"def foo\(\):\n\s+return",
+        "path": str(file_path),
+        "multiline": True,
+        "output_mode": "content",
+    })
+
+    assert result.success
+    assert result.data["matches"] > 0
+    assert result.data["output"] != "No matches found."
+    assert "def foo():" in result.data["output"]
+    assert "return 42" in result.data["output"]

--- a/chapter5/coding-agent/tools/grep_tool.py
+++ b/chapter5/coding-agent/tools/grep_tool.py
@@ -268,10 +268,17 @@ class GrepTool(BaseTool):
                 
                 # Find matching lines
                 matching_line_numbers = []
-                for i, line in enumerate(lines):
-                    if regex.search(line):
-                        matching_line_numbers.append(i)
-                
+                if (regex.flags & re.DOTALL) or (regex.flags & re.MULTILINE):
+                    full_content = "".join(lines)
+                    for match in regex.finditer(full_content):
+                        start_pos, end_pos = match.span()
+                        start_line = full_content.count('\n', 0, start_pos)
+                        end_line = full_content.count('\n', 0, max(start_pos, end_pos - 1 if end_pos > start_pos else start_pos))
+                        matching_line_numbers.extend(range(start_line, end_line + 1))
+                else:
+                    for i, line in enumerate(lines):
+                        if regex.search(line):
+                            matching_line_numbers.append(i)
                 if not matching_line_numbers:
                     continue
                 


### PR DESCRIPTION
When GrepTool was invoked with multiline matching enabled in content output mode, line-by-line search caused cross-line regex patterns to fail and return no matches. This searches full file content using finditer when multiline flags are set.