### PR TITLE
fix(user-memory): preserve earliest created_at timestamp when consolidating notes

### DIFF
--- a/chapter3/user-memory/memory_manager.py
+++ b/chapter3/user-memory/memory_manager.py
@@ -310,6 +310,7 @@ class NotesMemoryManager(BaseMemoryManager):
             # Duplicate found - keep whichever is newer, union the tags.
             keeper, dropped = (existing, note) if existing.updated_at >= note.updated_at else (note, existing)
             keeper.tags = sorted(set(keeper.tags) | set(dropped.tags))
+            keeper.created_at = min(existing.created_at, note.created_at)
             keeper.updated_at = max(existing.updated_at, note.updated_at)
             if keeper is note:  # replace the reference we already stored
                 idx = deduped.index(existing)

--- a/chapter3/user-memory/test_consolidate_created_at.py
+++ b/chapter3/user-memory/test_consolidate_created_at.py
@@ -1,0 +1,31 @@
+import pytest
+from memory_manager import NotesMemoryManager, MemoryNote
+
+def test_consolidate_memories_preserves_earliest_created_at():
+    """Verify deduplicating identical memory notes retains the earliest created_at timestamp."""
+    mgr = NotesMemoryManager(user_id="test_created_at_user")
+    mgr.notes = [
+        MemoryNote(
+            note_id="note_old",
+            content="User prefers Python for AI development",
+            session_id="s1",
+            created_at="2026-01-01T10:00:00",
+            updated_at="2026-01-01T10:00:00",
+            tags=["pref"]
+        ),
+        MemoryNote(
+            note_id="note_new",
+            content="User prefers Python for AI development",
+            session_id="s2",
+            created_at="2026-01-10T15:00:00",
+            updated_at="2026-01-10T15:00:00",
+            tags=["language"]
+        )
+    ]
+
+    report = mgr.consolidate_memories(resolve_conflicts=False)
+
+    assert len(mgr.notes) == 1
+    assert mgr.notes[0].created_at == "2026-01-01T10:00:00"
+    assert mgr.notes[0].updated_at == "2026-01-10T15:00:00"
+    assert mgr.notes[0].tags == ["language", "pref"]


### PR DESCRIPTION
When memory consolidation merges duplicate user notes, the keeper note's `created_at` timestamp was overwritten with the newer note's timestamp.

This fix preserves the earliest `created_at` timestamp across consolidated duplicate notes, and adds a regression test.