### PR TITLE
feat: support direct Alibaba Cloud Qwen API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@ OPENROUTER_MODEL=google/gemma-4-31b-it:free
 # SiliconFlow (Qwen)
 # SILICONFLOW_API_KEY=your-siliconflow-key
 
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+# Mainland-region key:
+# DASHSCOPE_API_KEY=your-dashscope-key
+# International-region key (use this endpoint with an international key):
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+
 # DeepSeek
 # DEEPSEEK_API_KEY=your-deepseek-key
 # DEEPSEEK_BASE_URL=https://api.deepseek.com

--- a/agentbook/providers/legacy.py
+++ b/agentbook/providers/legacy.py
@@ -26,7 +26,7 @@ from .resolution import build_openrouter_backend
 __all__ = ["resolve_llm_backend"]
 
 _NO_KEY_MESSAGE = (
-    "No API key found. Set a provider key (SILICONFLOW_API_KEY / ARK_API_KEY / "
+    "No API key found. Set a provider key (DASHSCOPE_API_KEY / SILICONFLOW_API_KEY / ARK_API_KEY / "
     "MOONSHOT_API_KEY / DEEPSEEK_API_KEY / ZHIPU_API_KEY / OPENAI_API_KEY / "
     "GEMINI_API_KEY) or OPENROUTER_API_KEY (universal fallback). " + ZERO_COST_HINT
 )

