### PR TITLE
fix(perception-tools): handle null limit option in expanded catalog

### DIFF
--- a/chapter4/perception-tools/src/expanded_catalog.py
+++ b/chapter4/perception-tools/src/expanded_catalog.py
@@ -480,7 +480,14 @@ def _options(raw: str) -> dict[str, Any]:
 
 
 def _limit(options: dict[str, Any], default: int = 10) -> int:
-    return max(1, min(int(options.get("limit", default)), 100))
+    raw = options.get("limit")
+    if raw is None:
+        raw = default
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        val = default
+    return max(1, min(val, 100))
 
 
 async def _http_json(url: str, *, params: dict[str, Any] | None = None,

--- a/tests/test_ch4_expanded_catalog_limit_null.py
+++ b/tests/test_ch4_expanded_catalog_limit_null.py
@@ -1,0 +1,14 @@
+import sys, os
+
+sys.path.insert(0, os.path.abspath("chapter4/perception-tools/src"))
+from expanded_catalog import _limit
+
+
+def test_expanded_catalog_limit_null_option_handled():
+    # Options dict with "limit": None (e.g. parsed from JSON '{"limit": null}')
+    limit = _limit({"limit": None}, default=10)
+    assert limit == 10
+
+    # Non-integer / string limit handled cleanly
+    limit_invalid = _limit({"limit": "invalid"}, default=15)
+    assert limit_invalid == 15


### PR DESCRIPTION
Executing expanded perception tools with options JSON containing {"limit": null} caused _limit to pass None to int(), raising TypeError: int() argument must be a string... not 'NoneType'.

This fix safely handles None and non-integer inputs in _limit, falling back to default and clamping valid limits within [1, 100].