### PR TITLE
fix(phone-agent): reject None values in critical dialogue completion fields

### DIFF
--- a/chapter9/phone-agent/agent.py
+++ b/chapter9/phone-agent/agent.py
@@ -340,8 +340,8 @@ def conversation_turn(
     if should_complete and not explicit:
         raise ValueError("model attempted completion without explicit confirmation")
     if should_complete and (
-        not str(completion.get("appointment_time", "")).strip()
-        or not str(completion.get("confirmation_number", "")).strip()
+        not str(completion.get("appointment_time") or "").strip()
+        or not str(completion.get("confirmation_number") or "").strip()
     ):
         raise ValueError("model attempted completion without both critical fields")
     if should_complete and (

--- a/chapter9/phone-agent/test_agent.py
+++ b/chapter9/phone-agent/test_agent.py
@@ -140,3 +140,34 @@ def test_model_errors_propagate_without_fallback():
     client = SimpleNamespace(chat=SimpleNamespace(completions=BrokenCompletions()))
     with pytest.raises(RuntimeError, match="provider unavailable"):
         react_plan("Call Jane and ask for the missing time", client=client, model="planner-test")
+def test_conversation_turn_rejects_none_critical_completion_fields():
+    plan = direct_plan(
+        callee_name="Jane",
+        goal="Confirm a time",
+        context="Tuesday afternoon",
+        instructions="Ask and confirm",
+    )
+    client = FakeClient(
+        [
+            {
+                "assistant_message": "Thanks.",
+                "explicit_confirmation_observed": True,
+                "should_complete": True,
+                "completion": {
+                    "result": "Local confirmation recorded.",
+                    "appointment_time": None,
+                    "confirmation_number": "MAPLE-7",
+                    "notes": "No external organization was contacted or booking made.",
+                },
+            }
+        ]
+    )
+    with pytest.raises(ValueError, match="without both critical fields"):
+        conversation_turn(
+            plan,
+            [],
+            "I explicitly confirm Maple seven.",
+            client=client,
+            model="planner-test",
+            provider_name="injected-test",
+        )


### PR DESCRIPTION
When model dialogue completion returns `None` for required fields like `appointment_time`, string conversion yields `'None'`, bypassing validation checks and returning `'None'` to callers.

This fix treats `None` completion field values as missing data, raising `ValueError` as expected, and adds a test.