### PR TITLE
fix(trajectory-verifier): tolerate non-dict result fields in _derive_claims_and_promises

### DIFF
--- a/chapter8/trajectory-verifier/customer_service_env.py
+++ b/chapter8/trajectory-verifier/customer_service_env.py
@@ -183,9 +183,12 @@ def _turn_precedes(candidate: Any, turn: Any) -> bool:
 
 def _derive_claims_and_promises(messages: list[dict[str, Any]], tool_calls: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     successful_turns: dict[str, list[int]] = {}
-    for item in tool_calls:
-        if item["result"].get("success"):
-            successful_turns.setdefault(item["name"], []).append(item["turn"])
+    if isinstance(tool_calls, list):
+        for item in tool_calls:
+            if isinstance(item, dict):
+                res = item.get("result")
+                if isinstance(res, dict) and res.get("success") and item.get("name") and item.get("turn") is not None:
+                    successful_turns.setdefault(item["name"], []).append(item["turn"])
     claims: list[dict[str, Any]] = []
     promises: list[dict[str, Any]] = []
     for message in messages:

--- a/chapter8/trajectory-verifier/test_derive_claims_promises_null_result.py
+++ b/chapter8/trajectory-verifier/test_derive_claims_promises_null_result.py
@@ -1,0 +1,24 @@
+import unittest
+
+from customer_service_env import _derive_claims_and_promises
+
+
+class TestDeriveClaimsPromisesNullResult(unittest.TestCase):
+    def test_derive_claims_and_promises_tolerates_non_dict_result(self):
+        """Contract: _derive_claims_and_promises handles tool calls with None or non-dict result fields.
+
+        Locks out AttributeError when tool_calls entries contain None, primitive, or missing result values.
+        """
+        messages = [{"role": "assistant", "content": "Your refund is completed", "turn": 2}]
+        tool_calls = [
+            {"name": "refund_order", "turn": 1, "result": None},
+            {"name": "refund_order", "turn": 1, "result": "error: timeout"},
+        ]
+        claims, promises = _derive_claims_and_promises(messages, tool_calls)
+        self.assertEqual(1, len(claims))
+        self.assertEqual("", claims[0]["supported_by"])
+        self.assertEqual(1, len(promises))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When trajectory tool calls record `result=None` or string error representations, `_derive_claims_and_promises` calls `item['result'].get('success')`, raising `AttributeError`.

This fix checks that `result` is a dictionary before calling `.get()`, and adds a regression test.