### PR TITLE
fix(timer-tools): handle timezone-aware expiry_time in status and loading

### DIFF
--- a/chapter4/collaboration-tools/src/timer_tools.py
+++ b/chapter4/collaboration-tools/src/timer_tools.py
@@ -254,8 +254,10 @@ async def get_timer_status(timer_id: str) -> Dict[str, Any]:
         
         # Recurring timers have an interval rather than a fixed expiry time.
         if timer["status"] == "active" and timer.get("type") != "recurring":
-            expiry = datetime.fromisoformat(timer["expiry_time"])
-            remaining = (expiry - datetime.now()).total_seconds()
+            expiry_str = timer["expiry_time"].replace("Z", "+00:00")
+            expiry = datetime.fromisoformat(expiry_str)
+            now = datetime.now(expiry.tzinfo) if expiry.tzinfo is not None else datetime.now()
+            remaining = (expiry - now).total_seconds()
             timer["remaining_seconds"] = max(0, int(remaining))
         
         return {
@@ -457,8 +459,10 @@ async def _load_timers():
                     continue
 
                 # Calculate remaining time
-                expiry = datetime.fromisoformat(timer_data["expiry_time"])
-                remaining = (expiry - datetime.now()).total_seconds()
+                expiry_str = timer_data["expiry_time"].replace("Z", "+00:00")
+                expiry = datetime.fromisoformat(expiry_str)
+                now = datetime.now(expiry.tzinfo) if expiry.tzinfo is not None else datetime.now()
+                remaining = (expiry - now).total_seconds()
                 
                 if remaining > 0:
                     # Timer still active, restart it

--- a/chapter4/collaboration-tools/test_timer_tools.py
+++ b/chapter4/collaboration-tools/test_timer_tools.py
@@ -155,6 +155,17 @@ class RecurringTimerPersistenceTests(unittest.IsolatedAsyncioTestCase):
             "completed",
         )
 
+    async def test_get_timer_status_timezone_aware_expiry(self):
+        expiry = datetime.now() + timedelta(seconds=3600)
+        timer_tools._active_timers["tz-timer"] = {
+            "timer_id": "tz-timer",
+            "status": "active",
+            "type": "one-shot",
+            "expiry_time": expiry.strftime("%Y-%m-%dT%H:%M:%S") + "+00:00",
+        }
+        result = await timer_tools.get_timer_status("tz-timer")
+        self.assertTrue(result["success"])
+        self.assertIn("remaining_seconds", result["timer"])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When a timer's `expiry_time` is parsed from an ISO string containing a timezone offset, `datetime.fromisoformat` yields a timezone-aware datetime. Subtracting timezone-naive `datetime.now()` raises `TypeError`.

This fix normalizes `expiry_time` comparison using timezone-aware UTC timestamps, and adds a test covering aware ISO strings.