### PR TITLE
fix(ch10): harden voice-werewolf production acceptance gates

### DIFF
--- a/chapter10/voice-werewolf/demo.py
+++ b/chapter10/voice-werewolf/demo.py
@@ -27,6 +27,7 @@
 import argparse
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -125,6 +126,49 @@ def verify_isolation(judge: Judge):
     print(f"信息隔离总校验：{'全部通过 ✓✓✓' if ok else '存在失败 ✗'}")
     print("=" * 78)
     return ok
+
+
+def verify_simulator_trace(events):
+    """Validate tool/TTS/ASR transactions before an acceptance report is written.
+
+    The independent validator performs the same check on persisted evidence.  The
+    in-process copy keeps the embedded report honest when a provider returns a
+    partial or reordered trace (for example, an ASR from a later turn).
+    """
+    tools = [e for e in events if isinstance(e, dict) and e.get("type") == "simulator_llm_tool"]
+    asr_count = sum(isinstance(e, dict) and e.get("type") == "simulator_asr" for e in events)
+    if not tools or asr_count != len(tools):
+        return False
+    seen_ids = set()
+    for index, tool in ((i, e) for i, e in enumerate(events)
+                        if isinstance(e, dict) and e.get("type") == "simulator_llm_tool"):
+        transaction = []
+        for item in events[index + 1:]:
+            if isinstance(item, dict) and item.get("type") == "simulator_llm_tool":
+                break
+            if isinstance(item, dict):
+                transaction.append(item)
+        seat = tool.get("seat")
+        tts = next((e for e in transaction if e.get("type") == "tts_ready"
+                    and e.get("speaker") == seat), None)
+        asr = next((e for e in transaction if e.get("type") == "simulator_asr"), None)
+        if tts is None or asr is None:
+            return False
+        if transaction.index(tts) > transaction.index(asr):
+            return False
+        audio_hash = tts.get("audio_sha256")
+        audio_bytes = tts.get("audio_bytes")
+        if (not isinstance(audio_hash, str) or not re.fullmatch(r"[0-9a-f]{64}", audio_hash)
+                or not isinstance(audio_bytes, int) or audio_bytes <= 0
+                or audio_hash != asr.get("source_audio_sha256")):
+            return False
+        request_id = asr.get("request_id")
+        tool_id = tool.get("response_id")
+        if not request_id or not tool_id or request_id in seen_ids or tool_id in seen_ids:
+            return False
+        seen_ids.update((request_id, tool_id))
+    return not any(isinstance(e, dict) and e.get("type") == "simulator_action_mismatch"
+                   for e in events)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -251,7 +295,22 @@ def run_game(args):
     strategy = None
     if not args.offline:
         from werewolf.strategy_audit import evaluate_strategy
-        strategy = evaluate_strategy(judge)
+        try:
+            strategy = evaluate_strategy(judge)
+        except Exception as exc:
+            # Preserve the completed game and its evidence even when every
+            # post-game judge endpoint is unavailable.  A missing audit is a hard
+            # acceptance failure, never a reason to discard the report or infer a
+            # pass from the model's absence.
+            strategy = {
+                "schema_valid": False,
+                "overall_pass": False,
+                "validation_errors": ["strategy audit unavailable"],
+                "error_type": type(exc).__name__,
+                "error": str(exc)[:500],
+                "judge_attempts": getattr(exc, "judge_attempts", []),
+            }
+            print(f"[策略审计] 未完成：{type(exc).__name__}")
 
     role_counts = {role.value: sum(1 for p in players if p.role == role) for role in Role}
     human_players = [p.name for p in players if getattr(p, "is_human", False)]
@@ -270,11 +329,36 @@ def run_game(args):
         e["type"] == "simulator_llm_tool" for e in voice_events
     )
     simulator_audio_roundtrips = sum(e["type"] == "simulator_asr" for e in voice_events)
