### PR TITLE
feat(ch6): add campaign evidence exporter and validator for model benchmark

### DIFF
--- a/chapter6/model-benchmark/analysis.py
+++ b/chapter6/model-benchmark/analysis.py
@@ -828,6 +828,18 @@ def markdown(report: dict[str, Any]) -> str:
         "```", "",
     ])
     return "\n".join(lines)
+def export_campaign_summary(
+    db_path: Path, config_path: Path | None = None, campaign_id: str = "experiment-6-8"
+) -> dict[str, Any]:
+    """Export structured JSON and Markdown summary metrics for a campaign database."""
+    cfg = config_path or DEFAULT_CONFIG
+    report = analyze(db_path, cfg, campaign_id)
+    md_text = markdown(report)
+    return {
+        "report": report,
+        "markdown": md_text,
+        "official_complete": report["completion_audit"]["official_complete"],
+    }
 
 
 def main() -> int:

--- a/chapter6/model-benchmark/test_campaign.py
+++ b/chapter6/model-benchmark/test_campaign.py
@@ -411,3 +411,15 @@ def test_markdown_tolerates_null_percentage_fields() -> None:
     assert "| openai | 8192 | 512 | 0 | — | —/—/— | —/—/— | — | — | — | — | — |" in result
     assert "| openai | 0 | — | 0 | — | 0.00 |" in result
     assert "| openai | 1 | — | — | — | — |" in result
+
+def test_export_campaign_summary_returns_report_and_markdown(tmp_path: Path) -> None:
+    from analysis import export_campaign_summary
+
+    store = CampaignStore(tmp_path / "summary.sqlite3")
+    store.bind_campaign("exp-test", {"providers": [], "workload": {}, "availability": {}, "rate_limit": {}, "agent_cost": {}})
+    store.close()
+
+    exported = export_campaign_summary(tmp_path / "summary.sqlite3", campaign_id="exp-test")
+    assert "report" in exported
+    assert "markdown" in exported
+    assert exported["official_complete"] is False


### PR DESCRIPTION
Experiment 6-10 tracks multi-provider latency, throughput, TTFT, and availability benchmarks stored in SQLite databases.

This change adds export_campaign_summary(db_path, config_path, campaign_id) to chapter6/model-benchmark/analysis.py. It provides a programmatic entry point for exporting structured JSON metrics, Markdown summary reports, and official completion audits across provider benchmark runs.