### PR TITLE
fix(star-history): make the x-axis adapt to the length of the history

### DIFF
--- a/scripts/gen_star_history.py
+++ b/scripts/gen_star_history.py
@@ -24,7 +24,7 @@ import subprocess
 import sys
 import time
 import urllib.request
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import matplotlib
@@ -47,6 +47,13 @@ THEMES = {
     "light": dict(bg="#ffffff", text="#1f2328", subtext="#6a737d", grid="#dfe3e8"),
     "dark": dict(bg="#0d1117", text="#e6edf3", subtext="#8b949e", grid="#272d35"),
 }
+
+# Upper bound on x-axis labels. The real guarantee comes from measuring the
+# rendered labels (see thin_xticklabels); this just keeps the tick step sane.
+MAX_XTICKS = 12
+DAY_STEPS = (1, 2, 3, 7, 14)  # days between ticks
+MONTH_STEPS = (1, 2, 3, 6)
+YEAR_STEPS = (1, 2, 5, 10)
 
 
 def get_token() -> str | None:
@@ -124,6 +131,87 @@ def build_series(starred: list[str], start: datetime) -> tuple[np.ndarray, np.nd
     return np.array(x), np.array(y)
 
 
+def pick_xticks(x0: float, x1: float) -> tuple[list[float], str]:
+    """Evenly spaced x tick positions plus a date format for the given span.
+
+    Ticks are anchored at the newest date and step backwards, so the latest
+    day is always labeled. The granularity coarsens from days to months to
+    years as the history grows, keeping the label count at or below
+    MAX_XTICKS instead of drawing one tick per day forever.
+    """
+    start = mdates.num2date(x0)
+    end = mdates.num2date(x1)
+    span_days = x1 - x0
+
+    for step in DAY_STEPS:
+        if span_days / step <= MAX_XTICKS:
+            anchor = end.replace(hour=0, minute=0, second=0, microsecond=0)
+            ticks = []
+            while (num := mdates.date2num(anchor)) >= x0:
+                ticks.append(num)
+                anchor -= timedelta(days=step)
+            fmt = "%b %-d" if start.year == end.year else "%b %-d, %Y"
+            return sorted(ticks), fmt
+
+    span_months = (end.year - start.year) * 12 + end.month - start.month
+    for step in MONTH_STEPS:
+        if span_months / step <= MAX_XTICKS:
+            # Month starts read better than an offset from "today" here.
+            year, month = end.year, end.month
+            ticks = []
+            while (num := mdates.date2num(end.replace(
+                year=year, month=month, day=1, hour=0, minute=0, second=0, microsecond=0
+            ))) >= x0:
+                ticks.append(num)
+                month -= step
+                while month < 1:
+                    month += 12
+                    year -= 1
+            fmt = "%b %Y" if start.year != end.year else "%b"
+            return sorted(ticks), fmt
+
+    # Year granularity is the coarsest fallback, so widen the step as far as
+    # needed rather than giving up and returning a crowded axis.
+    span_years = end.year - start.year
+    step = next(
+        (s for s in YEAR_STEPS if span_years / s <= MAX_XTICKS),
+        max(1, -(-span_years // MAX_XTICKS)),
+    )
+    year = end.year
+    ticks = []
+    while (num := mdates.date2num(end.replace(
+        year=year, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+    ))) >= x0:
+        ticks.append(num)
+        year -= step
+    return sorted(ticks), "%Y"
+
+
+def thin_xticklabels(fig, ax, min_gap: float = 14.0) -> None:
+    """Drop every n-th label until neighbours no longer crowd each other.
+
+    pick_xticks bounds the tick *count*, but whether the labels actually fit
+    depends on the rendered text width and figure size, so measure the drawn
+    labels and thin from the right (keeping the newest date) until every pair
+    is at least `min_gap` pixels apart.
+    """
+    ticks = list(ax.get_xticks())
+    for keep in range(1, max(len(ticks), 1) + 1):
+        kept = ticks[::-1][::keep][::-1]
+        ax.set_xticks(kept)
+        fig.canvas.draw()
+        renderer = fig.canvas.get_renderer()
+        boxes = [
+            lbl.get_window_extent(renderer=renderer)
+            for lbl in ax.get_xticklabels()
+            if lbl.get_text()
+        ]
+        if all(
+            nxt.x0 - cur.x1 >= min_gap for cur, nxt in zip(boxes, boxes[1:])
+        ):
+            return
+
+
 def draw(x: np.ndarray, y: np.ndarray, repo: str, theme_name: str, theme: dict, out: Path) -> None:
     bg, text, subtext, grid = theme["bg"], theme["text"], theme["subtext"], theme["grid"]
 
@@ -180,9 +268,11 @@ def draw(x: np.ndarray, y: np.ndarray, repo: str, theme_name: str, theme: dict, 
         ax.spines[side].set_visible(False)
     ax.spines["bottom"].set_color(grid)
     ax.tick_params(axis="both", length=0, labelsize=11.5, colors=subtext, pad=8)
-    ax.xaxis.set_major_locator(mdates.DayLocator())
-    ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %-d"))
+    ticks, date_fmt = pick_xticks(*ax.get_xlim())
+    ax.set_xticks(ticks)
+    ax.xaxis.set_major_formatter(mdates.DateFormatter(date_fmt))
     ax.yaxis.set_major_formatter(FuncFormatter(lambda v, _pos: f"{int(v):,}"))
+    thin_xticklabels(fig, ax)
 
     fig.savefig(out, facecolor=bg, bbox_inches="tight", pad_inches=0.3)
     plt.close(fig)


### PR DESCRIPTION
## Problem

`gen_star_history.py` set `mdates.DayLocator()` unconditionally, so the x-axis drew one tick per day no matter how long the history got. At the current ~24-day span the labels already ran together with no gap:

```
Jul 15Jul 16Jul 17Jul 18Jul 19Jul 20Jul 21Jul 22Jul 23Jul 24...
```

Since the chart is regenerated daily by `.github/workflows/star-history.yml`, this got monotonically worse — a year in, it would have been 365 labels on top of each other.

## Fix

Two layers, because either alone is insufficient:

1. **`pick_xticks(x0, x1)`** — derive tick positions from the span rather than hard-coding days. It walks day → month → year granularities (`1/2/3/7/14` days, `1/2/3/6` months, `1/2/5/10` years) and takes the first step whose label count fits under `MAX_XTICKS = 12`, widening the year step without bound as a final fallback. Ticks are anchored at the **newest** date and step backwards, so the latest day is always labeled. The date format coarsens with the span, and picks up a year when the range straddles one.

2. **`thin_xticklabels(fig, ax)`** — a bounded tick *count* still isn't proof the *text* fits, since that depends on rendered label width, font size, and figure geometry. So measure the drawn labels via `get_window_extent` and drop every n-th (keeping the newest) until every neighbouring pair clears a 14 px gap.

## Verification

Rendered 23 synthetic spans from 1 day to 50 years, re-measuring label bounding boxes after each draw. No overlapping pair in any of them:

| span | labels | min gap | format |
|---|---|---|---|
| 6d | 7 | 213.5 px | `Jul 15` |
| 24d | 9 | 133.2 px | `Jul 15` |
| 30d | 11 | 67.5 px | `Jul 15` |
| 90d | 7 | 177.9 px | `Jul 23` |
| 365d | 6 | 145.4 px | `Sep 2026` |
| 1825d | 11 | 27.0 px | `Mar 2027` |
| 18250d | 11 | 98.9 px | `2032` |

The reported 24-day case now renders 9 evenly spaced labels (`Jul 15 … Aug 8`) instead of 24 colliding ones.

## Notes

- Script-only change. `assets/star-history-{light,dark}.png` are left untouched — the daily workflow regenerates them with fresh stargazer data on its next run, which is more current than anything I could commit from a local cache.
- No new dependencies; still just matplotlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)