--- a/agentbook/providers/registry.py
+++ b/agentbook/providers/registry.py
@@ -23,6 +23,17 @@ __all__ = [
 ]
 
 PROVIDERS: dict[str, Provider] = {
+    "dashscope": Provider(
+        name="dashscope",
+        # Alibaba Cloud Model Studio (Bailian) keys are region-bound. Default
+        # to the mainland endpoint for this Chinese-first project; readers
+        # using an international-region key can set DASHSCOPE_BASE_URL to the
+        # Singapore endpoint documented in the experiment README.
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        default_model="qwen3.7-plus",
+        key_vars=("DASHSCOPE_API_KEY",),
+        base_url_var="DASHSCOPE_BASE_URL",
+    ),
     "siliconflow": Provider(
         name="siliconflow",
         base_url="https://api.siliconflow.cn/v1",
@@ -94,7 +105,15 @@ PROVIDERS: dict[str, Provider] = {
 }
 
 # Provider names used interchangeably in the chapters, mapped to canonical ones.
-_ALIASES = {"moonshot": "kimi", "ark": "doubao", "google": "gemini"}
+_ALIASES = {
+    "moonshot": "kimi",
+    "ark": "doubao",
+    "google": "gemini",
+    # "Qwen" is the model family and "Bailian" is the product name; both
+    # select Alibaba's DashScope-compatible endpoint rather than SiliconFlow.
+    "qwen": "dashscope",
+    "bailian": "dashscope",
+}
 
 # Every accepted name, canonical plus aliases. Chapter CLIs use this for their
 # --provider choices so a new registry entry is immediately selectable instead

--- a/chapter1/README.en.md
+++ b/chapter1/README.en.md
@@ -8,7 +8,7 @@
 
 | Exp. | Project | Type | Description |
 | :--: | --- | :--: | --- |
-| 1-1 | [context](context/) | ✅ | Demonstrates the importance of various Agent context components through systematic ablation experiments. Supports multiple LLM providers (SiliconFlow Qwen, ByteDance Doubao, Moonshot Kimi), allowing configuration of different context modes to observe changes in Agent behavior. |
+| 1-1 | [context](context/) | ✅ | Demonstrates the importance of various Agent context components through systematic ablation experiments. Supports direct Alibaba Cloud Model Studio Qwen plus SiliconFlow Qwen, ByteDance Doubao, Moonshot Kimi, and other providers. |
 | 1-2 | [web-search-agent](web-search-agent/) | ✅ | Implements an Agent with basic deep search capabilities, capable of multi-round searching and information integration. |
 | 1-3 | [search-codegen](search-codegen/) | ✅ | Builds an Agent with basic deep search and code sandbox capabilities, utilizing tools like web search and code execution for complex analysis. |
 | 7-1, 7-2 | [learning-from-experience](learning-from-experience/) | ✅ | Compares traditional reinforcement learning (Q-learning) with LLM-based in-context learning, reproducing key insights from Shunyu Yao's "The Second Half" blog post. Demonstrates how LLMs can surpass traditional RL with 250-400x sample efficiency through a treasure hunt game. |

--- a/chapter1/README.md
+++ b/chapter1/README.md
@@ -14,7 +14,7 @@ Responses API（hosted web_search + code_interpreter）实测通过全部验收�
 
 | 编号 | 项目 | 类型 | 一句话说明 |
 | :--: | --- | :--: | --- |
-| 1-1 | [context](context/) | ✅ | 系统性消融实验展示 Agent 上下文各组件的重要性；支持 SiliconFlow Qwen、字节 Doubao、月之暗面 Kimi 等多提供商 |
+| 1-1 | [context](context/) | ✅ | 系统性消融实验展示 Agent 上下文各组件的重要性；支持阿里云百炼直连 Qwen、SiliconFlow Qwen、字节 Doubao、月之暗面 Kimi 等多提供商 |
 | 1-2 | [web-search-agent](web-search-agent/) | ✅ | Kimi K3 模型即 Agent，具备基础深度搜索能力，能进行多轮搜索和信息整合 |
 | 1-3 | [search-codegen](search-codegen/) | ✅ | 模型自主多轮搜索 + 服务端代码执行的 Deep Research 闭环，先澄清意图再执行；官方 GPT-5.6 路径保留，阿里云百炼 qwen3.7-plus（hosted web_search + code_interpreter）实测通过东盟首都距离与比特币技术分析全部验收门 |
 | 7-1, 7-2 | [learning-from-experience](learning-from-experience/) | ✅ | 10,000 局 Q-learning + 100 局评估与官方 Kimi K3 第一局双臂实测已验收；[证据](learning-from-experience/validation/20260730_011704/evidence.json)记录 Kimi 17 步成功、零 fallback 及历史点估计差异 |

--- a/chapter1/context/README.md
+++ b/chapter1/context/README.md
@@ -11,11 +11,11 @@
 
 ### Overview
 
-This project implements a context-aware AI agent with multiple tools (PDF parsing, currency conversion, calculator, code interpreter) and provides comprehensive ablation testing to explore how different context components affect agent behavior and performance. It supports multiple LLM providers: SiliconFlow Qwen, ByteDance Doubao, Moonshot Kimi, and DeepSeek.
+This project implements a context-aware AI agent with multiple tools (PDF parsing, currency conversion, calculator, code interpreter) and provides comprehensive ablation testing to explore how different context components affect agent behavior and performance. It supports multiple LLM providers, including Qwen directly through Alibaba Cloud Model Studio (Bailian), SiliconFlow Qwen, ByteDance Doubao, Moonshot Kimi, and DeepSeek.
 
 ### Key Features
 
-- **Multi-provider Support**: Works with SiliconFlow (Qwen), Doubao (ByteDance), Kimi (Moonshot), and DeepSeek LLMs
+- **Multi-provider Support**: Works with Alibaba Cloud Model Studio (Qwen), SiliconFlow (Qwen), Doubao (ByteDance), Kimi (Moonshot), and DeepSeek LLMs
 - **Multi-tool Agent**: PDF parsing, currency conversion, calculations, and Python code execution
 - **Context Modes**: Five different context configurations for ablation studies
 - **Interactive & Batch Modes**: Run single tasks or comprehensive test suites
@@ -35,6 +35,13 @@ This project implements a context-aware AI agent with multiple tools (PDF parsin
 - **Model**: `Qwen/Qwen3.5-397B-A17B` (customizable)
 - **API**: OpenAI-compatible
 - **Best for**: Complex reasoning tasks, detailed analysis
+
+#### Alibaba Cloud Model Studio / Bailian (Qwen)
+
+- **Model**: `qwen3.7-plus` (customizable with `--model`)
+- **API**: Direct OpenAI-compatible DashScope endpoint; no SiliconFlow account required
+- **Provider names**: `dashscope` (canonical), with `qwen` and `bailian` aliases
+- **Region note**: API keys are region-bound. Mainland keys use the default endpoint; international keys must set `DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1`
 
 #### Kimi (Moonshot AI)
 
@@ -71,6 +78,7 @@ This project implements a context-aware AI agent with multiple tools (PDF parsin
 
 - Python 3.10+
 - API key for one of the supported providers:
+  - **Alibaba Cloud Model Studio / Bailian**: Get from [Model Studio](https://bailian.console.aliyun.com/)
   - **SiliconFlow**: Get from [SiliconFlow](https://siliconflow.cn)
   - **Doubao (ByteDance)**: Get from [Volcano Engine](https://www.volcengine.com/)
   - **Kimi (Moonshot)**: Get from [Moonshot Platform](https://platform.moonshot.cn/)
@@ -113,7 +121,7 @@ cd chapter1/context
 
 # Copy and configure environment
 cp env.example .env
-# Edit .env and add your API key (SILICONFLOW_API_KEY or ARK_API_KEY)
+# Edit .env and add one provider key (for example DASHSCOPE_API_KEY or ARK_API_KEY)
 ```
 
 #### 2. Configure Provider
@@ -126,6 +134,13 @@ python main.py  # Uses Doubao by default
 # For SiliconFlow (Qwen)
 export SILICONFLOW_API_KEY=your_key_here
 python main.py --provider siliconflow
+
+# For Qwen directly through Alibaba Cloud Model Studio / Bailian
+export DASHSCOPE_API_KEY=your_key_here
+python main.py --provider dashscope
+# --provider qwen and --provider bailian are equivalent aliases.
+# For an international-region key, also set:
+export DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
 # For Kimi (Moonshot)
 export MOONSHOT_API_KEY=your_key_here
@@ -150,9 +165,13 @@ python main.py                       # falls back to OpenRouter when ARK_API_KEY
 python main.py --provider openrouter # or use OpenRouter directly
 ```
 
-#### 3. Testing Kimi / DeepSeek Integration
+#### 3. Testing Qwen / Kimi / DeepSeek Integration
 
 ```bash
+# Run the ablation study directly on Alibaba Cloud Qwen
+export DASHSCOPE_API_KEY=your_key_here
+python main.py --provider dashscope --mode ablation
+
 # Quick test of Kimi K3 model
 export MOONSHOT_API_KEY=your_key_here
 python tests/manual/check_kimi.py
@@ -247,6 +266,13 @@ summary table:
 
 ```bash
 python run_experiment_1_1.py --provider kimi --model kimi-k3 --max-iterations 5
+```
+
+The same evidence runner can use a Bailian key directly:
+
+```bash
+export DASHSCOPE_API_KEY=your_key_here
+python run_experiment_1_1.py --provider dashscope --model qwen3.7-plus --max-iterations 5
 ```
 
 The accepted artifact is [validation/latest.json](validation/latest.json). All
@@ -476,11 +502,11 @@ context/
 
 ### 概述
 
-本项目实现一个上下文感知 AI Agent，配备多种工具（PDF 解析、货币换算、计算器、代码解释器），并通过系统化的**消融实验**（Ablation Study）检验不同上下文组件对 Agent 行为与性能的影响。支持多家 LLM 提供商：SiliconFlow Qwen、字节跳动 Doubao、月之暗面 Kimi、DeepSeek。对应书中**实验 1-1 ★★：上下文的关键作用**。
+本项目实现一个上下文感知 AI Agent，配备多种工具（PDF 解析、货币换算、计算器、代码解释器），并通过系统化的**消融实验**（Ablation Study）检验不同上下文组件对 Agent 行为与性能的影响。支持通过阿里云百炼直连 Qwen，也支持 SiliconFlow Qwen、字节跳动 Doubao、月之暗面 Kimi、DeepSeek。对应书中**实验 1-1 ★★：上下文的关键作用**。
 
 ### 主要特性
 
-- **多提供商支持**：SiliconFlow（Qwen）、Doubao（字节）、Kimi（月之暗面）、DeepSeek
+- **多提供商支持**：阿里云百炼（Qwen 直连）、SiliconFlow（Qwen）、Doubao（字节）、Kimi（月之暗面）、DeepSeek
 - **多工具 Agent**：PDF 解析、货币换算、计算与 Python 代码执行
 - **上下文模式**：五种配置，用于消融对照
 - **交互与批处理**：单任务运行或完整测试套件
@@ -500,6 +526,13 @@ context/
 - **模型**：`Qwen/Qwen3.5-397B-A17B`（可自定义）
 - **API**：OpenAI 兼容
 - **适合**：复杂推理与细致分析
+
+#### 阿里云百炼（Qwen 直连）
+
+- **模型**：`qwen3.7-plus`（可通过 `--model` 自定义）
+- **API**：直连 DashScope 的 OpenAI 兼容接口，无需 SiliconFlow 账号
+- **提供商名称**：规范名称为 `dashscope`，也可使用别名 `qwen` 或 `bailian`
+- **区域说明**：API Key 与区域绑定。中国内地 Key 默认直连内地端点；国际站 Key 必须设置 `DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1`
 
 #### Kimi（月之暗面）
 
@@ -536,6 +569,7 @@ context/
 
 - Python 3.10+
 - 任一支持提供商的 API Key：
+  - **阿里云百炼**：[百炼控制台](https://bailian.console.aliyun.com/)
   - **SiliconFlow**：[SiliconFlow](https://siliconflow.cn)
   - **Doubao（字节）**：[火山引擎](https://www.volcengine.com/)
   - **Kimi（月之暗面）**：[Moonshot Platform](https://platform.moonshot.cn/)
@@ -578,7 +612,7 @@ cd chapter1/context
 
 # 复制并配置环境变量
 cp env.example .env
-# 编辑 .env 并填入你的 API Key（SILICONFLOW_API_KEY 或 ARK_API_KEY）
+# 编辑 .env 并填入一个提供商的 API Key（例如 DASHSCOPE_API_KEY 或 ARK_API_KEY）
 ```
 
 #### 2. 配置提供商
@@ -591,6 +625,13 @@ python main.py  # Uses Doubao by default
 # For SiliconFlow (Qwen)
 export SILICONFLOW_API_KEY=your_key_here
 python main.py --provider siliconflow
+
+# 通过阿里云百炼直连 Qwen
+export DASHSCOPE_API_KEY=your_key_here
+python main.py --provider dashscope
+# --provider qwen 与 --provider bailian 是等价别名。
+# 如果使用国际站 Key，还需设置：
+export DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
 # For Kimi (Moonshot)
 export MOONSHOT_API_KEY=your_key_here
@@ -615,9 +656,13 @@ python main.py                       # falls back to OpenRouter when ARK_API_KEY
 python main.py --provider openrouter # or use OpenRouter directly
 ```
 
-#### 3. 测试 Kimi / DeepSeek 集成
+#### 3. 测试 Qwen / Kimi / DeepSeek 集成
 
 ```bash
+# 通过阿里云百炼 Qwen 直接运行消融实验
+export DASHSCOPE_API_KEY=your_key_here
+python main.py --provider dashscope --mode ablation
+
 # Quick test of Kimi K3 model
 export MOONSHOT_API_KEY=your_key_here
 python tests/manual/check_kimi.py
@@ -711,6 +756,13 @@ python main.py --mode ablation --ablation-modes full no_history --output my_abla
 
 ```bash
 python run_experiment_1_1.py --provider kimi --model kimi-k3 --max-iterations 5
+```
+
+同一证据运行器也支持直接使用百炼 Key：
+
+```bash
+export DASHSCOPE_API_KEY=your_key_here
+python run_experiment_1_1.py --provider dashscope --model qwen3.7-plus --max-iterations 5
 ```
 
 验收产物见 [validation/latest.json](validation/latest.json)。五组上下文契约全部通过；

--- a/chapter1/context/agent.py
+++ b/chapter1/context/agent.py
@@ -379,8 +379,9 @@ class ContextAwareAgent:
         Args:
             api_key: API key for the LLM provider
             context_mode: Context mode for ablation studies
-            provider: LLM provider ('siliconflow', 'doubao', 'kimi', 'moonshot',
-                'deepseek', or 'openrouter')
+            provider: Any provider registered in ``agentbook.providers`` (for
+                example ``dashscope``/``qwen``, ``siliconflow``, ``doubao``,
+                ``kimi``, ``deepseek``, or ``openrouter``)
             model: Optional model override
             verbose: If True, log full HTTP requests and responses (default: True)
         """

--- a/chapter1/context/config.py
+++ b/chapter1/context/config.py
@@ -55,6 +55,11 @@ class Config:
     LLM_PROVIDER: str = os.getenv("LLM_PROVIDER", "doubao").lower()
     
     # API Configuration
+    DASHSCOPE_API_KEY: str = os.getenv("DASHSCOPE_API_KEY", "")
+    DASHSCOPE_BASE_URL: str = os.getenv(
+        "DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    )
+
     SILICONFLOW_API_KEY: str = os.getenv("SILICONFLOW_API_KEY", "")
     SILICONFLOW_BASE_URL: str = "https://api.siliconflow.cn/v1"
     
@@ -198,13 +203,16 @@ class Config:
     @classmethod
     def print_config(cls):
         """Print current configuration (hiding sensitive data)"""
+        provider = canonical_provider(cls.LLM_PROVIDER)
+        api_key = cls.get_api_key(provider)
         print("\n" + "="*50)
         print("CONFIGURATION")
         print("="*50)
+        print(f"Provider: {provider}")
         print(f"Model: {cls.MODEL_NAME}")
         print(f"Temperature: {cls.MODEL_TEMPERATURE}")
         print(f"Max Tokens: {cls.MODEL_MAX_TOKENS}")
         print(f"Max Iterations: {cls.MAX_ITERATIONS}")
-        print(f"API Key Set: {'Yes' if cls.SILICONFLOW_API_KEY else 'No'}")
+        print(f"API Key Set: {'Yes' if api_key else 'No'}")
         print(f"Log Level: {cls.LOG_LEVEL}")
         print("="*50 + "\n")

--- a/chapter1/context/env.example
+++ b/chapter1/context/env.example
@@ -1,8 +1,13 @@
-# LLM Provider Configuration (siliconflow, doubao, kimi, moonshot, deepseek, or zhipu)
+# LLM Provider Configuration (dashscope/qwen, siliconflow, doubao, kimi,
+# moonshot, deepseek, zhipu, openrouter, or ollama)
 LLM_PROVIDER=doubao
 
 # API Keys (set the appropriate one for your provider)
 SILICONFLOW_API_KEY=your_siliconflow_api_key_here
+# Alibaba Cloud Model Studio (Bailian) / Qwen
+DASHSCOPE_API_KEY=your_dashscope_api_key_here
+# Optional: use this instead for an international-region key
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 ARK_API_KEY=your_ark_api_key_here
 MOONSHOT_API_KEY=your_moonshot_api_key_here
 DEEPSEEK_API_KEY=your_deepseek_api_key_here

--- a/chapter1/context/main.py
+++ b/chapter1/context/main.py
@@ -1133,7 +1133,7 @@ def main():
     parser.add_argument(
         "--api-key",
         type=str,
-        help="LLM 提供商的 API Key（也可通过环境变量 SILICONFLOW_API_KEY/ARK_API_KEY/MOONSHOT_API_KEY/DEEPSEEK_API_KEY/ZHIPU_API_KEY 设置；缺失主 key 时可用 OPENROUTER_API_KEY 兜底）"
+        help="LLM 提供商的 API Key（也可通过对应环境变量设置，例如 DASHSCOPE_API_KEY、SILICONFLOW_API_KEY、ARK_API_KEY、MOONSHOT_API_KEY、DEEPSEEK_API_KEY 或 ZHIPU_API_KEY；缺失主 key 时可用 OPENROUTER_API_KEY 兜底）"
     )
     parser.add_argument(
         "--output",

--- a/chapter1/context/run_experiment_1_1.py
+++ b/chapter1/context/run_experiment_1_1.py
@@ -40,6 +40,9 @@ rates yourself; use the tool observations."""
 
 EXPECTED_NUMBERS = ("9602895.73", "2400723.93")
 KEY_ENV = {
+    "dashscope": ("DASHSCOPE_API_KEY",),
+    "qwen": ("DASHSCOPE_API_KEY",),
+    "bailian": ("DASHSCOPE_API_KEY",),
     "kimi": ("MOONSHOT_API_KEY", "KIMI_API_KEY"),
     "moonshot": ("MOONSHOT_API_KEY", "KIMI_API_KEY"),
     "doubao": ("ARK_API_KEY",),

--- a/chapter1/context/tests/manual/check_conversation_history.py
+++ b/chapter1/context/tests/manual/check_conversation_history.py
@@ -22,12 +22,26 @@ def test_conversation_history():
     print("=" * 50)
     
     # Get API key (use any available provider)
-    api_key = os.getenv("ARK_API_KEY") or os.getenv("MOONSHOT_API_KEY") or os.getenv("SILICONFLOW_API_KEY")
-    provider = "doubao" if os.getenv("ARK_API_KEY") else ("kimi" if os.getenv("MOONSHOT_API_KEY") else "siliconflow")
+    api_key = (
+        os.getenv("ARK_API_KEY")
+        or os.getenv("DASHSCOPE_API_KEY")
+        or os.getenv("MOONSHOT_API_KEY")
+        or os.getenv("SILICONFLOW_API_KEY")
+    )
+    provider = (
+        "doubao"
+        if os.getenv("ARK_API_KEY")
+        else (
+            "dashscope"
+            if os.getenv("DASHSCOPE_API_KEY")
+            else ("kimi" if os.getenv("MOONSHOT_API_KEY") else "siliconflow")
+        )
+    )
     
     if not api_key:
         print("❌ No API key found. Please set one of:")
         print("  - ARK_API_KEY")
+        print("  - DASHSCOPE_API_KEY")
         print("  - MOONSHOT_API_KEY")
         print("  - SILICONFLOW_API_KEY")
         return False

--- a/chapter1/context/tests/manual/check_provider_config.py
+++ b/chapter1/context/tests/manual/check_provider_config.py
@@ -17,6 +17,22 @@ def test_providers():
     print("\n" + "="*60)
     print("🧪 PROVIDER CONFIGURATION TEST")
     print("="*60)
+
+    # Test Alibaba Cloud Model Studio / Bailian
+    dashscope_key = os.getenv("DASHSCOPE_API_KEY")
+    if dashscope_key:
+        print("\n✅ Alibaba Cloud Model Studio API key found")
+        try:
+            agent = ContextAwareAgent(
+                dashscope_key, ContextMode.FULL, provider="dashscope"
+            )
+            print(f"   Provider: {agent.provider}")
+            print(f"   Model: {agent.model}")
+            print(f"   Base URL: {agent.client.base_url}")
+        except Exception as e:
+            print(f"   ❌ Error: {str(e)}")
+    else:
+        print("\n⚠️ Alibaba Cloud Model Studio API key not found (DASHSCOPE_API_KEY)")
     
     # Test SiliconFlow
     sf_key = os.getenv("SILICONFLOW_API_KEY")
@@ -78,6 +94,11 @@ def test_providers():
     # Show usage examples
     print("\n📖 Usage Examples:")
     print("-"*40)
+
+    if dashscope_key:
+        print("\n# Using Qwen directly through Alibaba Cloud Model Studio:")
+        print("python main.py --provider dashscope")
+        print("python main.py --provider dashscope --model qwen3.7-plus")
     
     if sf_key:
         print("\n# Using SiliconFlow:")
@@ -94,8 +115,9 @@ def test_providers():
         print("python main.py --provider deepseek")
         print("python main.py --provider deepseek --model deepseek-v4-pro")
     
-    if not sf_key and not ark_key and not deepseek_key:
+    if not dashscope_key and not sf_key and not ark_key and not deepseek_key:
         print("\n⚠️ No API keys found. Please set one of:")
+        print("   export DASHSCOPE_API_KEY=your_key")
         print("   export SILICONFLOW_API_KEY=your_key")
         print("   export ARK_API_KEY=your_key")
         print("   export DEEPSEEK_API_KEY=your_key")

--- a/chapter1/context/tests/manual/check_provider_switching.py
+++ b/chapter1/context/tests/manual/check_provider_switching.py
@@ -24,6 +24,12 @@ def test_provider_switching():
     providers_to_test = []
     
     # Check which providers have API keys configured
+    if os.getenv("DASHSCOPE_API_KEY"):
+        providers_to_test.append(("dashscope", os.getenv("DASHSCOPE_API_KEY")))
+        print("✅ Alibaba Cloud Model Studio API key found")
+    else:
+        print("⏭️  Skipping Alibaba Cloud Model Studio (no API key)")
+
     if os.getenv("SILICONFLOW_API_KEY"):
         providers_to_test.append(("siliconflow", os.getenv("SILICONFLOW_API_KEY")))
         print("✅ SiliconFlow API key found")
@@ -50,6 +56,7 @@ def test_provider_switching():
     
     if not providers_to_test:
         print("\n❌ No API keys configured. Please set at least one:")
+        print("  - DASHSCOPE_API_KEY")
         print("  - SILICONFLOW_API_KEY")
         print("  - ARK_API_KEY")
         print("  - MOONSHOT_API_KEY")
@@ -101,7 +108,7 @@ def test_provider_switching():
     # Show summary
     print("\n📊 Summary:")
     print(f"  Providers tested: {len(providers_to_test)}")
-    print("  Available providers: siliconflow, doubao, kimi, moonshot, deepseek")
+    print("  Available providers include: dashscope (qwen/bailian), siliconflow, doubao, kimi, moonshot, deepseek")
     
     if len(providers_to_test) < 3:
         print("\n💡 Tip: Configure more API keys to test all providers")

--- a/chapter1/context/tests/manual/demo_conversation.py
+++ b/chapter1/context/tests/manual/demo_conversation.py
@@ -19,6 +19,8 @@ def main():
     # Get API key (use any available provider)
     if os.getenv("ARK_API_KEY"):
         api_key, provider = os.getenv("ARK_API_KEY"), "doubao"
+    elif os.getenv("DASHSCOPE_API_KEY"):
+        api_key, provider = os.getenv("DASHSCOPE_API_KEY"), "dashscope"
     elif os.getenv("MOONSHOT_API_KEY"):
         api_key, provider = os.getenv("MOONSHOT_API_KEY"), "kimi"
     elif os.getenv("DEEPSEEK_API_KEY"):
@@ -31,6 +33,7 @@ def main():
     if not api_key:
         print("❌ No API key found. Please set one of:")
         print("  - ARK_API_KEY")
+        print("  - DASHSCOPE_API_KEY")
         print("  - MOONSHOT_API_KEY")
         print("  - DEEPSEEK_API_KEY")
         print("  - SILICONFLOW_API_KEY")

--- a/chapter1/learning-from-experience/README.md
+++ b/chapter1/learning-from-experience/README.md
@@ -106,7 +106,12 @@ To run the LLM experiments, you need a Kimi (Moonshot) API key:
 2. Set the environment variable:
 
 ```bash
+export LLM_PROVIDER="moonshot"  # or dashscope/qwen/bailian
 export MOONSHOT_API_KEY="your-api-key-here"
+# For Alibaba Cloud Model Studio / Bailian (Qwen), use:
+# export LLM_PROVIDER="dashscope"
+# export DASHSCOPE_API_KEY="your-dashscope-api-key-here"
+# export DASHSCOPE_MODEL="qwen3.7-plus"
 ```
 
 Or create a `.env` file:

--- a/chapter1/learning-from-experience/demo.py
+++ b/chapter1/learning-from-experience/demo.py
@@ -123,15 +123,17 @@ def watch_llm_agent():
     print("="*60)
     
     # Check API key
-    api_key = os.getenv("MOONSHOT_API_KEY")
+    provider = os.getenv("LLM_PROVIDER", "moonshot").lower()
+    api_key = os.getenv("DASHSCOPE_API_KEY") if provider in {"dashscope", "qwen", "bailian"} else os.getenv("MOONSHOT_API_KEY")
     if not api_key and not os.getenv("OPENROUTER_API_KEY"):
-        print("\nError: MOONSHOT_API_KEY not set.")
+        print(f"\nError: API key for provider '{provider}' not set.")
         print("Please set your Kimi API key:")
-        print("  export MOONSHOT_API_KEY='your-key-here'")
+        print("  export DASHSCOPE_API_KEY='your-key-here'  # for dashscope/qwen/bailian")
+        print("  export MOONSHOT_API_KEY='your-key-here'   # for moonshot/kimi")
         print("Or set OPENROUTER_API_KEY as a universal fallback.")
         return
     
-    agent = LLMAgent(api_key=api_key)
+    agent = LLMAgent(api_key=api_key, provider=provider)
     
     # Load experiences if available
     exp_path = Path("results") / "llm_experiences_demo.json"

--- a/chapter1/learning-from-experience/env.example
+++ b/chapter1/learning-from-experience/env.example
@@ -1,6 +1,14 @@
+# Provider: moonshot (default) or dashscope/qwen/bailian
+LLM_PROVIDER=moonshot
+
 # Kimi (Moonshot) API Configuration
 # Get your API key from: https://platform.moonshot.cn/
 MOONSHOT_API_KEY=your-api-key-here
+
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+# DASHSCOPE_API_KEY=your-dashscope-api-key-here
+# DASHSCOPE_MODEL=qwen3.7-plus
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
 # Optional: Customize model (default: kimi-k3)
 # MOONSHOT_MODEL=kimi-k3

--- a/chapter1/learning-from-experience/experiment.py
+++ b/chapter1/learning-from-experience/experiment.py
@@ -174,10 +174,11 @@ class ExperimentRunner:
         print("="*70)
 
         # Check for API key
-        api_key = os.getenv("MOONSHOT_API_KEY")
+        provider = os.getenv("LLM_PROVIDER", "moonshot").lower()
+        api_key = os.getenv("DASHSCOPE_API_KEY") if provider in {"dashscope", "qwen", "bailian"} else os.getenv("MOONSHOT_API_KEY")
         if not api_key and not os.getenv("OPENROUTER_API_KEY"):
-            print("\n⚠️ Warning: MOONSHOT_API_KEY not set. Skipping LLM experiment.")
-            print("📝 Please set your Kimi API key: export MOONSHOT_API_KEY='your-key-here'")
+            print(f"\n⚠️ Warning: API key for provider '{provider}' not set. Skipping LLM experiment.")
+            print("📝 Set DASHSCOPE_API_KEY for dashscope/qwen/bailian or MOONSHOT_API_KEY for moonshot/kimi")
             print("🔗 Get your key at: https://platform.moonshot.cn/")
             print("💡 Or set OPENROUTER_API_KEY as a universal fallback.")
             return None
@@ -190,6 +191,7 @@ class ExperimentRunner:
         agent = LLMAgent(
             api_key=api_key,
             model=model,
+            provider=provider,
             temperature=0.7,
             max_experiences=50
         )

--- a/chapter1/learning-from-experience/llm_agent.py
+++ b/chapter1/learning-from-experience/llm_agent.py
@@ -69,23 +69,42 @@ class LLMAgent:
                  model: str = "kimi-k3",  # Kimi K3 (see 实验 7-2)
                  base_url: str = "https://api.moonshot.cn/v1",
                  temperature: float = 0.7,
-                 max_experiences: int = 50):
+                 max_experiences: int = 50,
+                 provider: str | None = None):
         """
         Initialize LLM agent with the Kimi (Moonshot) API.
 
         Args:
-            api_key: Kimi API key (or set MOONSHOT_API_KEY env var)
-            model: Model name (Moonshot/Kimi, default kimi-k3)
+            api_key: Provider API key (or set the provider's env var)
+            model: Model name (defaults to the selected provider's model)
             base_url: API base URL
             temperature: Sampling temperature for generation
             max_experiences: Maximum number of experiences to store
         """
-        # Set up API client (Moonshot primary, OpenRouter universal fallback)
-        primary_key = api_key or os.getenv("MOONSHOT_API_KEY")
-        self.api_key, resolved_base_url, self.model, self.using_openrouter = \
-            resolve_llm_backend(primary_key, base_url, model)
+        # Set up an OpenAI-compatible client. The default remains Moonshot,
+        # while LLM_PROVIDER=dashscope/qwen/bailian enables direct Bailian use.
+        requested_provider = (provider or os.getenv("LLM_PROVIDER", "moonshot")).lower()
+        requested_provider = {"qwen": "dashscope", "bailian": "dashscope"}.get(
+            requested_provider, requested_provider
+        )
+        if requested_provider == "dashscope":
+            dashscope_model = model if model != "kimi-k3" else None
+            backend = resolve_backend(
+                "dashscope",
+                model=dashscope_model or os.getenv("DASHSCOPE_MODEL"),
+                api_key=api_key,
+            )
+            self.api_key, resolved_base_url, self.model = (
+                backend.api_key, backend.base_url, backend.model
+            )
+            self.using_openrouter = backend.using_openrouter
+            self.provider = backend.provider
+        else:
+            primary_key = api_key or os.getenv("MOONSHOT_API_KEY")
+            self.api_key, resolved_base_url, self.model, self.using_openrouter = \
+                resolve_llm_backend(primary_key, base_url, model)
+            self.provider = "openrouter" if self.using_openrouter else "moonshot"
         self.base_url = resolved_base_url
-        self.provider = "openrouter" if self.using_openrouter else "moonshot"
         if self.using_openrouter:
             print(f"ℹ️  MOONSHOT_API_KEY not set; routing via OpenRouter (model: {self.model})")
 

--- a/chapter1/learning-from-experience/quick_demo.py
+++ b/chapter1/learning-from-experience/quick_demo.py
@@ -51,11 +51,13 @@ def run_llm_demo():
     print("🤖"*35)
     
     # Check API key
-    api_key = os.getenv("MOONSHOT_API_KEY")
+    provider = os.getenv("LLM_PROVIDER", "moonshot").lower()
+    api_key = os.getenv("DASHSCOPE_API_KEY") if provider in {"dashscope", "qwen", "bailian"} else os.getenv("MOONSHOT_API_KEY")
     if not api_key and not os.getenv("OPENROUTER_API_KEY"):
-        print("\n❌ Error: MOONSHOT_API_KEY not set.")
+        print(f"\n❌ Error: API key for provider '{provider}' not set.")
         print("Please set your Kimi API key:")
-        print("  export MOONSHOT_API_KEY='your-key-here'")
+        print("  export DASHSCOPE_API_KEY='your-key-here'  # for dashscope/qwen/bailian")
+        print("  export MOONSHOT_API_KEY='your-key-here'   # for moonshot/kimi")
         print("\nGet your key at: https://platform.moonshot.cn/")
         print("Or set OPENROUTER_API_KEY as a universal fallback.")
         return
@@ -67,6 +69,7 @@ def run_llm_demo():
     agent = LLMAgent(
         api_key=api_key,
         model=os.getenv("MOONSHOT_MODEL", "kimi-k3"),
+        provider=provider,
         temperature=0.7,
         max_experiences=30
     )

--- a/chapter2/context-compression/README.md
+++ b/chapter2/context-compression/README.md
@@ -78,7 +78,9 @@ cp env.example .env
 
 **API keys:**
 
-- `MOONSHOT_API_KEY` — Kimi/Moonshot (required for live runs). Book 实验 2-9 uses Kimi K3 (~1M real window); the demo **caps** the compression/overflow budget at `CONTEXT_WINDOW_SIZE` (default 128K) so overflow/compression is observable. Override model via `MODEL_NAME` or `-m/--model` (e.g. `kimi-k2.5`, `kimi-k3`, `moonshot-v1-128k`).
+- `LLM_PROVIDER` — `kimi` (default), `dashscope`/`qwen`/`bailian`, or `openrouter`.
+- `DASHSCOPE_API_KEY` — Alibaba Cloud Model Studio / Bailian key when using DashScope; default model is `qwen3.7-plus` (set `DASHSCOPE_BASE_URL` for international keys).
+- `MOONSHOT_API_KEY` — Kimi/Moonshot for live runs. Book 实验 2-9 uses Kimi K3 (~1M real window); the demo **caps** the compression/overflow budget at `CONTEXT_WINDOW_SIZE` (default 128K) so overflow/compression is observable. Override model via `MODEL_NAME` or `-m/--model`.
 - `OPENROUTER_API_KEY` — fallback if Moonshot key unset (`kimi-*` → `moonshotai/kimi-k2`). Unchanged if `MOONSHOT_API_KEY` is set.
 - `SERPER_API_KEY` — web search (optional; mock data if missing)
 
@@ -327,7 +329,9 @@ cp env.example .env
 
 **所需 Key：**
 
-- `MOONSHOT_API_KEY`：Kimi/Moonshot（在线跑必需）。书中实验 2-9 使用 Kimi K3（真实窗口约 1M）；演示通过 `CONTEXT_WINDOW_SIZE`（默认 128K）**故意收紧**溢出/压缩预算以便观察。可用 `MODEL_NAME` 或 `-m/--model` 覆盖（如 `kimi-k2.5`、`kimi-k3`、`moonshot-v1-128k`）。
+- `LLM_PROVIDER`：`kimi`（默认）、`dashscope`/`qwen`/`bailian` 或 `openrouter`。
+- `DASHSCOPE_API_KEY`：使用阿里云百炼 / Model Studio 时的 Key，默认模型 `qwen3.7-plus`（国际区 Key 可设置 `DASHSCOPE_BASE_URL`）。
+- `MOONSHOT_API_KEY`：Kimi/Moonshot 在线 Key。书中实验 2-9 使用 Kimi K3；可用 `MODEL_NAME` 或 `-m/--model` 覆盖。
 - `OPENROUTER_API_KEY`：未设置 Moonshot key 时的通用回退（`kimi-*` → `moonshotai/kimi-k2`）。设了 `MOONSHOT_API_KEY` 时行为不变。
 - `SERPER_API_KEY`：联网搜索（可选；缺失则用 mock 数据）
 

--- a/chapter2/context-compression/config.py
+++ b/chapter2/context-compression/config.py
@@ -14,6 +14,14 @@ class Config:
     """Configuration settings for the context compression experiment"""
     
     # API Configuration
+    LLM_PROVIDER: str = os.getenv("LLM_PROVIDER", "kimi").lower()
+    LLM_PROVIDER = {"qwen": "dashscope", "bailian": "dashscope"}.get(
+        LLM_PROVIDER, LLM_PROVIDER
+    )
+    DASHSCOPE_API_KEY: str = os.getenv("DASHSCOPE_API_KEY", "")
+    DASHSCOPE_BASE_URL: str = os.getenv(
+        "DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    )
     MOONSHOT_API_KEY: str = os.getenv("MOONSHOT_API_KEY", "")
     MOONSHOT_BASE_URL: str = "https://api.moonshot.cn/v1"
 
@@ -25,7 +33,9 @@ class Config:
     SERPER_BASE_URL: str = "https://google.serper.dev"
     
     # Model Configuration
-    MODEL_NAME: str = os.getenv("MODEL_NAME", "kimi-k3")
+    MODEL_NAME: str = os.getenv(
+        "MODEL_NAME", "qwen3.7-plus" if LLM_PROVIDER == "dashscope" else "kimi-k3"
+    )
     MODEL_TEMPERATURE: float = float(os.getenv("MODEL_TEMPERATURE", "0.3"))
     MODEL_MAX_TOKENS: int = int(os.getenv("MODEL_MAX_TOKENS", "8192"))
     
@@ -56,10 +66,10 @@ class Config:
         Returns:
             True if configuration is valid
         """
-        if not cls.MOONSHOT_API_KEY and not cls.OPENROUTER_API_KEY:
-            print("ERROR: neither MOONSHOT_API_KEY nor OPENROUTER_API_KEY is set")
-            print("Please set MOONSHOT_API_KEY (primary) or OPENROUTER_API_KEY "
-                  "(universal fallback) in .env or as an environment variable")
+        try:
+            cls.resolve_llm()
+        except ValueError as exc:
+            print(f"ERROR: {exc}")
             return False
         
         if not cls.SERPER_API_KEY:
@@ -71,7 +81,7 @@ class Config:
     
     @classmethod
     def resolve_llm(cls):
-        """Return ``(api_key, base_url, model)`` honoring the MOONSHOT->OpenRouter fallback.
+        """Return ``(api_key, base_url, model)`` for the configured provider.
 
         Computed at call time so a runtime override of ``Config.MODEL_NAME``
         (e.g. via ``--model``) is respected.
@@ -82,7 +92,7 @@ class Config:
         """
         from agentbook.providers import resolve_backend
 
-        backend = resolve_backend("kimi", model=cls.MODEL_NAME)
+        backend = resolve_backend(cls.LLM_PROVIDER, model=cls.MODEL_NAME)
         return backend.api_key, backend.base_url, backend.model
 
     @classmethod
@@ -104,6 +114,8 @@ class Config:
         print(f"Context Window: {cls.CONTEXT_WINDOW_SIZE:,} tokens")
         print(f"Max Webpage Length: {cls.MAX_WEBPAGE_LENGTH:,} chars")
         print(f"Summary Max Tokens: {cls.SUMMARY_MAX_TOKENS}")
+        print(f"Provider: {cls.LLM_PROVIDER}")
+        print(f"DashScope API Key Set: {'Yes' if cls.DASHSCOPE_API_KEY else 'No'}")
         print(f"Kimi API Key Set: {'Yes' if cls.MOONSHOT_API_KEY else 'No'}")
         print(f"Serper API Key Set: {'Yes' if cls.SERPER_API_KEY else 'No'}")
         print("="*50 + "\n")

--- a/chapter2/context-compression/env.example
+++ b/chapter2/context-compression/env.example
@@ -1,5 +1,12 @@
+# LLM provider: kimi (default), dashscope/qwen/bailian, or openrouter
+LLM_PROVIDER=kimi
+
 # Kimi API Configuration
 MOONSHOT_API_KEY=your_moonshot_api_key_here
+
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+# DASHSCOPE_API_KEY=your_dashscope_api_key_here
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
 # 通用回退：未设置 MOONSHOT_API_KEY 时，若配置了 OPENROUTER_API_KEY，则自动改走
 # OpenRouter（kimi-* 会映射为 moonshotai/kimi-k2）。

--- a/chapter2/context-compression/main.py
+++ b/chapter2/context-compression/main.py
@@ -75,6 +75,7 @@ def run_demo(enable_streaming=True, strategy: CompressionStrategy = None):
     if not Config.validate():
         print(f"\n{Fore.RED}Configuration validation failed!{Style.RESET_ALL}")
         print("\nPlease set up your .env file with:")
+        print("  DASHSCOPE_API_KEY=your_api_key_here (for LLM_PROVIDER=dashscope/qwen/bailian)")
         print("  MOONSHOT_API_KEY=your_api_key_here")
         print("  SERPER_API_KEY=your_api_key_here (optional, will use mock data)")
         sys.exit(1)
@@ -92,7 +93,7 @@ def run_demo(enable_streaming=True, strategy: CompressionStrategy = None):
     # Create agent
     print(f"\n{Fore.YELLOW}Initializing agent...{Style.RESET_ALL}")
     agent = ResearchAgent(
-        api_key=Config.MOONSHOT_API_KEY,
+        api_key=Config.resolve_llm()[0],
         compression_strategy=strategy,
         verbose=False,
         enable_streaming=enable_streaming

--- a/chapter2/context-compression/quickstart.py
+++ b/chapter2/context-compression/quickstart.py
@@ -12,18 +12,19 @@ load_dotenv()
 
 def check_environment():
     """Check if environment is properly configured"""
-    moonshot_key = os.getenv("MOONSHOT_API_KEY")
+    provider = os.getenv("LLM_PROVIDER", "kimi").lower()
+    provider_key = os.getenv("DASHSCOPE_API_KEY") if provider in {"dashscope", "qwen", "bailian"} else os.getenv("MOONSHOT_API_KEY")
     serper_key = os.getenv("SERPER_API_KEY")
     
     print("🔍 Checking environment configuration...")
     print("-" * 40)
     
-    if moonshot_key:
-        print("✅ MOONSHOT_API_KEY is set")
+    if provider_key:
+        print(f"✅ API key for {provider} is set")
     else:
-        print("❌ MOONSHOT_API_KEY is NOT set")
+        print(f"❌ API key for {provider} is NOT set")
         print("   Please add it to your .env file")
-        print("   Get API key at: https://platform.moonshot.cn/")
+        print("   Set DASHSCOPE_API_KEY for dashscope/qwen/bailian or MOONSHOT_API_KEY for kimi")
         return False
     
     if serper_key:
@@ -48,7 +49,7 @@ def quick_test():
     
     # Create agent
     agent = ResearchAgent(
-        api_key=Config.MOONSHOT_API_KEY,
+        api_key=Config.resolve_llm()[0],
         compression_strategy=CompressionStrategy.CONTEXT_AWARE_CITATIONS,
         verbose=False,
         enable_streaming=True

--- a/chapter2/prompt-injection/README.md
+++ b/chapter2/prompt-injection/README.md
@@ -54,11 +54,11 @@ cd chapter2/prompt-injection
 # Single-project compatibility path, still supported during migration:
 # python -m pip install -r requirements.txt
 
-cp env.example .env    # set OPENAI_API_KEY (OpenAI official API)
+cp env.example .env    # set LLM_PROVIDER and its key (OpenAI or DashScope/Bailian)
 python demo.py         # default: all 3×4=12 combos, 4 trials each
 ```
 
-> **OpenRouter fallback:** If `OPENAI_API_KEY` is unset but `OPENROUTER_API_KEY` is set, requests go through OpenRouter (`gpt-*` → `openai/…`). With `OPENAI_API_KEY` set, behavior is unchanged.
+> **DashScope/Bailian:** Set `LLM_PROVIDER=dashscope` (or `qwen`/`bailian`) and `DASHSCOPE_API_KEY`; the default model is `qwen3.7-plus`. `DASHSCOPE_BASE_URL` supports international-region keys. OpenRouter remains available as a fallback.
 
 The program runs selected combos and prints an **attack × defense** success-rate matrix.
 

--- a/chapter2/prompt-injection/agent.py
+++ b/chapter2/prompt-injection/agent.py
@@ -386,10 +386,12 @@ def make_client(
     # （间接/记忆注入在 D1 无防御下高成功，随 D2/D3/D4 依次降到 0）。
     # 换成更强的模型（如 gpt-5.6-luna）会在 D1 无防御下就抗住全部三类注入，
     # 全矩阵成功率为 0，从而抹平了本实验要展示的教学对比。故此处保留 gpt-4o-mini。
-    requested_model = model or os.getenv("OPENAI_MODEL", "gpt-4o-mini")
-    # OPENAI_API_KEY 存在 -> 官方直连；否则回退 OPENROUTER_API_KEY。
-    # 端点与 key 的对应关系由 agentbook 的 provider 注册表统一维护。
-    backend = resolve_backend("openai", model=requested_model)
+    requested_provider = os.getenv("LLM_PROVIDER", "openai").lower()
+    requested_model = model or os.getenv("OPENAI_MODEL")
+    if not requested_model and requested_provider == "openai":
+        requested_model = "gpt-4o-mini"
+    # Endpoint and key selection are handled by the shared provider registry.
+    backend = resolve_backend(requested_provider, model=requested_model)
     model = backend.model
     # 允许显式传入 base_url 覆盖（默认官方；OPENAI_BASE_URL 由注册表处理），
     # 但请勿指向已失效的第三方网关。回退到 OpenRouter 时不可覆盖：

--- a/chapter2/prompt-injection/env.example
+++ b/chapter2/prompt-injection/env.example
@@ -1,5 +1,12 @@
-# OpenAI 配置（本实验仅使用 OpenAI 官方接口）
+# Provider: openai (default), dashscope/qwen/bailian, or openrouter
+LLM_PROVIDER=openai
+
+# OpenAI 配置
 OPENAI_API_KEY=your_openai_api_key_here
+
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+# DASHSCOPE_API_KEY=your_dashscope_api_key_here
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
 # 模型（默认 gpt-4o-mini）：本实验特意用这个较弱、"故意可被攻破"的基线，
 # 才能展示"防御逐层加强 -> 注入成功率下降"的对照曲线；换更强的模型（如 gpt-5.6-luna）

--- a/chapter2/system-hint/README.md
+++ b/chapter2/system-hint/README.md
@@ -102,8 +102,12 @@ cd chapter2/system-hint
 # python -m pip install -r requirements.txt
 
 cp env.example .env
-# Edit .env with your KIMI_API_KEY
+# Edit .env with your provider key (Kimi or DashScope/Bailian)
 export KIMI_API_KEY='your-api-key-here'
+
+# Alibaba Cloud Model Studio / Bailian (Qwen):
+# export LLM_PROVIDER=dashscope
+# export DASHSCOPE_API_KEY='your-dashscope-api-key-here'
 ```
 
 > **OpenRouter fallback:** If `KIMI_API_KEY` is unset but `OPENROUTER_API_KEY` is set, the experiment uses OpenRouter (`kimi-*` → `moonshotai/kimi-k2`). With `KIMI_API_KEY` set, behavior is unchanged.

--- a/chapter2/system-hint/agent.py
+++ b/chapter2/system-hint/agent.py
@@ -94,7 +94,7 @@ class SystemHintAgent:
         
         Args:
             api_key: API key for the LLM provider
-            provider: LLM provider ('kimi' for Kimi K3)
+            provider: LLM provider (including dashscope/qwen/bailian for Qwen)
             model: Optional model override
             config: System hint configuration
             verbose: If True, log full details
@@ -104,7 +104,13 @@ class SystemHintAgent:
         self.config = config or SystemHintConfig()
         
         # Configure client based on provider
-        if self.provider == "kimi" or self.provider == "moonshot":
+        if self.provider in {"dashscope", "qwen", "bailian"}:
+            from agentbook.providers import resolve_backend
+
+            backend = resolve_backend("dashscope", model=model, api_key=api_key)
+            self.client = OpenAI(api_key=backend.api_key, base_url=backend.base_url)
+            self.model = backend.model
+        elif self.provider == "kimi" or self.provider == "moonshot":
             # 默认 Moonshot/Kimi 官方端点；若传入 OpenRouter key（sk-or-…）则自动
             # 回退到 OpenRouter，并把 kimi-* 映射为 moonshotai/kimi-k2。
             # 端点、key 与模型名映射统一由 agentbook 的 provider 注册表维护；
@@ -121,7 +127,7 @@ class SystemHintAgent:
             )
             self.model = backend.model
         else:
-            raise ValueError(f"Unsupported provider: {provider}")
+            raise ValueError(f"Unsupported provider: {provider}. Use dashscope/qwen/bailian, kimi, or openrouter")
         
         # Initialize tracking
         self.tool_call_counts: Dict[str, int] = {}

--- a/chapter2/system-hint/config.py
+++ b/chapter2/system-hint/config.py
@@ -7,7 +7,7 @@ from typing import Optional
 from dataclasses import dataclass
 from dotenv import load_dotenv
 
-from agentbook.providers import PROVIDERS
+from agentbook.providers import PROVIDERS, canonical_provider
 
 load_dotenv()
 
@@ -40,11 +40,11 @@ class AgentConfig:
     @classmethod
     def from_env(cls) -> "AgentConfig":
         """Create configuration from environment variables"""
+        provider = canonical_provider(os.getenv("LLM_PROVIDER", "kimi"))
         return cls(
-            # Kimi 官方 key 优先，缺失时用 OPENROUTER_API_KEY 兜底；
-            # 具体接受哪些环境变量由 agentbook 的 provider 注册表定义。
-            api_key=PROVIDERS["kimi"].api_key() or os.getenv("OPENROUTER_API_KEY"),
-            provider=os.getenv("LLM_PROVIDER", "kimi"),
+            # Provider credentials and aliases come from the shared registry.
+            api_key=PROVIDERS.get(provider, PROVIDERS["kimi"]).api_key() or os.getenv("OPENROUTER_API_KEY"),
+            provider=provider,
             model=os.getenv("LLM_MODEL"),
             enable_timestamps=os.getenv("ENABLE_TIMESTAMPS", "true").lower() == "true",
             enable_tool_counter=os.getenv("ENABLE_TOOL_COUNTER", "true").lower() == "true",
@@ -61,9 +61,10 @@ class AgentConfig:
     def validate(self) -> bool:
         """Validate the configuration"""
         if not self.api_key:
-            raise ValueError("API key is required. Set KIMI_API_KEY (or MOONSHOT_API_KEY / OPENROUTER_API_KEY fallback).")
-        
-        if self.provider not in ["kimi", "moonshot"]:
+            raise ValueError("API key is required. Set the selected provider's key or OPENROUTER_API_KEY fallback.")
+
+        self.provider = canonical_provider(self.provider)
+        if self.provider not in {"kimi", "moonshot", "dashscope"}:
             raise ValueError(f"Unsupported provider: {self.provider}")
         
         if self.max_iterations < 1:

--- a/chapter2/system-hint/env.example
+++ b/chapter2/system-hint/env.example
@@ -1,5 +1,9 @@
 # API Configuration
 KIMI_API_KEY=your-kimi-api-key-here
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+# LLM_PROVIDER=dashscope  # qwen and bailian are accepted aliases
+# DASHSCOPE_API_KEY=your-dashscope-api-key-here
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
 # 通用回退：未设置 KIMI_API_KEY 时，若配置了 OPENROUTER_API_KEY，则自动改走
 # OpenRouter（kimi-* 会映射为 moonshotai/kimi-k2）。

--- a/chapter3/agentic-rag-for-user-memory/config.py
+++ b/chapter3/agentic-rag-for-user-memory/config.py
@@ -44,6 +44,7 @@ def _openrouter_model_id(model: Optional[str]) -> str:
 
 class Provider(str, Enum):
     """Supported LLM providers"""
+    DASHSCOPE = "dashscope"  # Alibaba Cloud Model Studio / Bailian (Qwen)
     SILICONFLOW = "siliconflow"
     DOUBAO = "doubao"
     KIMI = "kimi"
@@ -81,6 +82,13 @@ class LLMConfig:
     
     # Provider-specific defaults
     PROVIDER_DEFAULTS = {
+        "dashscope": {
+            "model": "qwen3.7-plus",
+            "base_url": os.getenv(
+                "DASHSCOPE_BASE_URL",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            ),
+        },
         "siliconflow": {
             "model": "Qwen/Qwen3-235B-A22B-Thinking-2507",
             "base_url": "https://api.siliconflow.cn/v1"
@@ -122,6 +130,9 @@ class LLMConfig:
     def get_client_config(self) -> tuple[Dict[str, Any], str]:
         """Get OpenAI client configuration"""
         provider = self.provider.lower()
+        provider = {"qwen": "dashscope", "bailian": "dashscope"}.get(
+            provider, provider
+        )
         defaults = self.PROVIDER_DEFAULTS.get(provider, {})
         
         # Determine API key

--- a/chapter3/agentic-rag-for-user-memory/env.example
+++ b/chapter3/agentic-rag-for-user-memory/env.example
@@ -8,6 +8,9 @@ OPENAI_API_KEY=your_openai_api_key_here
 KIMI_API_KEY=your_kimi_api_key_here
 
 # Alternative providers
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+DASHSCOPE_API_KEY=your_dashscope_api_key_here
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 SILICONFLOW_API_KEY=your_siliconflow_api_key_here
 DOUBAO_API_KEY=your_doubao_api_key_here
 # OpenRouter: usable as an explicit provider, and also a universal fallback —

--- a/chapter3/agentic-rag/README.md
+++ b/chapter3/agentic-rag/README.md
@@ -23,7 +23,7 @@ hashes are written under `validation/runs/<run-id>/`; the auditable pointer is
 
 - **Agentic RAG (ReAct)**: iterative reason + tool search  
 - **Non-agentic RAG**: single retrieve + answer (for compare)  
-- **LLM providers**: Kimi/Moonshot, Doubao, SiliconFlow, OpenAI, OpenRouter, Groq, Together, DeepSeek  
+- **LLM providers**: Alibaba Cloud Model Studio / Bailian (Qwen), Kimi/Moonshot, Doubao, SiliconFlow, OpenAI, OpenRouter, Groq, Together, DeepSeek
 - **Knowledge bases**:  
   - **Offline BM25** (built-in, zero deps) over bundled `laws/` — no server/API for retrieval  
   - Local retrieval pipeline (`../retrieval-pipeline`)  
@@ -58,6 +58,8 @@ cd chapter3/agentic-rag
 MOONSHOT_API_KEY=...
 ARK_API_KEY=...
 SILICONFLOW_API_KEY=...
+DASHSCOPE_API_KEY=...  # Alibaba Cloud Model Studio / Bailian (Qwen)
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 OPENAI_API_KEY=...
 OPENROUTER_API_KEY=...
 GROQ_API_KEY=...
@@ -154,6 +156,7 @@ python main.py --batch queries.txt --mode non-agentic
 python main.py --provider openai --model gpt-5.6-luna
 python main.py --provider doubao --model doubao-seed-1-6-thinking-250715
 python main.py --provider siliconflow --query "你好"
+python main.py --provider dashscope --model qwen3.7-plus --query "你好"
 ```
 
 Interactive: type questions; `quit`/`exit`; `clear` history; `mode` switch agentic/non-agentic.

--- a/chapter3/agentic-rag/config.py
+++ b/chapter3/agentic-rag/config.py
@@ -35,6 +35,7 @@ def _openrouter_model_id(model: Optional[str]) -> str:
 
 class Provider(str, Enum):
     """Supported LLM providers"""
+    DASHSCOPE = "dashscope"  # Alibaba Cloud Model Studio / Bailian (Qwen)
     SILICONFLOW = "siliconflow"
     DOUBAO = "doubao"
     KIMI = "kimi"
@@ -67,6 +68,13 @@ class LLMConfig:
     
     # Provider-specific defaults
     PROVIDER_DEFAULTS = {
+        "dashscope": {
+            "model": "qwen3.7-plus",
+            "base_url": os.getenv(
+                "DASHSCOPE_BASE_URL",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            ),
+        },
         "siliconflow": {
             "model": "Qwen/Qwen3-235B-A22B-Thinking-2507",
             "base_url": "https://api.siliconflow.cn/v1"
@@ -109,6 +117,9 @@ class LLMConfig:
     def get_api_key(cls, provider: str) -> Optional[str]:
         """Get API key from environment"""
         env_mappings = {
+            "dashscope": "DASHSCOPE_API_KEY",
+            "qwen": "DASHSCOPE_API_KEY",
+            "bailian": "DASHSCOPE_API_KEY",
             "siliconflow": "SILICONFLOW_API_KEY",
             "doubao": "ARK_API_KEY",
             "kimi": "MOONSHOT_API_KEY",
@@ -124,6 +135,9 @@ class LLMConfig:
     def get_client_config(self) -> Dict[str, Any]:
         """Get OpenAI client configuration"""
         provider_lower = self.provider.lower()
+        provider_lower = {"qwen": "dashscope", "bailian": "dashscope"}.get(
+            provider_lower, provider_lower
+        )
         defaults = self.PROVIDER_DEFAULTS.get(provider_lower, {})
         
         # Get API key

--- a/chapter3/agentic-rag/env.example
+++ b/chapter3/agentic-rag/env.example
@@ -1,6 +1,9 @@
 # LLM Provider API Keys (set the one you're using)
 MOONSHOT_API_KEY=your_kimi_api_key_here
 ARK_API_KEY=your_doubao_api_key_here
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+DASHSCOPE_API_KEY=your_dashscope_api_key_here
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 SILICONFLOW_API_KEY=your_siliconflow_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
 # OpenRouter: usable as an explicit LLM_PROVIDER, and also a universal fallback
@@ -18,5 +21,5 @@ DIFY_API_KEY=your_dify_api_key_here  # Required if KB_TYPE=dify
 DIFY_DATASET_ID=your_dataset_id_here  # Optional, for specific Dify dataset
 
 # LLM Configuration
-LLM_PROVIDER=kimi  # Options: kimi, doubao, siliconflow, openai, openrouter, groq, together, deepseek
+LLM_PROVIDER=kimi  # Options include dashscope/qwen/bailian, kimi, doubao, siliconflow, openai, openrouter, groq, together, deepseek
 # LLM_MODEL=kimi-k3  # Optional, uses provider defaults if not set (kimi-k3 是推理模型：temperature 固定为 1、max_tokens 自动抬到 ≥4096)

--- a/chapter3/agentic-rag/main.py
+++ b/chapter3/agentic-rag/main.py
@@ -209,7 +209,7 @@ def main():
                         help="批量结果的输出文件路径（默认：results.json）")
 
     # 配置选项
-    parser.add_argument("--provider", type=str, help="LLM 提供商（如 kimi / doubao / openai）")
+    parser.add_argument("--provider", type=str, help="LLM 提供商（如 dashscope/qwen/bailian / kimi / doubao / openai）")
     parser.add_argument("--model", type=str, help="LLM 模型名称（不指定则用提供商默认模型）")
     parser.add_argument("--kb-type", choices=["offline", "local", "dify"],
                         help="知识库后端：offline=内置离线 BM25（无需服务/无需 API）/ local=检索流水线服务 / dify=Dify API")

--- a/chapter3/agentic-rag/quickstart.py
+++ b/chapter3/agentic-rag/quickstart.py
@@ -24,7 +24,7 @@ def check_environment():
     load_dotenv()
     
     # Check for at least one API key
-    providers = ["MOONSHOT_API_KEY", "ARK_API_KEY", "SILICONFLOW_API_KEY", 
+    providers = ["MOONSHOT_API_KEY", "ARK_API_KEY", "DASHSCOPE_API_KEY", "SILICONFLOW_API_KEY",
                  "OPENAI_API_KEY", "OPENROUTER_API_KEY"]
     
     has_key = False

--- a/chapter3/contextual-retrieval-for-user-memory/README.md
+++ b/chapter3/contextual-retrieval-for-user-memory/README.md
@@ -142,10 +142,12 @@ Create a `.env` file:
 MOONSHOT_API_KEY=your_api_key_here
 ARK_API_KEY=your_api_key_here
 SILICONFLOW_API_KEY=your_api_key_here
+DASHSCOPE_API_KEY=your_dashscope_api_key_here
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 OPENAI_API_KEY=your_api_key_here
 
 # Default Provider
-LLM_PROVIDER=kimi  # Options: kimi, doubao, siliconflow, openai
+LLM_PROVIDER=kimi  # Options: dashscope/qwen/bailian, kimi, doubao, siliconflow, openai
 
 # Model Settings
 LLM_MODEL=kimi-k3  # or another model
@@ -415,10 +417,12 @@ cd chapter3/contextual-retrieval-for-user-memory
 MOONSHOT_API_KEY=your_api_key_here
 ARK_API_KEY=your_api_key_here
 SILICONFLOW_API_KEY=your_api_key_here
+DASHSCOPE_API_KEY=your_dashscope_api_key_here
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 OPENAI_API_KEY=your_api_key_here
 
 # Default Provider
-LLM_PROVIDER=kimi  # Options: kimi, doubao, siliconflow, openai
+LLM_PROVIDER=kimi  # Options: dashscope/qwen/bailian, kimi, doubao, siliconflow, openai
 
 # Model Settings
 LLM_MODEL=kimi-k3  # 或其他模型

--- a/chapter3/contextual-retrieval-for-user-memory/config.py
+++ b/chapter3/contextual-retrieval-for-user-memory/config.py
@@ -44,6 +44,7 @@ def _openrouter_model_id(model: Optional[str]) -> str:
 
 class Provider(str, Enum):
     """Supported LLM providers"""
+    DASHSCOPE = "dashscope"  # Alibaba Cloud Model Studio / Bailian (Qwen)
     SILICONFLOW = "siliconflow"
     DOUBAO = "doubao"
     KIMI = "kimi"
@@ -81,6 +82,13 @@ class LLMConfig:
     
     # Provider-specific defaults
     PROVIDER_DEFAULTS = {
+        "dashscope": {
+            "model": "qwen3.7-plus",
+            "base_url": os.getenv(
+                "DASHSCOPE_BASE_URL",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            ),
+        },
         "siliconflow": {
             "model": "Qwen/Qwen3-235B-A22B-Thinking-2507",
             "base_url": "https://api.siliconflow.cn/v1"
@@ -122,6 +130,9 @@ class LLMConfig:
     def get_client_config(self) -> tuple[Dict[str, Any], str]:
         """Get OpenAI client configuration"""
         provider = self.provider.lower()
+        provider = {"qwen": "dashscope", "bailian": "dashscope"}.get(
+            provider, provider
+        )
         defaults = self.PROVIDER_DEFAULTS.get(provider, {})
         
         # Determine API key

--- a/chapter3/contextual-retrieval-for-user-memory/env.example
+++ b/chapter3/contextual-retrieval-for-user-memory/env.example
@@ -8,6 +8,9 @@ OPENAI_API_KEY=your_openai_api_key_here
 KIMI_API_KEY=your_kimi_api_key_here
 
 # Alternative providers
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+DASHSCOPE_API_KEY=your_dashscope_api_key_here
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 SILICONFLOW_API_KEY=your_siliconflow_api_key_here
 DOUBAO_API_KEY=your_doubao_api_key_here
 # OpenRouter: usable as an explicit provider, and also a universal fallback —

--- a/chapter3/contextual-retrieval-for-user-memory/main.py
+++ b/chapter3/contextual-retrieval-for-user-memory/main.py
@@ -712,7 +712,7 @@ class InteractiveContextualRAG:
             if Confirm.ask("Change LLM provider?"):
                 provider = Prompt.ask(
                     "Provider",
-                    choices=["kimi", "doubao", "siliconflow", "openai"],
+                    choices=["dashscope", "qwen", "bailian", "kimi", "doubao", "siliconflow", "openai"],
                     default=self.config.llm.provider
                 )
                 self.config.llm.provider = provider

--- a/chapter3/contextual-retrieval-for-user-memory/quickstart.py
+++ b/chapter3/contextual-retrieval-for-user-memory/quickstart.py
@@ -26,6 +26,7 @@ def check_environment():
     # Check for at least one LLM provider
     llm_providers = [
         "KIMI_API_KEY",
+        "DASHSCOPE_API_KEY",
         "SILICONFLOW_API_KEY", 
         "DOUBAO_API_KEY",
         "OPENROUTER_API_KEY"

--- a/chapter3/contextual-retrieval/config.py
+++ b/chapter3/contextual-retrieval/config.py
@@ -35,6 +35,7 @@ def _openrouter_model_id(model: Optional[str]) -> str:
 
 class Provider(str, Enum):
     """Supported LLM providers"""
+    DASHSCOPE = "dashscope"  # Alibaba Cloud Model Studio / Bailian (Qwen)
     SILICONFLOW = "siliconflow"
     DOUBAO = "doubao"
     KIMI = "kimi"
@@ -66,6 +67,13 @@ class LLMConfig:
     
     # Provider-specific defaults
     PROVIDER_DEFAULTS = {
+        "dashscope": {
+            "model": "qwen3.7-plus",
+            "base_url": os.getenv(
+                "DASHSCOPE_BASE_URL",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            ),
+        },
         "siliconflow": {
             "model": "Qwen/Qwen3-235B-A22B-Thinking-2507",
             "base_url": "https://api.siliconflow.cn/v1"
@@ -108,6 +116,9 @@ class LLMConfig:
     def get_api_key(cls, provider: str) -> Optional[str]:
         """Get API key from environment"""
         env_mappings = {
+            "dashscope": "DASHSCOPE_API_KEY",
+            "qwen": "DASHSCOPE_API_KEY",
+            "bailian": "DASHSCOPE_API_KEY",
             "siliconflow": "SILICONFLOW_API_KEY",
             "doubao": "ARK_API_KEY",
             "kimi": "MOONSHOT_API_KEY",
@@ -123,6 +134,9 @@ class LLMConfig:
     def get_client_config(self) -> Dict[str, Any]:
         """Get OpenAI client configuration"""
         provider_lower = self.provider.lower()
+        provider_lower = {"qwen": "dashscope", "bailian": "dashscope"}.get(
+            provider_lower, provider_lower
+        )
         defaults = self.PROVIDER_DEFAULTS.get(provider_lower, {})
         
         # Get API key

--- a/chapter3/contextual-retrieval/env.example
+++ b/chapter3/contextual-retrieval/env.example
@@ -10,6 +10,10 @@ MOONSHOT_API_KEY=your_kimi_api_key_here
 # Doubao
 ARK_API_KEY=your_doubao_api_key_here
 
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+DASHSCOPE_API_KEY=your_dashscope_api_key_here
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+
 # OpenAI (Good for general use)
 OPENAI_API_KEY=your_openai_api_key_here
 
@@ -32,7 +36,7 @@ TOGETHER_API_KEY=your_together_api_key_here
 DEEPSEEK_API_KEY=your_deepseek_api_key_here
 
 # Default LLM Configuration
-LLM_PROVIDER=openai  # Options: kimi, doubao, openai, siliconflow, etc.
+LLM_PROVIDER=openai  # Options include dashscope/qwen/bailian, kimi, doubao, openai, siliconflow, etc.
 LLM_MODEL=gpt-5.6-luna  # Model for context generation (use cheaper models to save cost)
 LLM_TEMPERATURE=0.3  # Lower temperature for consistent context generation
 LLM_MAX_TOKENS=150  # Max tokens for context generation (2-3 sentences)

--- a/chapter3/memobase/README.md
+++ b/chapter3/memobase/README.md
@@ -45,7 +45,7 @@ cd chapter3/memobase
 # python -m pip install -r requirements.txt
 
 cp env.example .env
-# Add Kimi API key (hand-rolled agent)
+# Set KIMI_API_KEY, or use LLM_PROVIDER=dashscope/qwen/bailian with DASHSCOPE_API_KEY
 ```
 
 Edit `config.py` for model, memory thresholds, benchmark, logging.
@@ -127,7 +127,7 @@ Benchmark outputs under `benchmark_results/`. Extend tools / memory types in `co
 
 ### Troubleshooting
 
-1. API key: `KIMI_API_KEY` in `.env`  
+1. API key: `KIMI_API_KEY` in `.env`, or `DASHSCOPE_API_KEY` with `LLM_PROVIDER=dashscope`
 2. Memory overflow: lower `MAX_MEMORY_ENTRIES`, more aggressive compression, manual consolidation  
 3. Slow: reduce `MODEL_MAX_TOKENS`, enable cache, category-specific benchmarks  
 
@@ -172,7 +172,7 @@ cd chapter3/memobase
 # python -m pip install -r requirements.txt
 
 cp env.example .env
-# 手写 Agent 填写 Kimi API Key
+# 手写 Agent 可填写 KIMI_API_KEY；也可用 LLM_PROVIDER=dashscope 与 DASHSCOPE_API_KEY
 ```
 
 在 `config.py` 中调整模型、记忆阈值、基准与日志。

--- a/chapter3/memobase/config.py
+++ b/chapter3/memobase/config.py
@@ -32,10 +32,19 @@ def _openrouter_model_id(model) -> str:
     return "openai/gpt-5.6-luna"
 
 
-# Kimi K3 Model Configuration
-KIMI_API_KEY = os.getenv("KIMI_API_KEY", "") or os.getenv("MOONSHOT_API_KEY", "")
-KIMI_BASE_URL = "https://api.moonshot.cn/v1"
-KIMI_MODEL = "kimi-k3"  # Kimi K3 model identifier
+# Chat model configuration (Kimi by default; DashScope/Bailian aliases supported)
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "kimi").lower()
+LLM_PROVIDER = {"qwen": "dashscope", "bailian": "dashscope"}.get(LLM_PROVIDER, LLM_PROVIDER)
+if LLM_PROVIDER == "dashscope":
+    KIMI_API_KEY = os.getenv("DASHSCOPE_API_KEY", "")
+    KIMI_BASE_URL = os.getenv(
+        "DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    )
+    KIMI_MODEL = os.getenv("MODEL_NAME", "qwen3.7-plus")
+else:
+    KIMI_API_KEY = os.getenv("KIMI_API_KEY", "") or os.getenv("MOONSHOT_API_KEY", "")
+    KIMI_BASE_URL = "https://api.moonshot.cn/v1"
+    KIMI_MODEL = os.getenv("MODEL_NAME", "kimi-k3")  # Kimi K3 model identifier
 
 # Universal OpenRouter fallback: primary key (KIMI/MOONSHOT) absent but
 # OPENROUTER_API_KEY present -> route the chat LLM through OpenRouter.

--- a/chapter3/memobase/env.example
+++ b/chapter3/memobase/env.example
@@ -1,5 +1,12 @@
+# Provider: kimi (default) or dashscope/qwen/bailian
+LLM_PROVIDER=kimi
+
 # Kimi API Configuration
 KIMI_API_KEY=your-kimi-api-key
+
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+# DASHSCOPE_API_KEY=your-dashscope-api-key
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
 # OpenRouter universal fallback (optional): if KIMI_API_KEY / MOONSHOT_API_KEY
 # is missing but OPENROUTER_API_KEY is set, the chat LLM is routed through

--- a/chapter3/memobase/quickstart.py
+++ b/chapter3/memobase/quickstart.py
@@ -21,9 +21,10 @@ def quick_demo():
     print("=" * 60)
     
     # Check for API key
-    api_key = os.getenv("KIMI_API_KEY", "")
+    provider = os.getenv("LLM_PROVIDER", "kimi").lower()
+    api_key = os.getenv("DASHSCOPE_API_KEY", "") if provider in {"dashscope", "qwen", "bailian"} else os.getenv("KIMI_API_KEY", "")
     if not api_key or api_key == "your-kimi-api-key":
-        print("\n⚠️  Warning: KIMI_API_KEY not set properly!")
+        print(f"\n⚠️  Warning: API key for provider '{provider}' not set properly!")
         print("Please set your API key in .env file or as environment variable")
         print("\nContinuing with demo setup...")
         api_key = "demo-key"  # Use demo key for structure demonstration
@@ -142,7 +143,7 @@ def quick_demo():
         print("✅ Quick Start Demo Complete!")
         print("=" * 60)
         print("\nNext steps:")
-        print("1. Set your KIMI_API_KEY in .env file")
+        print("1. Set DASHSCOPE_API_KEY for dashscope/qwen/bailian or KIMI_API_KEY for kimi in .env")
         print("2. Run 'python main.py --mode interactive' for full interaction")
         print("3. Run 'python main.py --mode benchmark' for complete evaluation")
         print("4. Check README.md for detailed documentation")

--- a/chapter3/structured-index/config.py
+++ b/chapter3/structured-index/config.py
@@ -95,19 +95,27 @@ class APIConfig:
 
 def get_raptor_config() -> RaptorConfig:
     """Get RAPTOR configuration from environment."""
+    provider = os.getenv("LLM_PROVIDER", "openai").lower()
+    provider = {"qwen": "dashscope", "bailian": "dashscope"}.get(provider, provider)
     openai_key = os.getenv("OPENAI_API_KEY", "")
+    dashscope_key = os.getenv("DASHSCOPE_API_KEY", "")
     ark_key = os.getenv("ARK_API_KEY") or os.getenv("DOUBAO_API_KEY", "")
-    direct_key = openai_key or ark_key
+    direct_key = dashscope_key if provider == "dashscope" else (openai_key or ark_key)
     default_model = (
+        os.getenv("RAPTOR_MODEL", "qwen3.7-plus")
+        if provider == "dashscope"
+        else (
         os.getenv("ARK_MODEL", "doubao-seed-1-6-250615")
         if ark_key and not openai_key
-        else "gpt-5.6-luna"
+        else "gpt-5.6-luna")
     )
     api_key, base_url, model_name = _resolve_llm(
         direct_key,
         os.getenv("RAPTOR_MODEL", default_model),
     )
-    if base_url is None and ark_key and not openai_key:
+    if base_url is None and provider == "dashscope":
+        base_url = os.getenv("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1")
+    elif base_url is None and ark_key and not openai_key:
         base_url = "https://ark.cn-beijing.volces.com/api/v3"
     return RaptorConfig(
         openai_api_key=api_key,
@@ -125,20 +133,28 @@ def get_raptor_config() -> RaptorConfig:
 
 def get_graphrag_config() -> GraphRAGConfig:
     """Get GraphRAG configuration from environment."""
+    provider = os.getenv("LLM_PROVIDER", "openai").lower()
+    provider = {"qwen": "dashscope", "bailian": "dashscope"}.get(provider, provider)
     openai_key = os.getenv("OPENAI_API_KEY", "")
+    dashscope_key = os.getenv("DASHSCOPE_API_KEY", "")
     ark_key = os.getenv("ARK_API_KEY") or os.getenv("DOUBAO_API_KEY", "")
-    direct_key = openai_key or ark_key
+    direct_key = dashscope_key if provider == "dashscope" else (openai_key or ark_key)
     default_model = (
+        os.getenv("GRAPHRAG_MODEL", "qwen3.7-plus")
+        if provider == "dashscope"
+        else (
         os.getenv("ARK_MODEL", "doubao-seed-1-6-250615")
         if ark_key and not openai_key
-        else "gpt-5.6-luna"
+        else "gpt-5.6-luna")
     )
     api_key, base_url, llm_model, summ_model = _resolve_llm(
         direct_key,
         os.getenv("GRAPHRAG_MODEL", default_model),
         os.getenv("GRAPHRAG_SUMMARY_MODEL", default_model),
     )
-    if base_url is None and ark_key and not openai_key:
+    if base_url is None and provider == "dashscope":
+        base_url = os.getenv("DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1")
+    elif base_url is None and ark_key and not openai_key:
         base_url = "https://ark.cn-beijing.volces.com/api/v3"
     return GraphRAGConfig(
         llm_api_key=api_key,

--- a/chapter3/structured-index/env.example
+++ b/chapter3/structured-index/env.example
@@ -1,5 +1,12 @@
+# LLM provider: openai (default) or dashscope/qwen/bailian
+LLM_PROVIDER=openai
+
 # OpenAI API Configuration
 OPENAI_API_KEY=your-openai-api-key-here
+
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+# DASHSCOPE_API_KEY=your-dashscope-api-key-here
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
 # OpenRouter universal fallback (optional): the chat LLM used for RAPTOR
 # summarization and GraphRAG entity extraction is routed through OpenRouter

--- a/chapter3/structured-knowledge-extraction/README.md
+++ b/chapter3/structured-knowledge-extraction/README.md
@@ -88,7 +88,7 @@ cd chapter3/structured-knowledge-extraction
 # Single-project compatibility path, still supported during migration:
 # python -m pip install -r requirements.txt
 
-cp env.example .env        # set OPENAI_API_KEY (default model gpt-5.6-luna)
+cp env.example .env        # set the selected provider key (OpenAI or DashScope/Bailian)
 python generate_data.py    # optional: regenerate synthetic cases (repo ships data/cases.jsonl)
 python demo.py             # full pipeline: discovery → extract → cluster → conversational advice
 ```

--- a/chapter3/structured-knowledge-extraction/config.py
+++ b/chapter3/structured-knowledge-extraction/config.py
@@ -38,17 +38,25 @@ def _openrouter_model_id(model) -> str:
     return "openai/gpt-5.6-luna"
 
 
+# Provider: OpenAI by default; DashScope/Qwen/Bailian are OpenAI-compatible.
+PROVIDER = os.getenv("LLM_PROVIDER", "openai").lower()
+PROVIDER = {"qwen": "dashscope", "bailian": "dashscope"}.get(PROVIDER, PROVIDER)
 # 默认模型，可用环境变量覆盖
-MODEL = os.getenv("OPENAI_MODEL", "gpt-5.6-luna")
+MODEL = os.getenv(
+    "DASHSCOPE_MODEL" if PROVIDER == "dashscope" else "OPENAI_MODEL",
+    "qwen3.7-plus" if PROVIDER == "dashscope" else "gpt-5.6-luna",
+)
 
 # 通用 OpenRouter 回退：若没有 OPENAI_API_KEY 但设置了 OPENROUTER_API_KEY，
 # 则把聊天模型路由到 OpenRouter，并把模型名映射为 OpenRouter 的 id。
 _OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+_DASHSCOPE_API_KEY = os.getenv("DASHSCOPE_API_KEY")
 _OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 # gpt-5.x（含 gpt-5.6*）在 OpenAI 直连 API 上需要组织实名认证；只要设置了
 # OPENROUTER_API_KEY，就优先把这类 id 走 OpenRouter。
 _PREFER_OPENROUTER = bool(_OPENROUTER_API_KEY) and MODEL.lower().startswith("gpt-5")
-_USE_OPENROUTER = _PREFER_OPENROUTER or ((not _OPENAI_API_KEY) and bool(_OPENROUTER_API_KEY))
+_PRIMARY_API_KEY = _DASHSCOPE_API_KEY if PROVIDER == "dashscope" else _OPENAI_API_KEY
+_USE_OPENROUTER = _PREFER_OPENROUTER or ((not _PRIMARY_API_KEY) and bool(_OPENROUTER_API_KEY))
 if _USE_OPENROUTER:
     MODEL = _openrouter_model_id(MODEL)
 
@@ -60,7 +68,17 @@ def get_client() -> OpenAI:
     回退到 OpenRouter（OpenAI 兼容端点）。"""
     # timeout + 自动重试：发现/抽取阶段要连续发几十次请求，单次瞬时错误
     # （网络抖动 / 限流 / 5xx）不应中断整条流水线。
-    if _OPENAI_API_KEY and not _PREFER_OPENROUTER:
+    if _PRIMARY_API_KEY and not _PREFER_OPENROUTER:
+        if PROVIDER == "dashscope":
+            return OpenAI(
+                api_key=_DASHSCOPE_API_KEY,
+                base_url=os.getenv(
+                    "DASHSCOPE_BASE_URL",
+                    "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                ),
+                timeout=60.0,
+                max_retries=5,
+            )
         return OpenAI(api_key=_OPENAI_API_KEY, timeout=60.0, max_retries=5)
     if _OPENROUTER_API_KEY:
         return OpenAI(
@@ -70,6 +88,6 @@ def get_client() -> OpenAI:
             max_retries=5,
         )
     raise RuntimeError(
-        "未找到 OPENAI_API_KEY 或 OPENROUTER_API_KEY，请先 `cp env.example .env` "
-        "并填入你的 OpenAI Key（或 OpenRouter Key 作为回退）。"
+        "未找到所选 provider 的 API Key，请设置 OPENAI_API_KEY、DASHSCOPE_API_KEY "
+        "或 OPENROUTER_API_KEY。"
     )

--- a/chapter3/structured-knowledge-extraction/env.example
+++ b/chapter3/structured-knowledge-extraction/env.example
@@ -1,5 +1,12 @@
+# Provider: openai (default) or dashscope/qwen/bailian
+LLM_PROVIDER=openai
+
 # 复制为 .env 后填入你的 OpenAI API Key
 OPENAI_API_KEY=your-openai-api-key
+
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+# DASHSCOPE_API_KEY=your-dashscope-api-key
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
 # 可选：覆盖默认模型（默认 gpt-5.6-luna）
 # OPENAI_MODEL=gpt-5.6-luna

--- a/chapter3/user-memory/PROVIDERS.md
+++ b/chapter3/user-memory/PROVIDERS.md
@@ -2,6 +2,14 @@
 
 The User Memory System now supports multiple LLM providers, allowing you to choose the best provider for your needs.
 
+### Alibaba Cloud DashScope / Bailian (Qwen)
+
+- **Provider names**: `dashscope`, `qwen`, or `bailian` (aliases)
+- **API key**: `DASHSCOPE_API_KEY`
+- **Default model**: `qwen3.7-plus`
+- **Base URL**: `https://dashscope.aliyuncs.com/compatible-mode/v1`
+- For an international-region key, set `DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1`.
+
 ## Supported Providers
 
 ### 1. **Kimi/Moonshot** (Default)
@@ -66,6 +74,11 @@ python main.py --mode interactive
 
 # Specify provider
 python main.py --provider siliconflow --mode interactive
+
+# Alibaba Cloud Model Studio / Bailian
+export DASHSCOPE_API_KEY="your-dashscope-key"
+python main.py --provider dashscope --mode interactive
+# `qwen` and `bailian` are accepted aliases for `dashscope`.
 
 # Specify provider and model
 python main.py --provider doubao --model "doubao-seed-1-6-thinking-250715" --mode demo

--- a/chapter3/user-memory/README.md
+++ b/chapter3/user-memory/README.md
@@ -13,7 +13,7 @@
 
 - **Separated architecture**: conversational agent vs background memory processor  
 - **Memory modes**: notes → enhanced notes → JSON cards → advanced JSON cards  
-- **Providers**: Kimi/Moonshot, SiliconFlow, Doubao, OpenRouter  
+- **Providers**: Alibaba Cloud DashScope/Bailian (Qwen), Kimi/Moonshot, SiliconFlow, Doubao, OpenRouter
 - **React + tools** for structured memory ops  
 - **Streaming** with tool calls  
 - **Evaluation** integration with `user-memory-evaluation`  
@@ -43,7 +43,7 @@ cd chapter3/user-memory
 # python -m pip install -r requirements.txt
 
 cp env.example .env
-# MOONSHOT_API_KEY / SILICONFLOW_API_KEY / DOUBAO_API_KEY / OPENROUTER_API_KEY
+# DASHSCOPE_API_KEY / MOONSHOT_API_KEY / SILICONFLOW_API_KEY / DOUBAO_API_KEY / OPENROUTER_API_KEY
 ```
 
 ### Quick start
@@ -92,6 +92,7 @@ python main.py --mode evaluation --memory-mode advanced_json_cards --provider ki
 
 | Provider | Models (examples) | Notes |
 |----------|-------------------|--------|
+| DashScope / Bailian (Qwen) | qwen3.7-plus | Alibaba Cloud Model Studio; `qwen` and `bailian` are aliases |
 | Kimi/Moonshot | kimi-k3 | Chinese, general |
 | SiliconFlow | Qwen3-235B-… | High performance |
 | Doubao | doubao-seed-1-6-thinking-… | ByteDance |
@@ -101,6 +102,7 @@ python main.py --mode evaluation --memory-mode advanced_json_cards --provider ki
 python main.py --provider siliconflow --model "Qwen/Qwen3-235B-A22B-Thinking-2507"
 python main.py --provider openrouter --model "google/gemini-3.5-flash"
 python main.py --provider doubao --model "doubao-seed-1-6-thinking-250715"
+python main.py --provider dashscope --model "qwen3.7-plus"
 ```
 
 ### API usage
@@ -154,6 +156,7 @@ Uses test cases from `user-memory-evaluation` (histories → question → score/
 
 ```bash
 PROVIDER=kimi
+# For DashScope/Bailian, use PROVIDER=dashscope (or qwen/bailian) and set DASHSCOPE_API_KEY.
 MODEL_TEMPERATURE=0.3
 MODEL_MAX_TOKENS=4096
 MEMORY_MODE=enhanced_notes

--- a/chapter3/user-memory/agent.py
+++ b/chapter3/user-memory/agent.py
@@ -69,7 +69,7 @@ class UserMemoryAgent:
         Args:
             user_id: Unique user identifier
             api_key: API key (defaults to env based on provider)
-            provider: LLM provider ('siliconflow', 'doubao', 'kimi', 'moonshot')
+            provider: LLM provider ('dashscope'/'qwen'/'bailian', 'siliconflow', 'doubao', 'kimi', 'moonshot')
             model: Model name (defaults to provider's default)
             config: Agent configuration
             verbose: Enable verbose logging
@@ -80,6 +80,9 @@ class UserMemoryAgent:
         
         # Determine provider
         self.provider = (provider or Config.PROVIDER).lower()
+        self.provider = {"qwen": "dashscope", "bailian": "dashscope"}.get(
+            self.provider, self.provider
+        )
         
         # Get API key for provider
         api_key = api_key or Config.get_api_key(self.provider)
@@ -98,7 +101,13 @@ class UserMemoryAgent:
             )
 
         # Configure client based on provider
-        if self.provider == "siliconflow":
+        if self.provider == "dashscope":
+            self.client = OpenAI(
+                api_key=api_key,
+                base_url=Config.DASHSCOPE_BASE_URL
+            )
+            self.model = model or PROVIDER_DEFAULT_MODELS["dashscope"]
+        elif self.provider == "siliconflow":
             self.client = OpenAI(
                 api_key=api_key,
                 base_url="https://api.siliconflow.cn/v1"
@@ -125,7 +134,7 @@ class UserMemoryAgent:
             self.model = model or "google/gemini-3.5-flash"
             # Supported models: google/gemini-3.5-flash, openai/gpt-5, anthropic/claude-sonnet-4
         else:
-            raise ValueError(f"Unsupported provider: {self.provider}. Use 'siliconflow', 'doubao', 'kimi', 'moonshot', or 'openrouter'")
+            raise ValueError(f"Unsupported provider: {self.provider}. Use 'dashscope'/'qwen'/'bailian', 'siliconflow', 'doubao', 'kimi', 'moonshot', or 'openrouter'")
         
         # Initialize memory manager
         self.memory_manager = create_memory_manager(user_id, self.config.memory_mode)

--- a/chapter3/user-memory/background_memory_processor.py
+++ b/chapter3/user-memory/background_memory_processor.py
@@ -62,7 +62,7 @@ class BackgroundMemoryProcessor:
         Args:
             user_id: Unique user identifier
             api_key: API key (defaults to env based on provider)
-            provider: LLM provider ('siliconflow', 'doubao', 'kimi', 'moonshot')
+            provider: LLM provider ('dashscope'/'qwen'/'bailian', 'siliconflow', 'doubao', 'kimi', 'moonshot')
             model: Model name (defaults to provider's default)
             config: Processor configuration
             memory_mode: Memory storage mode

--- a/chapter3/user-memory/config.py
+++ b/chapter3/user-memory/config.py
@@ -46,6 +46,7 @@ def openrouter_model_id(model) -> str:
 # Default model per provider, used to map onto an OpenRouter model id when the
 # primary provider key is missing but OPENROUTER_API_KEY is present.
 PROVIDER_DEFAULT_MODELS = {
+    "dashscope": "qwen3.7-plus",
     "siliconflow": "Qwen/Qwen3-235B-A22B-Thinking-2507",
     "doubao": os.getenv("ARK_MODEL", "doubao-seed-1-6-250615"),
     "kimi": "kimi-k3",
@@ -70,6 +71,7 @@ class Config:
     # API Keys for different providers
     MOONSHOT_API_KEY: str = os.getenv("MOONSHOT_API_KEY", "")  # For kimi/moonshot
     SILICONFLOW_API_KEY: str = os.getenv("SILICONFLOW_API_KEY", "")
+    DASHSCOPE_API_KEY: str = os.getenv("DASHSCOPE_API_KEY", "")
     # Ark is the provider's canonical product name; older companion docs used
     # DOUBAO_API_KEY. Accept both without copying credentials into local files.
     DOUBAO_API_KEY: str = os.getenv("DOUBAO_API_KEY") or os.getenv("ARK_API_KEY", "")
@@ -78,6 +80,9 @@ class Config:
     # Base URLs for different providers
     MOONSHOT_BASE_URL: str = "https://api.moonshot.cn/v1"
     SILICONFLOW_BASE_URL: str = "https://api.siliconflow.cn/v1"
+    DASHSCOPE_BASE_URL: str = os.getenv(
+        "DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    )
     DOUBAO_BASE_URL: str = "https://ark.cn-beijing.volces.com/api/v3"
     OPENROUTER_BASE_URL: str = "https://openrouter.ai/api/v1"
     
@@ -126,9 +131,12 @@ class Config:
             API key or None if not found
         """
         provider = (provider or cls.PROVIDER).lower()
+        provider = {"qwen": "dashscope", "bailian": "dashscope"}.get(provider, provider)
         
         if provider in ["kimi", "moonshot"]:
             return cls.MOONSHOT_API_KEY
+        elif provider == "dashscope":
+            return cls.DASHSCOPE_API_KEY
         elif provider == "siliconflow":
             return cls.SILICONFLOW_API_KEY
         elif provider == "doubao":
@@ -150,6 +158,7 @@ class Config:
             True if configuration is valid
         """
         provider = (provider or cls.PROVIDER).lower()
+        provider = {"qwen": "dashscope", "bailian": "dashscope"}.get(provider, provider)
         api_key = cls.get_api_key(provider)
         
         if not api_key:
@@ -158,6 +167,8 @@ class Config:
                 print("Please set MOONSHOT_API_KEY in .env file or as environment variable")
             elif provider == "siliconflow":
                 print("Please set SILICONFLOW_API_KEY in .env file or as environment variable")
+            elif provider == "dashscope":
+                print("Please set DASHSCOPE_API_KEY in .env file or as environment variable")
             elif provider == "doubao":
                 print("Please set DOUBAO_API_KEY in .env file or as environment variable")
             elif provider == "openrouter":
@@ -210,6 +221,7 @@ class Config:
         # Show which API keys are set
         print(f"\nAPI Keys:")
         print(f"  Kimi/Moonshot: {'✓ Set' if cls.MOONSHOT_API_KEY else '✗ Not set'}")
+        print(f"  DashScope/Bailian: {'✓ Set' if cls.DASHSCOPE_API_KEY else '✗ Not set'}")
         print(f"  SiliconFlow: {'✓ Set' if cls.SILICONFLOW_API_KEY else '✗ Not set'}")
         print(f"  Doubao: {'✓ Set' if cls.DOUBAO_API_KEY else '✗ Not set'}")
         print(f"  OpenRouter: {'✓ Set' if cls.OPENROUTER_API_KEY else '✗ Not set'}")

--- a/chapter3/user-memory/conversational_agent.py
+++ b/chapter3/user-memory/conversational_agent.py
@@ -58,7 +58,7 @@ class ConversationalAgent:
         Args:
             user_id: Unique user identifier
             api_key: API key (defaults to env based on provider)
-            provider: LLM provider ('siliconflow', 'doubao', 'kimi', 'moonshot')
+            provider: LLM provider ('dashscope'/'qwen'/'bailian', 'siliconflow', 'doubao', 'kimi', 'moonshot')
             model: Model name (defaults to provider's default)
             config: Agent configuration
             memory_mode: Memory storage mode
@@ -71,6 +71,9 @@ class ConversationalAgent:
         
         # Determine provider
         self.provider = (provider or Config.PROVIDER).lower()
+        self.provider = {"qwen": "dashscope", "bailian": "dashscope"}.get(
+            self.provider, self.provider
+        )
         
         # Get API key for provider
         api_key = api_key or Config.get_api_key(self.provider)
@@ -89,7 +92,13 @@ class ConversationalAgent:
             )
 
         # Configure client based on provider
-        if self.provider == "siliconflow":
+        if self.provider == "dashscope":
+            self.client = OpenAI(
+                api_key=api_key,
+                base_url=Config.DASHSCOPE_BASE_URL
+            )
+            self.model = model or PROVIDER_DEFAULT_MODELS["dashscope"]
+        elif self.provider == "siliconflow":
             self.client = OpenAI(
                 api_key=api_key,
                 base_url="https://api.siliconflow.cn/v1"
@@ -116,7 +125,7 @@ class ConversationalAgent:
             self.model = model or "google/gemini-3.5-flash"
             # Supported models: google/gemini-3.5-flash, openai/gpt-5, anthropic/claude-sonnet-4
         else:
-            raise ValueError(f"Unsupported provider: {self.provider}. Use 'siliconflow', 'doubao', 'kimi', 'moonshot', or 'openrouter'")
+            raise ValueError(f"Unsupported provider: {self.provider}. Use 'dashscope'/'qwen'/'bailian', 'siliconflow', 'doubao', 'kimi', 'moonshot', or 'openrouter'")
         
         # Initialize memory manager (read-only access)
         self.memory_manager = create_memory_manager(user_id, memory_mode)

--- a/chapter3/user-memory/env.example
+++ b/chapter3/user-memory/env.example
@@ -1,11 +1,12 @@
 # User Memory System Configuration
 
 # Provider Selection (default: kimi)
-# Options: kimi (== moonshot), siliconflow, doubao, openrouter
+# Options: dashscope (== qwen/bailian), kimi (== moonshot), siliconflow, doubao, openrouter
 PROVIDER=kimi
 
 # API Keys — set the one(s) for the provider(s) you use
 MOONSHOT_API_KEY=your_moonshot_api_key_here   # for kimi / moonshot
+DASHSCOPE_API_KEY=your_dashscope_api_key_here # for dashscope / qwen / bailian
 SILICONFLOW_API_KEY=your_siliconflow_api_key_here
 DOUBAO_API_KEY=your_doubao_api_key_here
 # OpenRouter: usable as an explicit PROVIDER, and also a universal fallback —
@@ -16,7 +17,7 @@ OPENROUTER_API_KEY=your_openrouter_api_key_here
 
 # Model Settings
 # Leave MODEL_NAME empty to use each provider's built-in default
-# (kimi -> kimi-k3, siliconflow -> Qwen/Qwen3-235B-A22B-Thinking-2507,
+# (dashscope -> qwen3.7-plus, kimi -> kimi-k3, siliconflow -> Qwen/Qwen3-235B-A22B-Thinking-2507,
 #  doubao -> doubao-seed-1-6-thinking-250715, openrouter -> google/gemini-3.5-flash)
 MODEL_NAME=kimi-k3
 MODEL_TEMPERATURE=0.3

--- a/chapter3/user-memory/main.py
+++ b/chapter3/user-memory/main.py
@@ -104,6 +104,8 @@ def interactive_mode(user_id: str, memory_mode: MemoryMode = MemoryMode.NOTES,
         print(f"❌ Error: Please set API key for provider '{provider}'")
         if provider in ["kimi", "moonshot"]:
             print("   export MOONSHOT_API_KEY='your-api-key-here'")
+        elif provider in ["dashscope", "qwen", "bailian"]:
+            print("   export DASHSCOPE_API_KEY='your-api-key-here'")
         elif provider == "siliconflow":
             print("   export SILICONFLOW_API_KEY='your-api-key-here'")
         elif provider == "doubao":
@@ -267,6 +269,8 @@ def demo_memory_system(memory_mode: MemoryMode = None, provider: Optional[str] =
     api_key = Config.get_api_key(provider)
     if not api_key:
         print(f"❌ Please set API key for provider '{provider}'")
+        if provider in ["dashscope", "qwen", "bailian"]:
+            print("   export DASHSCOPE_API_KEY='your-api-key-here'")
         return
     
     # Create test user
@@ -438,6 +442,8 @@ def run_evaluation_mode(user_id: str, memory_mode: MemoryMode, verbose: bool = T
     api_key = Config.get_api_key(provider)
     if not api_key:
         print(f"❌ Error: Please set API key for provider '{provider}'")
+        if provider in ["dashscope", "qwen", "bailian"]:
+            print("   export DASHSCOPE_API_KEY='your-api-key-here'")
         sys.exit(1)
     
     # Initialize agents without incorrect parameters
@@ -865,7 +871,7 @@ def main():
     
     parser.add_argument(
         "--provider",
-        choices=["siliconflow", "doubao", "kimi", "moonshot", "openrouter"],
+        choices=["dashscope", "qwen", "bailian", "siliconflow", "doubao", "kimi", "moonshot", "openrouter"],
         default=None,
         help="LLM provider (defaults to env PROVIDER or 'kimi')"
     )

--- a/chapter3/user-memory/memory_cli.py
+++ b/chapter3/user-memory/memory_cli.py
@@ -277,7 +277,7 @@ def build_parser():
     add_common(p_ext)
     p_ext.add_argument("--conversation", required=True, help="对话文本或对话文件路径")
     p_ext.add_argument("--provider", default=None,
-                       choices=["siliconflow", "doubao", "kimi", "moonshot", "openrouter"],
+                       choices=["dashscope", "qwen", "bailian", "siliconflow", "doubao", "kimi", "moonshot", "openrouter"],
                        help="LLM 提供商（默认取环境变量 PROVIDER）")
     p_ext.add_argument("--model", default=None, help="模型名称（默认使用提供商默认模型）")
     p_ext.set_defaults(func=cmd_extract)

--- a/chapter4/active-tool-selection/README.md
+++ b/chapter4/active-tool-selection/README.md
@@ -213,7 +213,12 @@ cp env.example .env
 > (`base_url=https://openrouter.ai/api/v1`) and maps the model id to
 > `provider/model` form (`gpt-*` → `openai/…`, `claude-*` →
 > `anthropic/claude-opus-4.8`). Existing `OPENAI_BASE_URL`/`OPENAI_MODEL`
+
 > overrides are preserved.
+
+For direct Alibaba Cloud Model Studio / Bailian (Qwen), set
+`LLM_PROVIDER=dashscope` (or `qwen`/`bailian`) and `DASHSCOPE_API_KEY`; the
+default model is `qwen3.7-plus`. Set `DASHSCOPE_BASE_URL` for international keys.
 
 #### 3. Run Quick Start
 

--- a/chapter4/active-tool-selection/config.py
+++ b/chapter4/active-tool-selection/config.py
@@ -5,9 +5,18 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # LLM Configuration
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
-OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-5.6-luna")
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai").lower()
+LLM_PROVIDER = {"qwen": "dashscope", "bailian": "dashscope"}.get(LLM_PROVIDER, LLM_PROVIDER)
+if LLM_PROVIDER == "dashscope":
+    OPENAI_API_KEY = os.getenv("DASHSCOPE_API_KEY")
+    OPENAI_BASE_URL = os.getenv(
+        "DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    )
+    OPENAI_MODEL = os.getenv("DASHSCOPE_MODEL", "qwen3.7-plus")
+else:
+    OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+    OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-5.6-luna")
 
 
 def _map_model_for_openrouter(model: str) -> str:

--- a/chapter4/active-tool-selection/env.example
+++ b/chapter4/active-tool-selection/env.example
@@ -1,7 +1,15 @@
+# Provider: openai (default) or dashscope/qwen/bailian
+LLM_PROVIDER=openai
+
 # OpenAI API Configuration
 OPENAI_API_KEY=your_api_key_here
 OPENAI_BASE_URL=https://api.openai.com/v1
 OPENAI_MODEL=gpt-5.6-luna
+
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+# DASHSCOPE_API_KEY=your_dashscope_api_key_here
+# DASHSCOPE_MODEL=qwen3.7-plus
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
 # Or use compatible APIs (Kimi, DeepSeek, etc.)
 # OPENAI_BASE_URL=https://api.moonshot.cn/v1

--- a/chapter4/agent-with-event-trigger/README.md
+++ b/chapter4/agent-with-event-trigger/README.md
@@ -85,6 +85,12 @@ Drop `--mock` to use a real LLM (built-in tools only by default, no MCP); set th
 ```bash
 export KIMI_API_KEY='your-api-key-here'
 python event_loop_demo.py --trigger timer --provider kimi
+
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+export DASHSCOPE_API_KEY='your-dashscope-api-key-here'
+python event_loop_demo.py --trigger timer --provider dashscope
+# `qwen` and `bailian` are accepted aliases; international keys may use
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 ```
 
 > **Universal OpenRouter fallback**: if the chosen provider’s key is missing (default `kimi`) but `OPENROUTER_API_KEY` is set, `event_loop_demo.py` / `server.py` / `quickstart.py` switch to `openrouter` (set model with `LLM_MODEL=openai/gpt-5.6-luna`). Example:  
@@ -153,6 +159,7 @@ cd chapter4/agent-with-event-trigger
 cp env.example .env
 # Edit .env and add your API key
 export KIMI_API_KEY='your-api-key-here'
+export DASHSCOPE_API_KEY='your-dashscope-api-key-here'  # for dashscope/qwen/bailian
 ```
 
 #### Tests and Manual Demo
@@ -352,7 +359,7 @@ Uses:
 export KIMI_API_KEY="your-key"
 
 # Optional
-export LLM_PROVIDER="kimi"              # kimi, siliconflow, doubao, openrouter
+export LLM_PROVIDER="kimi"              # dashscope/qwen/bailian, kimi, siliconflow, doubao, openrouter
 export LLM_MODEL="kimi-k3" # Override default model
 export AGENT_PORT="8000"                # Server port (default: 8000)
 export ENABLE_MCP_TOOLS="true"          # Enable MCP (default: true)
@@ -665,6 +672,9 @@ python event_loop_demo.py --mock --trigger file --watch-dir watched_dir
 ```bash
 export KIMI_API_KEY='your-api-key-here'
 python event_loop_demo.py --trigger timer --provider kimi
+
+export DASHSCOPE_API_KEY='your-dashscope-api-key-here'
+python event_loop_demo.py --trigger timer --provider dashscope
 ```
 
 > **OpenRouter 通用兜底**：若所选 provider（默认 `kimi`）的 Key 缺失，但设置了
@@ -899,7 +909,7 @@ curl -X POST http://localhost:8000/event \
 export KIMI_API_KEY="your-key"
 
 # Optional
-export LLM_PROVIDER="kimi"              # kimi, siliconflow, doubao, openrouter
+export LLM_PROVIDER="kimi"              # dashscope/qwen/bailian, kimi, siliconflow, doubao, openrouter
 export LLM_MODEL="kimi-k3" # Override default model
 export AGENT_PORT="8000"                # Server port (default: 8000)
 export ENABLE_MCP_TOOLS="true"          # Enable MCP (default: true)

--- a/chapter4/agent-with-event-trigger/agent.py
+++ b/chapter4/agent-with-event-trigger/agent.py
@@ -44,6 +44,9 @@ def _reasoning_safe_temperature(model, requested=1.0):
 
 # Per-provider env var holding that provider's API key.
 _PROVIDER_KEY_ENV = {
+    "dashscope": "DASHSCOPE_API_KEY",
+    "qwen": "DASHSCOPE_API_KEY",
+    "bailian": "DASHSCOPE_API_KEY",
     "siliconflow": "SILICONFLOW_API_KEY",
     "doubao": "DOUBAO_API_KEY",
     "kimi": "KIMI_API_KEY",
@@ -62,6 +65,7 @@ def resolve_provider_and_key(provider: Optional[str] = None):
     emit its own error.
     """
     provider = (provider or os.getenv("LLM_PROVIDER", "kimi")).lower()
+    provider = {"qwen": "dashscope", "bailian": "dashscope"}.get(provider, provider)
     key_env = _PROVIDER_KEY_ENV.get(provider)
     api_key = os.getenv(key_env) if key_env else None
     if api_key:
@@ -263,17 +267,29 @@ class EventTriggeredAgent:
         
         Args:
             api_key: API key for the LLM provider
-            provider: LLM provider ('siliconflow', 'doubao', 'kimi', 'moonshot', 'openrouter')
+            provider: LLM provider ('dashscope'/'qwen'/'bailian', 'siliconflow', 'doubao', 'kimi', 'moonshot', 'openrouter')
             model: Optional model override
             config: System hint configuration
             verbose: If True, log full details
         """
         self.provider = provider.lower()
+        self.provider = {"qwen": "dashscope", "bailian": "dashscope"}.get(
+            self.provider, self.provider
+        )
         self.verbose = verbose
         self.config = config or SystemHintConfig()
         
         # Configure client based on provider (matching conversational_agent.py)
-        if self.provider == "siliconflow":
+        if self.provider == "dashscope":
+            self.client = OpenAI(
+                api_key=api_key,
+                base_url=os.getenv(
+                    "DASHSCOPE_BASE_URL",
+                    "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                )
+            )
+            self.model = model or "qwen3.7-plus"
+        elif self.provider == "siliconflow":
             self.client = OpenAI(
                 api_key=api_key,
                 base_url="https://api.siliconflow.cn/v1"
@@ -300,7 +316,7 @@ class EventTriggeredAgent:
             self.model = model or "google/gemini-3.5-flash"
             # Supported models: google/gemini-3.5-flash, openai/gpt-5.6-luna, anthropic/claude-sonnet-4.6
         else:
-            raise ValueError(f"Unsupported provider: {provider}. Use 'siliconflow', 'doubao', 'kimi', 'moonshot', or 'openrouter'")
+            raise ValueError(f"Unsupported provider: {provider}. Use 'dashscope'/'qwen'/'bailian', 'siliconflow', 'doubao', 'kimi', 'moonshot', or 'openrouter'")
         
         # Initialize tracking
         self.tool_call_counts: Dict[str, int] = {}

--- a/chapter4/agent-with-event-trigger/env.example
+++ b/chapter4/agent-with-event-trigger/env.example
@@ -2,11 +2,12 @@
 # Choose one provider and set the corresponding API key
 
 # Provider selection (default: kimi)
-# Options: siliconflow, doubao, kimi, moonshot, openrouter
+# Options: dashscope (== qwen/bailian), siliconflow, doubao, kimi, moonshot, openrouter
 LLM_PROVIDER=kimi
 
 # API Keys (set the one matching your provider)
 KIMI_API_KEY=your-kimi-api-key-here
+# DASHSCOPE_API_KEY=your-dashscope-api-key-here
 # SILICONFLOW_API_KEY=your-siliconflow-api-key-here
 # DOUBAO_API_KEY=your-doubao-api-key-here
 # OPENROUTER_API_KEY=your-openrouter-api-key-here
@@ -23,6 +24,7 @@ KIMI_API_KEY=your-kimi-api-key-here
 # - siliconflow: Qwen/Qwen3-235B-A22B-Thinking-2507
 # - doubao: doubao-seed-1-6-thinking-250715
 # - kimi/moonshot: kimi-k3
+# - dashscope/qwen/bailian: qwen3.7-plus
 # - openrouter: google/gemini-3.5-flash
 #   (also supports: openai/gpt-5, anthropic/claude-sonnet-4)
 

--- a/chapter4/agent-with-event-trigger/event_loop_demo.py
+++ b/chapter4/agent-with-event-trigger/event_loop_demo.py
@@ -329,7 +329,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--provider", default=os.getenv("LLM_PROVIDER", "kimi"),
-        choices=["siliconflow", "doubao", "kimi", "moonshot", "openrouter"],
+        choices=["dashscope", "qwen", "bailian", "siliconflow", "doubao", "kimi", "moonshot", "openrouter"],
         help="真实模式使用的大模型提供商（默认：环境变量 LLM_PROVIDER 或 kimi）",
     )
     parser.add_argument(

--- a/chapter4/agent-with-event-trigger/example_with_mcp.py
+++ b/chapter4/agent-with-event-trigger/example_with_mcp.py
@@ -5,7 +5,7 @@ Example demonstrating the Event-Triggered Agent with MCP tools
 import os
 import asyncio
 from dotenv import load_dotenv
-from agent import EventTriggeredAgent, SystemHintConfig
+from agent import EventTriggeredAgent, SystemHintConfig, resolve_provider_and_key
 from event_types import Event, EventType
 
 # Load environment variables
@@ -21,10 +21,10 @@ async def main():
     
     # Get API credentials
     provider = os.getenv("LLM_PROVIDER", "kimi")
-    api_key = os.getenv("KIMI_API_KEY")
+    provider, api_key = resolve_provider_and_key(provider)
     
     if not api_key:
-        print("❌ Please set KIMI_API_KEY in your .env file")
+        print("❌ Please set the provider API key in your .env file (DASHSCOPE_API_KEY for dashscope/qwen/bailian)")
         return
     
     # Create agent configuration

--- a/chapter4/agent-with-event-trigger/quickstart.py
+++ b/chapter4/agent-with-event-trigger/quickstart.py
@@ -19,10 +19,11 @@ resolved_provider, api_key = resolve_provider_and_key(provider)
 if not api_key:
     print(f"❌ Error: no API key for provider '{provider}', and no OPENROUTER_API_KEY fallback")
     print(f"\nPlease set one of:")
+    print(f"  export DASHSCOPE_API_KEY='...'    # for dashscope/qwen/bailian")
     print(f"  export KIMI_API_KEY='...'         # or SILICONFLOW/DOUBAO/OPENROUTER per provider")
     print(f"  export OPENROUTER_API_KEY='...'   # universal fallback")
     print(f"\nOr change provider:")
-    print(f"  export LLM_PROVIDER=kimi  # or siliconflow, doubao, openrouter")
+    print(f"  export LLM_PROVIDER=dashscope  # or qwen, bailian, siliconflow, doubao, kimi, openrouter")
     sys.exit(1)
 
 if resolved_provider != provider:

--- a/chapter4/agent-with-event-trigger/server.py
+++ b/chapter4/agent-with-event-trigger/server.py
@@ -417,7 +417,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--provider", default=None,
-        choices=["siliconflow", "doubao", "kimi", "moonshot", "openrouter"],
+        choices=["dashscope", "qwen", "bailian", "siliconflow", "doubao", "kimi", "moonshot", "openrouter"],
         help="大模型提供商（默认：环境变量 LLM_PROVIDER 或 kimi）",
     )
     parser.add_argument(

--- a/chapter4/agent-with-event-trigger/server_fastapi.py
+++ b/chapter4/agent-with-event-trigger/server_fastapi.py
@@ -9,7 +9,7 @@ from typing import Dict, Any, Optional
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, BackgroundTasks
 from pydantic import BaseModel
-from agent import EventTriggeredAgent, SystemHintConfig
+from agent import EventTriggeredAgent, SystemHintConfig, resolve_provider_and_key
 from event_types import Event, EventType
 import threading
 import time
@@ -119,26 +119,20 @@ async def init_agent():
     """Initialize the agent with optional MCP tools"""
     global agent, mcp_loading_status
     
-    # Determine provider from environment
-    provider = os.getenv("LLM_PROVIDER", "kimi").lower()
-    
-    # Get API key based on provider
-    if provider == "siliconflow":
-        api_key = os.getenv("SILICONFLOW_API_KEY")
-    elif provider == "doubao":
-        api_key = os.getenv("DOUBAO_API_KEY")
-    elif provider in ["kimi", "moonshot"]:
-        api_key = os.getenv("KIMI_API_KEY")
-    elif provider == "openrouter":
-        api_key = os.getenv("OPENROUTER_API_KEY")
-    else:
-        raise ValueError(f"Unsupported provider: {provider}")
+    # Determine provider and key, applying the universal OpenRouter fallback.
+    requested_provider = os.getenv("LLM_PROVIDER", "kimi").lower()
+    provider, api_key = resolve_provider_and_key(requested_provider)
     
     if not api_key:
-        raise ValueError(f"API key not set for provider '{provider}'. Set the appropriate environment variable.")
+        raise ValueError(
+            f"API key not set for provider '{requested_provider}'. Set the appropriate "
+            "environment variable or OPENROUTER_API_KEY."
+        )
     
     # Get model from environment if specified
     model = os.getenv("LLM_MODEL")
+    if provider == "openrouter" and provider != requested_provider and model and "/" not in model:
+        model = None
     
     # Check if MCP should be enabled (default: true)
     enable_mcp = os.getenv("ENABLE_MCP_TOOLS", "true").lower() not in ["false", "0", "no"]

--- a/chapter4/agent-with-event-trigger/tests/manual/demo.py
+++ b/chapter4/agent-with-event-trigger/tests/manual/demo.py
@@ -12,7 +12,7 @@ EXPERIMENT_ROOT = Path(__file__).resolve().parents[2]
 if str(EXPERIMENT_ROOT) not in sys.path:
     sys.path.insert(0, str(EXPERIMENT_ROOT))
 
-from agent import EventTriggeredAgent, SystemHintConfig
+from agent import EventTriggeredAgent, SystemHintConfig, resolve_provider_and_key
 from event_types import Event, EventType
 
 
@@ -32,24 +32,13 @@ def main():
     print("="*80)
     print()
     
-    # Get provider and API key (matching conversational_agent.py)
+    # Get provider and API key (including DashScope/Bailian aliases and fallback)
     provider = os.getenv("LLM_PROVIDER", "kimi").lower()
-    
-    if provider == "siliconflow":
-        api_key = os.getenv("SILICONFLOW_API_KEY")
-    elif provider == "doubao":
-        api_key = os.getenv("DOUBAO_API_KEY")
-    elif provider in ["kimi", "moonshot"]:
-        api_key = os.getenv("KIMI_API_KEY")
-    elif provider == "openrouter":
-        api_key = os.getenv("OPENROUTER_API_KEY")
-    else:
-        print(f"❌ Error: Unsupported provider: {provider}")
-        return
+    provider, api_key = resolve_provider_and_key(provider)
     
     if not api_key:
         print(f"❌ Error: Please set API key for provider '{provider}'")
-        print(f"   export {provider.upper()}_API_KEY='your-api-key-here'")
+        print("   export DASHSCOPE_API_KEY='your-api-key-here'  # for dashscope/qwen/bailian")
         return
     
     # Get optional model override

--- a/chapter4/async-agent/README.md
+++ b/chapter4/async-agent/README.md
@@ -156,6 +156,8 @@ Default OpenAI `gpt-5.6-luna`. Other OpenAI-compatible providers:
 LLM_PROVIDER=moonshot python demo.py scenarios --scenario 1
 # Volcengine ARK (LLM_MODEL = inference endpoint id)
 LLM_PROVIDER=ark LLM_MODEL=ep-xxxx python demo.py scenarios --scenario 1
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+LLM_PROVIDER=dashscope DASHSCOPE_API_KEY=your-key LLM_MODEL=qwen3.7-plus python demo.py scenarios --scenario 1
 ```
 
 > **Universal OpenRouter fallback**: if `OPENAI_API_KEY` is unset (and not moonshot/ark), with `OPENROUTER_API_KEY` set, `demo.py` routes via OpenRouter and maps model ids to `provider/model` (`gpt-*` → `openai/…`, `claude-*` → `anthropic/claude-opus-4.8`, ids with `/` pass through). Or set `LLM_PROVIDER=openrouter` explicitly. Example:  

--- a/chapter4/async-agent/demo.py
+++ b/chapter4/async-agent/demo.py
@@ -77,6 +77,15 @@ def make_client():
     """
     from openai import AsyncOpenAI  # 惰性导入：离线演示无需安装 openai
     provider = os.getenv("LLM_PROVIDER", "openai").lower()
+    if provider in {"dashscope", "qwen", "bailian"}:
+        key = os.environ["DASHSCOPE_API_KEY"]
+        model = os.getenv("LLM_MODEL", "qwen3.7-plus")
+        base_url = os.getenv(
+            "DASHSCOPE_BASE_URL",
+            "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        )
+        client = AsyncOpenAI(api_key=key, base_url=base_url)
+        return client, model, _completion_params_for(model)
     if provider == "moonshot":
         key = os.environ["MOONSHOT_API_KEY"]
         # 默认用当前的推理模型 kimi-k3（旧的 kimi-k2-*-preview 与 moonshot-v1-* 均已过时/停用）。

--- a/chapter4/async-agent/env.example
+++ b/chapter4/async-agent/env.example
@@ -1,6 +1,6 @@
 # 复制为 .env 后填入你的 key（demo.py 会自动加载）
 
-# ===== LLM 服务（三选一，默认 openai）=====
+# ===== LLM 服务（默认 openai；也支持 moonshot、dashscope/qwen/bailian、ark）=====
 LLM_PROVIDER=openai
 
 # OpenAI（默认）
@@ -12,6 +12,12 @@ LLM_MODEL=gpt-5.6-luna
 # Moonshot（LLM_PROVIDER=moonshot；默认模型为推理模型 kimi-k3，代码会自动用 temperature=1 且 max_tokens>=2048）
 MOONSHOT_API_KEY=your-moonshot-api-key
 # LLM_MODEL=kimi-k3
+
+# Alibaba Cloud Model Studio / Bailian (Qwen)
+# DASHSCOPE_API_KEY=your-dashscope-api-key
+# LLM_PROVIDER=dashscope
+# LLM_MODEL=qwen3.7-plus
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
 # 火山方舟 ARK（LLM_PROVIDER=ark，LLM_MODEL 需填推理接入点 ID）
 ARK_API_KEY=xxxx

--- a/chapter4/collaboration-tools/README.md
+++ b/chapter4/collaboration-tools/README.md
@@ -126,6 +126,9 @@ HITL_TIMEOUT_SECONDS=3600
 #### For Browser Tasks (AI Agent)
 ```env
 OPENAI_API_KEY=your-openai-api-key
+# Or use Alibaba Cloud Model Studio / Bailian (Qwen):
+# COLLAB_PROVIDER=dashscope  # qwen and bailian are aliases
+# DASHSCOPE_API_KEY=your-dashscope-api-key
 OPENAI_MODEL=gpt-5.6-luna
 ```
 

--- a/chapter4/collaboration-tools/env.example
+++ b/chapter4/collaboration-tools/env.example
@@ -1,4 +1,8 @@
 # LLM Configuration (for sub-agents, intelligence tools, and browser-use)
+# Set COLLAB_PROVIDER=dashscope (or qwen/bailian) for Alibaba Cloud Model Studio.
+# COLLAB_PROVIDER=dashscope
+# DASHSCOPE_API_KEY=your-dashscope-api-key
+# DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 # Direct OpenAI (preferred when set):
 OPENAI_API_KEY=your-openai-api-key
 # OPENAI_MODEL=gpt-5.6-luna

--- a/chapter4/collaboration-tools/src/llm_fallback.py
+++ b/chapter4/collaboration-tools/src/llm_fallback.py
@@ -44,7 +44,8 @@ def map_model_for_openrouter(model: str) -> str:
 def has_llm() -> bool:
     """True when at least one usable LLM credential is configured."""
     return bool(os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY")
-                or os.getenv("MOONSHOT_API_KEY") or os.getenv("KIMI_API_KEY"))
+                or os.getenv("MOONSHOT_API_KEY") or os.getenv("KIMI_API_KEY")
+                or os.getenv("DASHSCOPE_API_KEY"))
 
 
 def resolve_llm(default_model: str = "gpt-5.6-luna") -> Tuple[str, Optional[str], str]:
@@ -54,7 +55,20 @@ def resolve_llm(default_model: str = "gpt-5.6-luna") -> Tuple[str, Optional[str]
     """
     model = os.getenv("OPENAI_MODEL", default_model)
 
-    if os.getenv("COLLAB_PROVIDER", "").lower() == "moonshot":
+    provider = os.getenv("COLLAB_PROVIDER", "").lower()
+    if provider in {"dashscope", "qwen", "bailian"}:
+        dashscope_key = os.getenv("DASHSCOPE_API_KEY")
+        if not dashscope_key:
+            raise RuntimeError("COLLAB_PROVIDER=dashscope requires DASHSCOPE_API_KEY")
+        return (
+            dashscope_key,
+            os.getenv(
+                "DASHSCOPE_BASE_URL",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            ),
+            os.getenv("OPENAI_MODEL", "qwen3.7-plus"),
+        )
+    if provider == "moonshot":
         moonshot_key = os.getenv("MOONSHOT_API_KEY") or os.getenv("KIMI_API_KEY")
         if not moonshot_key:
             raise RuntimeError("COLLAB_PROVIDER=moonshot requires MOONSHOT_API_KEY or KIMI_API_KEY")
@@ -74,6 +88,6 @@ def resolve_llm(default_model: str = "gpt-5.6-luna") -> Tuple[str, Optional[str]
         return or_key, "https://openrouter.ai/api/v1", map_model_for_openrouter(model)
 
     raise RuntimeError(
-        "No LLM key configured. Set OPENAI_API_KEY, OPENROUTER_API_KEY, or MOONSHOT_API_KEY "
+        "No LLM key configured. Set OPENAI_API_KEY, DASHSCOPE_API_KEY, OPENROUTER_API_KEY, or MOONSHOT_API_KEY "
         "(universal fallback)."
     )

--- a/chapter4/execution-tools/EXPERIMENT.md
+++ b/chapter4/execution-tools/EXPERIMENT.md
@@ -67,6 +67,7 @@ KIMI_API_KEY=your-key
 
 **Supported Providers:**
 - **SiliconFlow**: `SILICONFLOW_API_KEY` - Uses Qwen/Qwen3-235B-A22B-Thinking-2507
+- **DashScope / Bailian (Qwen)**: `DASHSCOPE_API_KEY` - Uses `qwen3.7-plus`; select with `PROVIDER=dashscope` (or `qwen`/`bailian`)
 - **Doubao**: `DOUBAO_API_KEY` - Uses doubao-seed-1-6-thinking-250715
 - **Kimi/Moonshot**: `KIMI_API_KEY` - Uses kimi-k3 (default)
 - **OpenRouter**: `OPENROUTER_API_KEY` - Uses google/gemini-3.5-flash

--- a/chapter4/execution-tools/README.md
+++ b/chapter4/execution-tools/README.md
@@ -70,6 +70,9 @@ PROVIDER=kimi
 
 # API Keys (set the one for your provider)
 KIMI_API_KEY=your_kimi_key
+# DashScope / Bailian (Qwen)
+# PROVIDER=dashscope  # qwen and bailian are accepted aliases
+# DASHSCOPE_API_KEY=your_dashscope_key
 # SILICONFLOW_API_KEY=your_siliconflow_key
 # DOUBAO_API_KEY=your_doubao_key
 # OPENROUTER_API_KEY=your_openrouter_key
@@ -93,6 +96,7 @@ AUTO_VERIFY_CODE=true
 
 **Supported Providers:**
 - `siliconflow`: Qwen/Qwen3-235B-A22B-Thinking-2507
+- `dashscope` / `qwen` / `bailian`: qwen3.7-plus (Alibaba Cloud Model Studio)
 - `doubao`: doubao-seed-1-6-thinking-250715  
 - `kimi`/`moonshot`: kimi-k3
 - `openrouter`: google/gemini-3.5-flash (or openai/gpt-5.6-luna, anthropic/claude-sonnet-4.6)
@@ -312,6 +316,9 @@ PROVIDER=kimi
 
 # API Keys (set the one for your provider)
 KIMI_API_KEY=your_kimi_key
+# DashScope / Bailian (Qwen)
+# PROVIDER=dashscope  # qwen and bailian are accepted aliases
+# DASHSCOPE_API_KEY=your_dashscope_key
 # SILICONFLOW_API_KEY=your_siliconflow_key
 # DOUBAO_API_KEY=your_doubao_key
 # OPENROUTER_API_KEY=your_openrouter_key
@@ -335,6 +342,7 @@ AUTO_VERIFY_CODE=true
 
 **支持的 Provider：**
 - `siliconflow`：Qwen/Qwen3-235B-A22B-Thinking-2507
+- `dashscope` / `qwen` / `bailian`：qwen3.7-plus（阿里云百炼 / Model Studio）
 - `doubao`：doubao-seed-1-6-thinking-250715  
 - `kimi`/`moonshot`：kimi-k3
 - `openrouter`：google/gemini-3.5-flash（或 openai/gpt-5.6-luna、anthropic/claude-sonnet-4.6）

--- a/chapter4/execution-tools/cli.py
+++ b/chapter4/execution-tools/cli.py
@@ -330,7 +330,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     # 全局开关
-    parser.add_argument("--provider", help="LLM 提供商（覆盖 PROVIDER，如 kimi/doubao/siliconflow/openrouter）")
+    parser.add_argument("--provider", help="LLM 提供商（覆盖 PROVIDER，如 dashscope/qwen/bailian/kimi/doubao/siliconflow/openrouter）")
     parser.add_argument("--workspace", help="工作目录（覆盖 WORKSPACE_DIR，文件操作被限制在此目录内）")
     parser.add_argument("--no-approval", action="store_true", help="关闭危险操作的 LLM 事前审批")
     parser.add_argument("--no-verify", action="store_true", help="关闭写文件/代码的自动语法校验")

--- a/chapter4/execution-tools/config.py
+++ b/chapter4/execution-tools/config.py
@@ -43,11 +43,15 @@ class Config:
     PROVIDER: str = os.getenv("PROVIDER", "kimi")
     
     # API Keys
+    DASHSCOPE_API_KEY: Optional[str] = os.getenv("DASHSCOPE_API_KEY")
     SILICONFLOW_API_KEY: Optional[str] = os.getenv("SILICONFLOW_API_KEY")
     DOUBAO_API_KEY: Optional[str] = os.getenv("DOUBAO_API_KEY")
     KIMI_API_KEY: Optional[str] = os.getenv("KIMI_API_KEY")
     MOONSHOT_API_KEY: Optional[str] = os.getenv("MOONSHOT_API_KEY")
     OPENROUTER_API_KEY: Optional[str] = os.getenv("OPENROUTER_API_KEY")
+    DASHSCOPE_BASE_URL: str = os.getenv(
+        "DASHSCOPE_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    )
     
     # Model names (optional, defaults to provider defaults)
     MODEL: Optional[str] = os.getenv("MODEL")
@@ -82,7 +86,10 @@ class Config:
     def get_api_key(cls, provider: str) -> Optional[str]:
         """Get API key for the specified provider."""
         provider = provider.lower()
-        if provider == "siliconflow":
+        provider = {"qwen": "dashscope", "bailian": "dashscope"}.get(provider, provider)
+        if provider == "dashscope":
+            return cls.DASHSCOPE_API_KEY
+        elif provider == "siliconflow":
             return cls.SILICONFLOW_API_KEY
         elif provider == "doubao":
             return cls.DOUBAO_API_KEY
@@ -101,6 +108,7 @@ class Config:
         fall back to 'openrouter' so the tools still run with only that key set.
         """
         provider = cls.PROVIDER.lower()
+        provider = {"qwen": "dashscope", "bailian": "dashscope"}.get(provider, provider)
         if cls.get_api_key(provider):
             return provider
         if cls.OPENROUTER_API_KEY:
@@ -132,7 +140,14 @@ class Config:
                 f"Set {cls.PROVIDER.upper()}_API_KEY or OPENROUTER_API_KEY."
             )
         
-        if provider == "siliconflow":
+        if provider == "dashscope":
+            return {
+                "provider": "dashscope",
+                "api_key": api_key,
+                "base_url": cls.DASHSCOPE_BASE_URL,
+                "model": cls.MODEL or "qwen3.7-plus"
+            }
+        elif provider == "siliconflow":
             return {
                 "provider": "siliconflow",
                 "api_key": api_key,
@@ -163,7 +178,7 @@ class Config:
         else:
             raise ValueError(
                 f"Unsupported provider: {provider}. "
-                f"Use 'siliconflow', 'doubao', 'kimi', 'moonshot', or 'openrouter'"
+                f"Use 'dashscope'/'qwen'/'bailian', 'siliconflow', 'doubao', 'kimi', 'moonshot', or 'openrouter'"
             )
 
 

--- a/chapter4/execution-tools/env.example
+++ b/chapter4/execution-tools/env.example
@@ -2,6 +2,7 @@
 PROVIDER=kimi
 
 # API Keys (set the one for your provider)
+DASHSCOPE_API_KEY=your_dashscope_key
 SILICONFLOW_API_KEY=your_siliconflow_key
 DOUBAO_API_KEY=your_doubao_key
 KIMI_API_KEY=your_kimi_key
@@ -16,6 +17,8 @@ OPENROUTER_API_KEY=your_openrouter_key
 
 # Model (optional, defaults to provider's default model)
 # MODEL=kimi-k3
+# DashScope/Bailian defaults to qwen3.7-plus; set DASHSCOPE_BASE_URL to
+# https://dashscope-intl.aliyuncs.com/compatible-mode/v1 for international keys.
 
 # Model parameters
 TEMPERATURE=0.7

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -22,6 +22,8 @@ from agentbook.providers.registry import supported_providers
 from agentbook.providers.resolution import build_openrouter_backend
 
 PROVIDER_KEY_VARS = [
+    "DASHSCOPE_API_KEY",
+    "DASHSCOPE_BASE_URL",
     "SILICONFLOW_API_KEY",
     "ARK_API_KEY",
     "MOONSHOT_API_KEY",
@@ -119,6 +121,35 @@ def test_legacy_kimi_key_still_accepted(monkeypatch):
 def test_moonshot_alias_resolves_to_kimi(monkeypatch):
     monkeypatch.setenv("MOONSHOT_API_KEY", "test-moonshot-key")
     assert resolve_backend("moonshot").provider == "kimi"
+
+
+def test_dashscope_key_uses_bailian_directly(monkeypatch):
+    """A Bailian key must call Alibaba directly, not the SiliconFlow route."""
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+    backend = resolve_backend("dashscope")
+    assert backend.api_key == "test-dashscope-key"
+    assert backend.base_url == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    assert backend.model == "qwen3.7-plus"
+    assert backend.provider == "dashscope"
+    assert backend.using_openrouter is False
+
+
+@pytest.mark.parametrize("alias", ["qwen", "bailian"])
+def test_qwen_and_bailian_aliases_resolve_to_dashscope(monkeypatch, alias):
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+    backend = resolve_backend(alias)
+    assert backend.provider == "dashscope"
+    assert backend.base_url == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+
+def test_dashscope_international_region_override(monkeypatch):
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+    monkeypatch.setenv(
+        "DASHSCOPE_BASE_URL",
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    )
+    backend = resolve_backend("dashscope")
+    assert backend.base_url == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
 
 
 def test_falls_back_to_openrouter_when_provider_key_missing(monkeypatch):
@@ -230,8 +261,9 @@ def test_supported_providers_covers_registry_and_aliases():
     must be selectable without touching argparse."""
     for name in PROVIDERS:
         assert name in SUPPORTED_PROVIDERS
-    for alias in ("moonshot", "ark", "google"):
+    for alias in ("moonshot", "ark", "google", "qwen", "bailian"):
         assert alias in SUPPORTED_PROVIDERS
+    assert "dashscope" in SUPPORTED_PROVIDERS
     assert "ollama" in SUPPORTED_PROVIDERS
     assert "openai" in SUPPORTED_PROVIDERS
     assert "gemini" in SUPPORTED_PROVIDERS


### PR DESCRIPTION
## Summary

- add Alibaba Cloud Model Studio / Bailian (DashScope) as a direct OpenAI-compatible provider with `DASHSCOPE_API_KEY`, `DASHSCOPE_BASE_URL`, `qwen`/`bailian` aliases, and `qwen3.7-plus` defaults
- broaden direct provider selection beyond Experiment 1.1 across applicable Chapter 1–4 text/chat experiment paths: learning-from-experience; context compression; prompt injection; system hint; Agentic RAG and contextual retrieval variants; structured index and structured knowledge extraction; Memobase; user memory; active tool selection; event-trigger; async agent; collaboration tools; and execution tools
- update CLIs, quickstarts, env templates, English/Chinese setup docs, and provider validation/configuration branches so a Bailian key can be used without routing through SiliconFlow
- preserve provider-specific boundaries: Moonshot Formula web search and SiliconFlow speech services are not relabeled as Qwen support

Closes #755

## Verification

- provider/context tests: 84 passed
- Chapter 1 learning-from-experience: 16 passed
- Chapter 2 context-compression: 6 passed; prompt-injection: 5 passed; system-hint: 12 passed
- Chapter 3 user-memory: 15 passed; Memobase: 7 passed; Agentic RAG/contextual retrieval startup checks passed; direct DashScope config smoke checks passed
- Chapter 4 execution-tools: 5 config tests passed; event-trigger: 5 tests passed; active-tool-selection: 8 passed
- direct DashScope smoke checks covered Chapter 1–4 agents/configs without external API calls
- `python -m compileall` and `git diff --check` passed

One structured-index run had 6 synchronous tests pass and one unrelated pre-existing async test fail because this environment does not provide a pytest async plugin (`async def` is not natively supported).