### PR TITLE
fix(site): render LaTeX math on the book website (MathJax 3 config)

### DIFF
--- a/extras/mathjax.js
+++ b/extras/mathjax.js
@@ -1,0 +1,37 @@
+/**
+ * MathJax 3 configuration for MkDocs Material.
+ *
+ * This file MUST be loaded before the MathJax bundle
+ * (`tex-mml-chtml.js`) in mkdocs.yml `extra_javascript` — MathJax reads
+ * `window.MathJax` once at startup, so setting it afterwards has no effect.
+ *
+ * `pymdownx.arithmatex` (generic mode) rewrites the book's `$...$` and
+ * `$$...$$` source math into `\(...\)` / `\[...\]` wrapped in
+ * `<span class="arithmatex">` / `<div class="arithmatex">`. MathJax's
+ * default delimiters are `$...$`/`$$...$$`, which no longer exist in the
+ * rendered HTML, so without this config nothing is typeset at all.
+ */
+window.MathJax = {
+  tex: {
+    inlineMath: [['\\(', '\\)']],
+    displayMath: [['\\[', '\\]']],
+    processEscapes: true,
+    processEnvironments: true,
+  },
+  options: {
+    // Only typeset elements arithmatex marked as math; ignore everything
+    // else (code blocks, search summaries, etc.).
+    ignoreHtmlClass: '.*|',
+    processHtmlClass: 'arithmatex',
+  },
+};
+
+// Material's `navigation.instant` swaps page content without a full reload,
+// so MathJax must re-typeset after every page swap (same pattern as
+// extras/mermaid-init.js).
+document$.subscribe(() => {
+  MathJax.startup.output.clearCache();
+  MathJax.typesetClear();
+  MathJax.texReset();
+  MathJax.typesetPromise();
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,6 +138,9 @@ extra_javascript:
   - extras/nav-collapse.js
   - https://unpkg.com/mermaid@11/dist/mermaid.min.js
   - extras/mermaid-init.js
+  # mathjax.js must load first: it sets the `window.MathJax` config that
+  # the MathJax bundle reads at startup (see the file header).
+  - extras/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 extra_css:


### PR DESCRIPTION
## Problem

Math on the book site (e.g. https://bojieli.github.io/ai-agent-book/book/chapter7/#rl-llm) renders as raw `$...$` / `$$...$$` source instead of typeset equations.

Root cause: `pymdownx.arithmatex` (generic mode) rewrites the book's `$...$` / `$$...$$` source math into `\(...\)` / `\[...\]` wrapped in `<span class="arithmatex">` / `<div class="arithmatex">`, but `mkdocs.yml` loaded the MathJax 3 bundle (`tex-mml-chtml.js`) with **no configuration**. MathJax 3 defaults to `$...$`/`$$...$$` delimiters — which no longer exist in the rendered HTML — so it typeset nothing.

## Fix

- Add `extras/mathjax.js`, loaded **before** the MathJax bundle in `extra_javascript` (MathJax reads `window.MathJax` once at startup):
  - `inlineMath: \\( \\)`, `displayMath: \\[ \\]` — the delimiters arithmatex emits
  - `processHtmlClass: 'arithmatex'` — only typeset arithmatex-marked elements (code blocks etc. untouched)
  - `document$.subscribe(...)` re-typeset after every `navigation.instant` page swap (same pattern as `extras/mermaid-init.js`), so math renders on SPA-style navigations too
- Wire it into `mkdocs.yml` ahead of the MathJax CDN bundle.

## Verification

Local `mkdocs build` (with the unchanged markdown pipeline; only the social/git-date plugins disabled for speed) confirms for `/book/chapter7/`:
- `extras/mathjax.js` is included before `tex-mml-chtml.js` in the page
- the page contains `<span class="arithmatex">\(T\)</span>`-style elements matching the configured delimiters/classes