+    simulator_receipt_events = [
+        e for e in voice_events if e.get("type") in {"simulator_llm_tool", "simulator_asr"}
+    ]
+    simulator_receipt_ids = [
+        e.get("response_id") or e.get("request_id") for e in simulator_receipt_events
+    ]
+    simulator_unique_receipts = bool(simulator_receipt_ids) and all(simulator_receipt_ids) \
+        and len(simulator_receipt_ids) == len(set(simulator_receipt_ids))
+    simulator_audio_receipts = [
+        e.get("usage", {}).get("prompt_tokens_details", {}).get("audio_tokens", 0)
+        for e in voice_events if e.get("type") == "simulator_asr"
+    ]
+    simulator_asr_events = [e for e in voice_events if e.get("type") == "simulator_asr"]
+    audio_token_receipt_required = any(
+        "OpenRouter" in str(e.get("provider", "")) for e in simulator_asr_events
+    )
+    simulator_nonzero_audio_receipts = (not audio_token_receipt_required) or (
+        bool(simulator_audio_receipts) and all(
+        isinstance(value, (int, float)) and value > 0 for value in simulator_audio_receipts
+        )
+    )
+    simulator_trace_integrity = verify_simulator_trace(voice_events) if simulated_user else False
     simulator_boundary_ok = bool(
         not simulated_user
         or (
             simulator_tool_calls > 0
-            and simulator_audio_roundtrips > 0
+            and simulator_tool_calls == simulator_audio_roundtrips
+            and simulator_unique_receipts
+            and simulator_nonzero_audio_receipts
+            and simulator_trace_integrity
             and not any(e["type"] == "simulator_action_mismatch" for e in voice_events)
         )
     )
@@ -326,7 +410,15 @@ def run_game(args):
             "one_llm_user_simulator": {"status": "pass" if simulated_user and len(simulated_user_players) == 1 else "not_applicable" if live_human else "not_run" if not simulated_user else "fail"},
             "real_user_input_asr": {"status": "pass" if voice_has_asr else "not_run" if not end_to_end else "fail"},
             "real_ai_and_judge_tts": {"status": "pass" if voice_has_tts else "not_run" if not end_to_end else "fail"},
-            "llm_tool_to_audio_to_asr_boundary": {"status": "pass" if simulated_user and simulator_boundary_ok else "not_applicable" if live_human else "not_run" if not simulated_user else "fail", "tool_calls": simulator_tool_calls, "audio_roundtrips": simulator_audio_roundtrips},
+            "llm_tool_to_audio_to_asr_boundary": {
+                "status": "pass" if simulated_user and simulator_boundary_ok else "not_applicable" if live_human else "not_run" if not simulated_user else "fail",
+                "tool_calls": simulator_tool_calls,
+                "audio_roundtrips": simulator_audio_roundtrips,
+                "unique_provider_receipts": simulator_unique_receipts,
+                "audio_token_receipt_required": audio_token_receipt_required,
+                "nonzero_audio_token_receipts": simulator_nonzero_audio_receipts,
+                "transaction_integrity": simulator_trace_integrity,
+            },
             "three_complete_cycles": {"status": "pass" if judge.completed_rounds >= 3 else "fail" if end_to_end else "supplemental_only", "observed": judge.completed_rounds},
             "information_isolation": {"status": "pass" if isolation_ok else "fail"},
             "real_llm_strategy_acceptance": {"status": "pass" if strategy_pass else "not_run" if args.offline else "fail"},

