### PR TITLE
fix(coding-agent): support killing background jobs in KillBashTool

### DIFF
--- a/chapter5/coding-agent/tests/test_kill_bash_tool.py
+++ b/chapter5/coding-agent/tests/test_kill_bash_tool.py
@@ -56,4 +56,17 @@ class TestKillBashTool:
         
         assert result.success
         assert result.data["shell_id"] == "default"
+    def test_kill_background_job(self, system_state):
+        """Test killing a background job using its background_job_id."""
+        bash_tool = BashTool(system_state)
+        kill_tool = KillBashTool(system_state)
+
+        res = bash_tool.execute({"command": "sleep 10", "run_in_background": True})
+        assert res.success
+        bg_id = res.data["background_job_id"]
+
+        result = kill_tool.execute({"shell_id": bg_id})
+        assert result.success
+        assert result.data["status"] == "terminated"
+        assert result.data["shell_id"] == bg_id
 

--- a/chapter5/coding-agent/tools/kill_bash_tool.py
+++ b/chapter5/coding-agent/tools/kill_bash_tool.py
@@ -23,19 +23,37 @@ class KillBashTool(BaseTool):
         """
         shell_id = params["shell_id"]
         
-        if shell_id not in self.state.shell_sessions:
-            return {"error": f"Shell session not found: {shell_id}"}
-        
-        try:
-            session = self.state.shell_sessions[shell_id]
-            session.kill()
-            del self.state.shell_sessions[shell_id]
-            
-            return {
-                "shell_id": shell_id,
-                "status": "terminated"
-            }
-            
-        except Exception as e:
-            return {"error": f"Error killing shell: {str(e)}"}
+        if shell_id in self.state.shell_sessions:
+            try:
+                session = self.state.shell_sessions[shell_id]
+                session.kill()
+                del self.state.shell_sessions[shell_id]
+                return {
+                    "shell_id": shell_id,
+                    "status": "terminated"
+                }
+            except Exception as e:
+                return {"error": f"Error killing shell: {str(e)}"}
+
+        for session in self.state.shell_sessions.values():
+            if shell_id in session.background_processes:
+                try:
+                    proc = session.background_processes.pop(shell_id)
+                    if isinstance(proc, int):
+                        import os
+                        import signal
+                        try:
+                            os.kill(proc, signal.SIGTERM)
+                        except ProcessLookupError:
+                            pass
+                    else:
+                        session._terminate_process(proc)
+                    return {
+                        "shell_id": shell_id,
+                        "status": "terminated"
+                    }
+                except Exception as e:
+                    return {"error": f"Error killing shell: {str(e)}"}
+
+        return {"error": f"Shell session not found: {shell_id}"}
 

--- a/chapter5/coding-agent/tools/shell_session.py
+++ b/chapter5/coding-agent/tools/shell_session.py
@@ -388,7 +388,9 @@ class ShellSession:
             if exit_code != 0:
                 raise RuntimeError(f"Unable to start background command: {output}")
             try:
-                return int(output.strip().splitlines()[-1])
+                pid = int(output.strip().splitlines()[-1])
+                self.background_processes[job_id] = pid
+                return pid
             except (IndexError, ValueError) as exc:
                 raise RuntimeError(
                     f"Unable to determine background command PID: {output}"

--- a/chapter5/coding-agent/tools/shell_session.py
+++ b/chapter5/coding-agent/tools/shell_session.py
@@ -6,6 +6,7 @@ import base64
 import os
 import queue
 import re
+import signal
 import shlex
 import shutil
 import subprocess
@@ -14,7 +15,7 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, TextIO, Tuple
+from typing import Dict, List, Optional, TextIO, Tuple, Union
 
 
 def get_background_log_path(job_id: str) -> str:
@@ -62,7 +63,7 @@ class ShellSession:
     output_buffer: str = ""
     shell_kind: str = field(default="", init=False)
     shell_command: List[str] = field(default_factory=list, init=False, repr=False)
-    background_processes: Dict[str, subprocess.Popen] = field(
+    background_processes: Dict[str, Union[subprocess.Popen, int]] = field(
         default_factory=dict, init=False, repr=False
     )
 
@@ -235,8 +236,16 @@ class ShellSession:
         self.start()
 
     @staticmethod
-    def _terminate_process(process: Optional[subprocess.Popen]) -> None:
-        if process is None or process.poll() is not None:
+    def _terminate_process(process: Optional[Union[subprocess.Popen, int]]) -> None:
+        if process is None:
+            return
+        if isinstance(process, int):
+            try:
+                os.kill(process, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            return
+        if process.poll() is not None:
             return
         process.terminate()
         try:


### PR DESCRIPTION
When `KillBashTool` receives a background job ID, attempting session termination failed because job ID mapping was unhandled.

This fix routes background job IDs through session process termination and returns standard exit status, backed by a unit test.