### PR TITLE
fix(providers): resolve default model when resolve_backend receives whitespace model

### DIFF
--- a/agentbook/providers/resolution.py
+++ b/agentbook/providers/resolution.py
@@ -138,8 +138,9 @@ def resolve_backend(
             neither its own variables nor ``OPENROUTER_API_KEY`` are set.
     """
     spec = lookup(provider)
-    if model:
-        resolved_model = model
+    model_clean = (model or "").strip()
+    if model_clean:
+        resolved_model = model_clean
     elif spec.name == _OPENROUTER:
         # The OpenRouter default honours OPENROUTER_MODEL — the env var this
         # package documents (see the module docstring / ZERO_COST_HINT) as the

--- a/tests/test_resolve_backend_whitespace_model.py
+++ b/tests/test_resolve_backend_whitespace_model.py
@@ -1,0 +1,6 @@
+from agentbook.providers.resolution import resolve_backend
+
+
+def test_resolve_backend_whitespace_model_uses_default():
+    backend = resolve_backend("ollama", model="   ")
+    assert backend.model == "qwen3:8b"


### PR DESCRIPTION
Passing a whitespace-only model string (such as model="   ") to resolve_backend caused it to return Backend(model="   ") instead of stripping whitespace and falling back to the provider default model.

This change normalizes model_clean = (model or "").strip() at the entry point of resolve_backend, ensuring whitespace-only model overrides safely resolve the provider default model.