--- a/chapter10/voice-werewolf/evaluate_audio_run.py
+++ b/chapter10/voice-werewolf/evaluate_audio_run.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Direct-audio independent evaluation of simulator utterances through OpenRouter."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+from openai import OpenAI
+
+
+WORDS = {
+    1: "one", 2: "two", 3: "three", 4: "four", 5: "five",
+    6: "six", 7: "seven", 8: "eight", 9: "nine", 10: "ten",
+}
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def expected_text(tool_event: dict[str, Any]) -> str:
+    arguments = tool_event.get("arguments") or {}
+    if tool_event.get("tool") == "speak_publicly":
+        return str(arguments.get("utterance", "")).strip()
+    target = str(arguments.get("target", "")).strip()
+    if target == "none":
+        return "I choose to abstain."
+    number = int(target.removeprefix("P"))
+    return f"I choose player {WORDS.get(number, str(number))}."
+
+
+def parse_json(text: str) -> dict[str, Any]:
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*|\s*```$", "", text, flags=re.S)
+    return json.loads(text)
+
+
+def evaluate(report_path: Path, output: Path, model: str) -> dict[str, Any]:
+    if not os.getenv("OPENROUTER_API_KEY"):
+        raise RuntimeError("OPENROUTER_API_KEY is required")
+    raw = report_path.read_bytes()
+    report = json.loads(raw)
+    events = report.get("voice_events") or []
+    client = OpenAI(
+        api_key=os.environ["OPENROUTER_API_KEY"],
+        base_url="https://openrouter.ai/api/v1",
+        timeout=120,
+        max_retries=2,
+    )
+    rows = []
+    for index, event in enumerate(events):
+        if event.get("type") != "simulator_llm_tool":
+            continue
+        seat = event.get("seat")
+        # Treat each tool -> TTS -> ASR sequence as a transaction.  Searching to
+        # the end of the report can pair a failed turn with a later player's audio
+        # and produce a false positive independent evaluation.
+        transaction = []
+        for item in events[index + 1:]:
+            if item.get("type") == "simulator_llm_tool":
+                break
+            transaction.append(item)
+        tts = next(
+            (item for item in transaction
+             if item.get("type") == "tts_ready" and item.get("speaker") == seat),
+            None,
+        )
+        asr = next(
+            (item for item in transaction if item.get("type") == "simulator_asr"),
+            None,
+        )
+        if not tts or not asr:
+            raise ValueError(f"tool event {event.get('sequence')} lacks TTS/ASR evidence")
+        if transaction.index(tts) > transaction.index(asr):
+            raise ValueError(f"tool event {event.get('sequence')} has ASR before TTS")
+        if asr.get("source_audio_sha256") != tts.get("audio_sha256"):
+            raise ValueError(f"tool event {event.get('sequence')} ASR/TTS audio hash mismatch")
+        audio_path = Path(str(tts["file"]))
+        if not audio_path.is_absolute():
+            project_root = next(
+                parent for parent in report_path.resolve().parents
+                if parent.name == "voice-werewolf"
+            )
+            candidates = [Path.cwd() / audio_path, project_root / audio_path]
+            audio_path = next((path for path in candidates if path.is_file()), candidates[0])
+        if not audio_path.is_file():
+            raise FileNotFoundError(audio_path)
+        if sha256(audio_path) != tts.get("audio_sha256"):
+            raise ValueError(f"audio hash mismatch: {audio_path}")
+        expected = expected_text(event)
+        started = time.perf_counter()
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "Independently evaluate this synthetic Werewolf-game speech audio. "
+                                f"The intended text is: {expected!r}. Return one JSON object only with "
+                                "keys transcript (string), intelligibility_1_to_5 (integer), "
+                                "semantic_fidelity_1_to_5 (integer), naturalness_1_to_5 (integer), "
+                                "action_or_seat_preserved (boolean), and rationale (short string). "
+                                "Judge the waveform itself. A robotic voice may score low on naturalness "
+                                "without losing intelligibility or semantic fidelity."
+                            ),
+                        },
+                        {
+                            "type": "input_audio",
+                            "input_audio": {
+                                "data": base64.b64encode(audio_path.read_bytes()).decode("ascii"),
+                                "format": audio_path.suffix.lstrip(".").lower(),
+                            },
+                        },
+                    ],
+                }
+            ],
+            temperature=0,
+            max_tokens=600,
+        )
+        judgment = parse_json(response.choices[0].message.content or "")
+        usage = response.usage.model_dump() if response.usage else None
+        row = {
+            "tool_sequence": event.get("sequence"),
+            "tts_sequence": tts.get("sequence"),
+            "asr_sequence": asr.get("sequence"),
+            "tool": event.get("tool"),
+            "target": (event.get("arguments") or {}).get("target"),
+            "expected_text": expected,
+            "original_asr_transcript": asr.get("transcript"),
+            "audio_file": str(audio_path.relative_to(Path.cwd())),
+            "audio_bytes": audio_path.stat().st_size,
+            "audio_sha256": sha256(audio_path),
+            "judge": judgment,
+            "request_id": response.id,
+            "provider_reported_model": response.model,
+            "usage": usage,
+            "latency_seconds": round(time.perf_counter() - started, 3),
+        }
+        row["pass"] = bool(
+            int(judgment.get("intelligibility_1_to_5", 0)) >= 4
+            and int(judgment.get("semantic_fidelity_1_to_5", 0)) >= 4
+            and judgment.get("action_or_seat_preserved") is True
+        )
+        rows.append(row)
+
+    result = {
+        "schema_version": 1,
+        "experiment": "10-8-independent-audio-evaluation",
+        "source_report": str(report_path),
+        "source_report_sha256": hashlib.sha256(raw).hexdigest(),
+        "provider": "OpenRouter multimodal audio API",
+        "requested_model": model,
+        "evaluations": rows,
+        "gates": {
+            "all_simulator_audio_evaluated": len(rows)
+            == sum(event.get("type") == "simulator_llm_tool" for event in events),
+            "unique_real_request_ids": len({row["request_id"] for row in rows}) == len(rows),
+            "all_audio_hashes_match": bool(rows),
+            "all_intelligible_and_semantically_faithful": bool(rows)
+            and all(row["pass"] for row in rows),
+        },
+    }
+    result["status"] = "pass" if all(result["gates"].values()) else "fail"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(result, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("report", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--model", default="google/gemini-3-flash-preview")
+    args = parser.parse_args()
+    result = evaluate(args.report, args.output, args.model)
+    print(json.dumps({"status": result["status"], "gates": result["gates"]}, indent=2))
+    return 0 if result["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/chapter10/voice-werewolf/test_exp108_validation_evidence.py
+++ b/chapter10/voice-werewolf/test_exp108_validation_evidence.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from pathlib import Path
 
@@ -100,3 +101,24 @@ def test_fixed_abstention_has_real_audio_api_receipt():
     assert probe["usage"]["prompt_tokens_details"]["audio_tokens"] > 0
     assert len(probe["source_audio_sha256"]) == 64
     assert probe["status"] == "pass"
+
+
+def test_latest_formal_run_passes_every_gate_in_one_report():
+    run = ROOT / "runs" / "exp10-8-simulated-user-openrouter-20260803-v11"
+    report = json.loads((run / "acceptance_report.json").read_text())
+    independent = json.loads((run / "independent_validation.json").read_text())
+
+    assert report["overall_status"] == "pass"
+    assert report["end_to_end_status"] == "pass"
+    assert report["completed_day_night_vote_cycles"] >= 3
+    assert report["strategy_audit_pass"] is True
+    assert report["information_isolation_pass"] is True
+    assert all(
+        gate["status"] in {"pass", "not_applicable"}
+        for gate in report["gates"].values()
+    )
+    assert independent["strict_audio_action_boundary"] == "pass"
+    assert independent["source_report_sha256"] == hashlib.sha256(
+        (run / "acceptance_report.json").read_bytes()
+    ).hexdigest()
+    assert independent["simulator_tool_events_checked"] == report["simulator_llm_tool_calls"]

--- a/chapter10/voice-werewolf/test_live_human.py
+++ b/chapter10/voice-werewolf/test_live_human.py
@@ -173,6 +173,14 @@ def test_strategy_acceptance_requires_all_named_criteria_and_evidence():
     assert not strategy_acceptance_passes(checked)
 
 
+@pytest.mark.parametrize("malformed", [None, [], "not-json-object", 7])
+def test_strategy_validation_fails_closed_for_non_object_provider_output(malformed):
+    checked = validate_strategy_result(malformed)
+    assert checked["schema_valid"] is False
+    assert checked["overall_pass"] is False
+    assert not strategy_acceptance_passes(checked)
+
+
 def test_strategy_audit_retains_invalid_schema_and_tries_next_backend(monkeypatch):
     from werewolf import strategy_audit as audit_module
 

--- a/chapter10/voice-werewolf/validate_simulator_run.py
+++ b/chapter10/voice-werewolf/validate_simulator_run.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 from pathlib import Path
 
 from werewolf.human import HumanPlayerAgent
@@ -17,17 +18,94 @@ def validate(report_path: Path) -> dict:
     events = report.get("voice_events", [])
     errors = []
     checked = 0
+    seen_sequences = set()
+    seen_request_ids = set()
+    seen_provider_ids = set()
+    simulator_asr_count = sum(
+        isinstance(event, dict) and event.get("type") == "simulator_asr"
+        for event in events
+    ) if isinstance(events, list) else 0
+    simulator_tool_count = 0
+
+    if not isinstance(events, list):
+        errors.append("voice_events must be an array")
+        events = []
+
+    # A trace is an append-only sequence.  Reject duplicate/out-of-order sequence
+    # numbers instead of allowing a later event to be accidentally paired with an
+    # earlier action.
+    previous_sequence = 0
+    for event in events:
+        if not isinstance(event, dict):
+            errors.append("every voice event must be an object")
+            continue
+        sequence = event.get("sequence")
+        if isinstance(sequence, int) and sequence in seen_sequences:
+            errors.append(f"duplicate voice event sequence: {sequence}")
+        if not isinstance(sequence, int) or sequence <= previous_sequence:
+            errors.append(f"voice event sequence is not strictly increasing: {sequence!r}")
+        if isinstance(sequence, int):
+            seen_sequences.add(sequence)
+            previous_sequence = max(previous_sequence, sequence)
+
     for index, event in enumerate(events):
+        if not isinstance(event, dict):
+            continue
         if event.get("type") != "simulator_llm_tool":
             continue
         checked += 1
-        following = next(
-            (item for item in events[index + 1:] if item.get("type") == "simulator_asr"),
-            None,
-        )
+        simulator_tool_count += 1
+        tool_request_id = event.get("response_id") or event.get("request_id")
+        if not isinstance(tool_request_id, str) or not tool_request_id.strip():
+            errors.append(f"tool event {event.get('sequence')} lacks provider response_id")
+        elif tool_request_id in seen_provider_ids:
+            errors.append(f"duplicate tool provider response_id: {tool_request_id}")
+        else:
+            seen_provider_ids.add(tool_request_id)
+        seat = event.get("seat")
+        if not isinstance(seat, str) or not re.fullmatch(r"P\d+", seat):
+            errors.append(f"tool event {event.get('sequence')} has invalid seat")
+        # Only events in this action's contiguous transaction may be used.  The
+        # old validator searched to the end of the trace, so a missing ASR could
+        # silently borrow another turn's transcript.
+        transaction = []
+        for item in events[index + 1:]:
+            if not isinstance(item, dict):
+                errors.append(f"tool event {event.get('sequence')} has non-object transaction event")
+                continue
+            if item.get("type") == "simulator_llm_tool":
+                break
+            transaction.append(item)
+        tts = next((item for item in transaction
+                    if item.get("type") == "tts_ready" and item.get("speaker") == seat), None)
+        following = next((item for item in transaction
+                          if item.get("type") == "simulator_asr"), None)
+        if tts is None:
+            errors.append(f"tool event {event.get('sequence')} has no same-seat TTS")
         if following is None:
-            errors.append(f"tool event {event.get('sequence')} has no later simulator_asr")
+            errors.append(f"tool event {event.get('sequence')} has no transaction-local simulator_asr")
             continue
+        if tts is not None:
+            if transaction.index(tts) > transaction.index(following):
+                errors.append(f"tool event {event.get('sequence')} has ASR before TTS")
+            audio_hash = tts.get("audio_sha256")
+            source_hash = following.get("source_audio_sha256")
+            if not isinstance(audio_hash, str) or not re.fullmatch(r"[0-9a-f]{64}", audio_hash):
+                errors.append(f"tool event {event.get('sequence')} has invalid TTS audio hash")
+            if source_hash != audio_hash:
+                errors.append(f"tool event {event.get('sequence')} ASR source hash does not match TTS")
+            if not isinstance(tts.get("audio_bytes"), int) or tts["audio_bytes"] <= 0:
+                errors.append(f"tool event {event.get('sequence')} has empty TTS audio")
+        request_id = following.get("request_id")
+        if not isinstance(request_id, str) or not request_id.strip():
+            errors.append(f"ASR event for tool {event.get('sequence')} lacks request_id")
+        elif request_id in seen_request_ids:
+            errors.append(f"duplicate ASR request_id: {request_id}")
+        else:
+            seen_request_ids.add(request_id)
+            if request_id in seen_provider_ids:
+                errors.append(f"provider response_id reused by ASR: {request_id}")
+            seen_provider_ids.add(request_id)
         arguments = event.get("arguments") or {}
         if event.get("tool") == "speak_publicly":
             if not str(following.get("transcript", "")).strip():
@@ -44,12 +122,24 @@ def validate(report_path: Path) -> dict:
         elif target and target not in transcript.replace(" ", ""):
             # English word-number transcripts are valid too; use the production parser
             # with the report roster as candidates.
-            candidates = [f"P{number}" for number in range(1, report["players"] + 1)]
+            try:
+                player_count = int(report["players"])
+            except (KeyError, TypeError, ValueError):
+                player_count = 0
+                errors.append("report players must be an integer")
+            candidates = [f"P{number}" for number in range(1, player_count + 1)]
             parsed = HumanPlayerAgent._spoken_target(transcript, candidates, False)
             if parsed != target:
                 errors.append(
                     f"tool event {event.get('sequence')} selected {target} but ASR parsed {parsed}"
                 )
+    if simulator_tool_count != report.get("simulator_llm_tool_calls", simulator_tool_count):
+        errors.append("report simulator_llm_tool_calls does not match trace")
+    if simulator_asr_count != report.get("simulator_audio_roundtrips", simulator_asr_count):
+        errors.append("report simulator_audio_roundtrips does not match trace")
+    if any(isinstance(event, dict) and event.get("type") == "simulator_action_mismatch"
+           for event in events):
+        errors.append("trace contains simulator_action_mismatch")
     return {
         "schema_version": 1,
         "source_report": str(report_path),

--- a/chapter10/voice-werewolf/werewolf/strategy_audit.py
+++ b/chapter10/voice-werewolf/werewolf/strategy_audit.py
@@ -16,8 +16,23 @@ VALID_STATUSES = {"pass", "fail", "insufficient"}
 
 
 def validate_strategy_result(result):
-    """Turn a model grade into a strict, machine-checkable acceptance record."""
+    """Turn a model grade into a strict, machine-checkable acceptance record.
+
+    This function is deliberately fail-closed.  Provider SDKs occasionally return
+    ``None`` or a scalar when a JSON-mode response is truncated; attempting to
+    mutate those values used to raise an incidental ``AttributeError`` and abort
+    report generation.  Returning a normal, serialisable rejection keeps the
+    acceptance pipeline auditable and prevents malformed model output from being
+    mistaken for a passing grade.
+    """
     errors = []
+    if not isinstance(result, dict):
+        return {
+            "model_overall_pass_claim": None,
+            "schema_valid": False,
+            "validation_errors": ["strategy result must be a JSON object"],
+            "overall_pass": False,
+        }
     criteria = result.get("criteria")
     if not isinstance(criteria, dict):
         criteria = {}


### PR DESCRIPTION
## Summary

- enforce same-seat tool → TTS → ASR transaction integrity in embedded and independent validation
- require matching audio hashes, positive audio bytes, unique provider receipts, exact event counts, and OpenRouter audio-token receipts
- fail closed and retain an auditable report when the strategy judge is unavailable or returns a non-object
- add regression coverage for malformed strategy output and the latest single-run formal acceptance evidence

## Validation

- `PYTHONPATH=chapter10/voice-werewolf pytest -q chapter10/voice-werewolf` (34 passed)
- strict independent validation of `exp10-8-simulated-user-openrouter-20260803-v11` (pass; 6 simulator transactions)

The unrelated full `chapter10` collection has pre-existing duplicate test-module/import conflicts outside `voice-werewolf`.