### PR TITLE
feat(ch8): add trajectory perturbation generator for safety gate evolution

### DIFF
--- a/chapter8/harness-safety-gate/evolution.py
+++ b/chapter8/harness-safety-gate/evolution.py
@@ -530,3 +530,30 @@ def write_candidate(candidate_source: str, path: Path) -> None:
     """只写候选制品路径，绝不覆盖稳定模块。"""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(candidate_source, encoding="utf-8")
+def generate_synthetic_perturbations(trajectories: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Generate synthetic edge-case perturbations (null args, whitespace, missing fields) for safety verifier testing."""
+    perturbed: List[Dict[str, Any]] = []
+    for traj in trajectories:
+        item = dict(traj)
+        tool_name = item.get("tool_name", "")
+        args = item.get("args")
+
+        # Perturbation 1: null args dictionary
+        item_null_args = dict(item)
+        item_null_args["args"] = None
+        item_null_args["id"] = f"{item.get('id', 'traj')}_null_args"
+        perturbed.append(item_null_args)
+
+        # Perturbation 2: empty tool name with risk args
+        item_empty_tool = dict(item)
+        item_empty_tool["tool_name"] = "  "
+        item_empty_tool["id"] = f"{item.get('id', 'traj')}_empty_tool"
+        perturbed.append(item_empty_tool)
+
+        # Perturbation 3: non-dict args
+        item_list_args = dict(item)
+        item_list_args["args"] = [tool_name, args]
+        item_list_args["id"] = f"{item.get('id', 'traj')}_list_args"
+        perturbed.append(item_list_args)
+
+    return perturbed

--- a/chapter8/harness-safety-gate/test_evolution.py
+++ b/chapter8/harness-safety-gate/test_evolution.py
@@ -143,6 +143,14 @@ class CandidateGateTest(unittest.TestCase):
                                  execute=execute, confirm_token=token)
         self.assertEqual("rejected", third["status"])
         self.assertEqual(1, len(calls))
+    def test_generate_synthetic_perturbations_creates_edge_cases(self):
+        from evolution import generate_synthetic_perturbations
+        sample = [{"id": "t1", "tool_name": "delete_file", "args": {"path": "/tmp/a"}}]
+        perturbed = generate_synthetic_perturbations(sample)
+        self.assertEqual(3, len(perturbed))
+        self.assertIsNone(perturbed[0]["args"])
+        self.assertEqual("  ", perturbed[1]["tool_name"])
+        self.assertIsInstance(perturbed[2]["args"], list)
 
     def test_suspended_call_never_reaches_executor(self):
         case = self.boundary[0]  # 第六章实验 6-5 的"高风险删除前确认"场景


### PR DESCRIPTION
Experiment 8-8 evaluates risk-based confirmation gates and self-evolution safety verifiers.

This change adds generate_synthetic_perturbations(trajectories) to chapter8/harness-safety-gate/evolution.py. It generates synthetic boundary perturbations (such as None argument structures, whitespace tool names, and list arguments) to stress-test trajectory safety verifiers against edge-case agent execution inputs.