### PR TITLE
fix(sparse-embedding): preserve words with apostrophes in TextProcessor.tokenize

### DIFF
--- a/chapter3/sparse-embedding/bm25_engine.py
+++ b/chapter3/sparse-embedding/bm25_engine.py
@@ -60,14 +60,16 @@ class TextProcessor:
             r'#[0-9A-Fa-f]{3,8}\b|0x[0-9A-Fa-f]+\b',
             # Numbers (including decimals)
             r'\b\d+(?:\.\d+)?\b',
+            # Words with apostrophes
+            r"\b[a-zA-Z]+'[a-zA-Z]+\b",
             # Acronyms and uppercase words (USA, NASA, API)
             r'\b[A-Z]{2,}\b',
             # Mixed case words (JavaScript, PyTorch)
             r'\b[A-Z][a-z]+[A-Z][a-zA-Z]*\b',
             # Alphanumeric combinations (Python3, ES6, 3DS)
             r'\b[A-Za-z]+\d+\b|\b\d+[A-Za-z]+\b',
-            # Regular words (including apostrophes)
-            r"\b[a-zA-Z]+(?:'[a-z]+)?\b",
+            # Regular words
+            r"\b[a-zA-Z]+\b",
         ]
         
         # Combine all patterns

--- a/chapter3/sparse-embedding/test_tokenize_apostrophes.py
+++ b/chapter3/sparse-embedding/test_tokenize_apostrophes.py
@@ -1,0 +1,10 @@
+import pytest
+from bm25_engine import TextProcessor
+
+
+def test_tokenize_preserves_apostrophe_contractions():
+    processor = TextProcessor()
+    tokens = processor.tokenize("don't user's it's text")
+    assert "don't" in tokens
+    assert "user's" in tokens
+    assert "it's" in tokens


### PR DESCRIPTION
Tokenizing words containing apostrophes (such as `user's` or `don't`) split tokens at the apostrophe or dropped apostrophe-attached suffixes due to regex patterns.

This fix updates tokenization regex to preserve apostrophe-joined words, and adds a test covering apostrophe terms.