### PR TITLE
fix(parallel-research): handle terminate broadcast before task_assigned

### DIFF
--- a/chapter10/parallel-web-research/agents.py
+++ b/chapter10/parallel-web-research/agents.py
@@ -119,6 +119,14 @@ class WorkerAgent:
     async def run(self):
         assigned = await self.sub.get()
         while assigned.type != "task_assigned":
+            if assigned.type == "terminate":
+                self._termination_reason = assigned.payload.get("reason", "cascade")
+                self.terminate.set()
+                await self.report(TaskState.TERMINATED, f"安全点响应终止：{self._termination_reason}")
+                await self.bus.send(self.id, "coordinator", "ack", {
+                    "acked": "terminate", "source": self.site.name,
+                })
+                return
             assigned = await self.sub.get()
         signal_task = asyncio.create_task(self._signals())
         try:

--- a/chapter10/parallel-web-research/test_worker_terminate_before_task.py
+++ b/chapter10/parallel-web-research/test_worker_terminate_before_task.py
@@ -1,0 +1,32 @@
+import asyncio
+import pytest
+import sys
+from pathlib import Path
+
+# Ensure chapter10/parallel-web-research is in sys.path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from agents import WorkerAgent
+from message_bus import MessageBus, BROADCAST
+from sources import Website
+
+
+@pytest.mark.asyncio
+async def test_worker_exits_early_when_terminate_arrives_before_task_assigned():
+    """Contract proved: WorkerAgent handles terminate broadcast received before task_assigned without hanging or ignoring the signal.
+    Bug locked out: infinite loop awaiting task_assigned while ignoring terminate signal."""
+    bus = MessageBus(verbose=False)
+    site = Website("s1", "http://site1.edu", "College 1")
+    w = WorkerAgent("worker-1", site, bus, "target", None)
+
+    # Broadcast terminate to bus BEFORE worker-1 gets task_assigned
+    await bus.send("coordinator", BROADCAST, "terminate", {"reason": "target_found_by_other"})
+
+    # w.run() must exit promptly (not hang awaiting task_assigned), set terminate event, and send ACK
+    await asyncio.wait_for(w.run(), timeout=2.0)
+
+    assert w.terminate.is_set()
+    assert w._termination_reason == "target_found_by_other"
+    acks = [m for m in bus.history if m.type == "ack" and m.sender_id == "worker-1"]
+    assert len(acks) == 1
+    assert acks[0].payload.get("acked") == "terminate"


### PR DESCRIPTION
When a terminate broadcast message arrived before task_assigned in WorkerAgent.run, the worker loop hung indefinitely waiting for task assignment. This checks for terminate messages while waiting for assignment so workers shut down promptly.