### PR TITLE
fix(ch7): add robust messages type validation in MultilingualReasoning SFT

### DIFF
--- a/chapter7/MultilingualReasoning/gpt_oss_20b_sft.py
+++ b/chapter7/MultilingualReasoning/gpt_oss_20b_sft.py
@@ -25,15 +25,18 @@ https://cookbook.openai.com/articles/gpt-oss/fine-tune-transfomers
 
 import os
 import argparse
-import torch
-from datasets import load_dataset
-from transformers import (
-    AutoModelForCausalLM,
-    AutoTokenizer,
-    Mxfp4Config,
-)
-from peft import LoraConfig, PeftModel, get_peft_model
-from trl import SFTTrainer, SFTConfig
+try:
+    import torch
+    from datasets import load_dataset
+    from transformers import AutoModelForCausalLM, AutoTokenizer, Mxfp4Config
+    from peft import LoraConfig, PeftModel, get_peft_model
+    from trl import SFTTrainer, SFTConfig
+except ImportError:
+    torch = None
+    load_dataset = None
+    AutoModelForCausalLM = AutoTokenizer = Mxfp4Config = None
+    LoraConfig = PeftModel = get_peft_model = None
+    SFTTrainer = SFTConfig = None
 
 
 # ============================================================================
@@ -80,9 +83,12 @@ def format_chat_template(example, tokenizer):
     Returns:
         dict: 格式化后的样本
     """
-    # 应用聊天模板
+    # 应用聊天模板（带 messages 类型校验）
+    messages = example.get("messages")
+    if not isinstance(messages, list):
+        messages = []
     example["text"] = tokenizer.apply_chat_template(
-        example["messages"],
+        messages,
         tokenize=False,
     )
     return example

--- a/tests/test_ch7_multilingual_reasoning_sft.py
+++ b/tests/test_ch7_multilingual_reasoning_sft.py
@@ -1,0 +1,17 @@
+import sys, os
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath("chapter7/MultilingualReasoning"))
+from gpt_oss_20b_sft import format_chat_template
+
+
+def test_format_chat_template_handles_non_list_messages():
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.apply_chat_template.return_value = "formatted text"
+
+    # Example with missing / non-list messages
+    example = {"messages": None}
+    res = format_chat_template(example, mock_tokenizer)
+    assert res["text"] == "formatted text"
+    # apply_chat_template should receive [] when messages is None/invalid
+    mock_tokenizer.apply_chat_template.assert_called_once_with([], tokenize=False)


### PR DESCRIPTION
Experiment 7-7 demonstrates multilingual SFT reasoning models using Hugging Face TRL and chat templates.

When dataset examples contain missing or non-list messages fields (such as None), format_chat_template raised TypeError during dataset formatting. This fix adds a type guard to default to [] when messages is not a list. Additionally, optional training dependencies (peft, trl) are cleanly guarded to permit lightweight utility imports.