### PR TITLE
fix(multi-role-transfer): handle non-dict arguments payload in tool calls

### DIFF
--- a/chapter10/multi-role-transfer/orchestrator.py
+++ b/chapter10/multi-role-transfer/orchestrator.py
@@ -181,7 +181,9 @@ class MultiRoleOrchestrator:
             name = tc.function.name
             try:
                 args = json.loads(tc.function.arguments or "{}")
-            except json.JSONDecodeError:
+                if not isinstance(args, dict):
+                    args = {}
+            except (json.JSONDecodeError, TypeError):
                 args = {}
 
             if name == "transfer_to_agent":

--- a/tests/test_ch10_orchestrator_non_dict_tool_arguments.py
+++ b/tests/test_ch10_orchestrator_non_dict_tool_arguments.py
@@ -1,0 +1,37 @@
+import sys, os
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath("chapter10/multi-role-transfer"))
+from orchestrator import MultiRoleOrchestrator
+
+
+def test_orchestrator_non_dict_tool_call_arguments_handled():
+    mock_client = MagicMock()
+
+    # Mock tool call with arguments parsing to a list [1, 2] instead of a dict
+    tool_call = MagicMock()
+    tool_call.id = "call_non_dict"
+    tool_call.function.name = "transfer_to_agent"
+    tool_call.function.arguments = "[1, 2]"
+
+    msg = MagicMock()
+    msg.content = None
+    msg.tool_calls = [tool_call]
+
+    choice = MagicMock()
+    choice.message = msg
+
+    response = MagicMock()
+    response.choices = [choice]
+
+    mock_client.chat.completions.create.return_value = response
+
+    orchestrator = MultiRoleOrchestrator(client=mock_client, verbose=False)
+    # _run_one_llm_turn should handle non-dict arguments gracefully without raising AttributeError
+    res = orchestrator._run_one_llm_turn()
+    assert res is None
+    assert len(orchestrator.history) >= 2
+    # The tool response message should record the invalid transfer attempt cleanly
+    tool_msg = orchestrator.history[-1]
+    assert tool_msg["role"] == "tool"
+    assert "移交失败" in tool_msg["content"]


### PR DESCRIPTION
When an LLM generated tool calls with non-dictionary JSON argument payloads (such as lists "[1, 2]" or primitives "123"), json.loads returned non-dict objects, causing MultiRoleOrchestrator._run_one_llm_turn to raise AttributeError: 'list' object has no attribute 'get'.

This fix adds an explicit isinstance(args, dict) check during argument parsing, safely falling back to {} and returning a clear tool error message to the LLM instead of crashing the orchestrator.