### PR TITLE
fix(trajectory-verifier): handle null content in assistant messages

### DIFF
--- a/chapter8/trajectory-verifier/verifier.py
+++ b/chapter8/trajectory-verifier/verifier.py
@@ -66,7 +66,7 @@ def _assistant_text(trajectory: Dict[str, Any]) -> str:
     if not isinstance(messages, list):
         messages = []
     return "\n".join(
-        str(message.get("content", ""))
+        str(message.get("content") or "")
         for message in messages
         if isinstance(message, dict) and message.get("role") == "assistant"
     )

--- a/tests/test_ch8_assistant_text_null_content.py
+++ b/tests/test_ch8_assistant_text_null_content.py
@@ -1,0 +1,32 @@
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath("chapter8/trajectory-verifier"))
+
+from verifier import _assistant_text, ProcessVerifier, PASS
+
+
+def test_assistant_text_handles_null_content():
+    """Contract: _assistant_text does not output literal 'None' for assistant tool-call messages with content: None."""
+    trajectory = {
+        "messages": [
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "call_1"}]}
+        ]
+    }
+    assert _assistant_text(trajectory) == ""
+
+
+def test_process_verifier_privacy_tolerates_null_content_assistant_messages():
+    """Contract: ProcessVerifier._privacy does not flag false positive privacy leak on content: None assistant messages."""
+    trajectory = {
+        "messages": [
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "call_1"}]}
+        ],
+        "sensitive_values": [
+            {"label": "auth token", "value": "None"}
+        ]
+    }
+    pv = ProcessVerifier()
+    res = pv._privacy(trajectory)
+    assert res.verdict == PASS


### PR DESCRIPTION
Assistant messages in tool-calling trajectories may carry `content=None` per standard OpenAI format. Extracting assistant text converted `None` to literal `'None'`, polluting extracted text and causing false-positive verification flags.

This fix safely handles `content=None` by returning an empty string when content is falsy, and adds a regression test.