### PR TITLE
fix(trajectory-verifier): support DimensionResult objects in calibration_report

### DIFF
--- a/chapter8/trajectory-verifier/calibration.py
+++ b/chapter8/trajectory-verifier/calibration.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable
 
-from verifier import FAIL
+from verifier import FAIL, _item_get
 
 
 def calibration_report(
@@ -14,7 +14,7 @@ def calibration_report(
     dimensions = sorted({
         dimension
         for trajectory, _ in pairs
-        for dimension in trajectory.get("expert_labels", {})
+        for dimension in (trajectory.get("expert_labels") if isinstance(trajectory, dict) and isinstance(trajectory.get("expert_labels"), dict) else {})
     })
     per_dimension: Dict[str, Any] = {}
     total_equal = 0
@@ -22,10 +22,12 @@ def calibration_report(
     for dimension in dimensions:
         tp = fp = fn = tn = 0
         for trajectory, report in pairs:
-            expected = trajectory.get("expert_labels", {}).get(dimension)
+            labels = trajectory.get("expert_labels") if isinstance(trajectory, dict) and isinstance(trajectory.get("expert_labels"), dict) else {}
+            expected = labels.get(dimension)
             if expected is None:
                 continue
-            predicted_map = {item["dimension"]: item["verdict"] for item in report["dimensions"]}
+            dims = report.get("dimensions") if isinstance(report, dict) and isinstance(report.get("dimensions"), list) else getattr(report, "dimensions", [])
+            predicted_map = {_item_get(item, "dimension"): _item_get(item, "verdict") for item in dims}
             predicted = predicted_map.get(dimension)
             expected_fail = expected == FAIL
             predicted_fail = predicted == FAIL

--- a/chapter8/trajectory-verifier/test_calibration_report_dimension_result.py
+++ b/chapter8/trajectory-verifier/test_calibration_report_dimension_result.py
@@ -1,0 +1,29 @@
+import unittest
+
+from calibration import calibration_report
+from verifier import DimensionResult
+
+
+class TestCalibrationReportDimensionResult(unittest.TestCase):
+    def test_calibration_report_supports_dimension_result_objects(self):
+        """Contract: calibration_report handles report dimensions containing DimensionResult objects.
+
+        Locks out TypeError when report dimensions are DimensionResult dataclasses instead of dicts.
+        """
+        trajectory = {
+            "id": "t1",
+            "expert_labels": {"task_resolution": "pass"},
+        }
+        report = {
+            "trajectory_id": "t1",
+            "dimensions": [
+                DimensionResult("task_resolution", "environment_result", "pass", 1.0, ["ok"], 1.0)
+            ],
+        }
+        result = calibration_report([trajectory], [report])
+        self.assertEqual(1.0, result["exact_label_agreement"])
+        self.assertIn("task_resolution", result["per_dimension"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When `calibration_report` processes evaluation reports containing `DimensionResult` dataclass objects, subscripting `item['dimension']` raises `TypeError`.

This fix inspects `DimensionResult` objects via attribute access alongside dictionary items, and adds a test covering `DimensionResult` inputs.