### PR TITLE
fix(arxiv): handle case-insensitive arXiv prefix in paper ID

### DIFF
--- a/chapter4/perception-tools/src/arxiv_enhanced.py
+++ b/chapter4/perception-tools/src/arxiv_enhanced.py
@@ -34,7 +34,7 @@ async def get_paper_details(
         TextContent with paper details
     """
     try:
-        clean_id = paper_id.replace("arxiv:", "").strip()
+        clean_id = re.sub(r"^arxiv:", "", paper_id, flags=re.IGNORECASE).strip()
         
         logging.info(f"📄 Getting paper details: {clean_id}")
         
@@ -104,7 +104,7 @@ async def download_paper(
     try:
         from pathlib import Path
         
-        clean_id = paper_id.replace("arxiv:", "").strip()
+        clean_id = re.sub(r"^arxiv:", "", paper_id, flags=re.IGNORECASE).strip()
         
         logging.info(f"📥 Downloading paper: {clean_id}")
         

--- a/chapter4/perception-tools/test_arxiv_request_bounds.py
+++ b/chapter4/perception-tools/test_arxiv_request_bounds.py
@@ -67,3 +67,14 @@ def test_search_arxiv_bounds_client_page_size(monkeypatch):
     }
     assert payload["success"] is True
     assert payload["message"]["count"] == 1
+def test_download_paper_case_insensitive_arxiv_prefix():
+    import arxiv_enhanced
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        result = loop.run_until_complete(arxiv_enhanced.download_paper("arXiv:2301.07041"))
+        payload = json.loads(result.text)
+        assert payload["success"] is True or "Invalid arXiv paper ID" not in payload["message"]
+        assert "Invalid arXiv paper ID: arXiv:2301.07041" not in payload["message"]
+    finally:
+        loop.close()

--- a/chapter4/perception-tools/test_arxiv_request_bounds.py
+++ b/chapter4/perception-tools/test_arxiv_request_bounds.py
@@ -67,14 +67,30 @@ def test_search_arxiv_bounds_client_page_size(monkeypatch):
     }
     assert payload["success"] is True
     assert payload["message"]["count"] == 1
-def test_download_paper_case_insensitive_arxiv_prefix():
+def test_download_paper_case_insensitive_arxiv_prefix(monkeypatch, tmp_path):
     import arxiv_enhanced
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        result = loop.run_until_complete(arxiv_enhanced.download_paper("arXiv:2301.07041"))
-        payload = json.loads(result.text)
-        assert payload["success"] is True or "Invalid arXiv paper ID" not in payload["message"]
-        assert "Invalid arXiv paper ID: arXiv:2301.07041" not in payload["message"]
-    finally:
-        loop.close()
+
+    class FakeResponse:
+        content = b"%PDF-1.7\n" + b"0" * 1000
+        headers = {"content-type": "application/pdf"}
+
+        def raise_for_status(self):
+            pass
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            pass
+
+        async def get(self, _url):
+            return FakeResponse()
+
+    monkeypatch.setattr(arxiv_enhanced.httpx, "AsyncClient", FakeClient)
+    result = asyncio.run(
+        arxiv_enhanced.download_paper("arXiv:2301.07041", download_dir=str(tmp_path))
+    )
+    payload = json.loads(result.text)
+    assert payload["success"] is True
+    assert payload["message"]["paper_id"] == "2301.07041"


### PR DESCRIPTION
Passing arXiv paper IDs with uppercase or mixed-case prefixes like `arXiv:2301.07041` failed prefix stripping because only lowercase `arxiv:` was replaced.

This fix strips the prefix case-insensitively using regex matching, and adds a test covering mixed-case arXiv prefixes.