### PR TITLE
fix(ch3): guard BM25 calculate_term_score against zero avgdl and calculate_raw_idf

### DIFF
--- a/chapter3/sparse-embedding/bm25_engine.py
+++ b/chapter3/sparse-embedding/bm25_engine.py
@@ -272,7 +272,11 @@ class BM25:
         if df == 0:
             return 0
         
-        return math.log((N - df + 0.5) / (df + 0.5))
+        N = max(N, df)
+        val = (N - df + 0.5) / (df + 0.5)
+        if val <= 0:
+            return 0.0
+        return math.log(val)
 
     def calculate_idf(self, term: str) -> float:
         """Return RSJ IDF with a small floor for corpus-ubiquitous terms.
@@ -310,6 +314,8 @@ class BM25:
         idf = self.calculate_idf(term)
         
         # BM25 term score formula
+        if self.avgdl == 0:
+            return 0.0
         numerator = tf * (self.k1 + 1)
         denominator = tf + self.k1 * (1 - self.b + self.b * (dl / self.avgdl))
         score = idf * (numerator / denominator)

--- a/tests/test_ch3_bm25_zero_avgdl.py
+++ b/tests/test_ch3_bm25_zero_avgdl.py
@@ -1,0 +1,31 @@
+import pytest
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("chapter3/sparse-embedding"))
+
+from collections import Counter
+from bm25_engine import InvertedIndex, BM25
+
+
+def test_bm25_calculate_term_score_zero_avgdl():
+    """Prove that calculating term score when avgdl is 0 handles division by zero safely."""
+    index = InvertedIndex()
+    bm25 = BM25(index)
+    assert bm25.avgdl == 0
+    index.term_frequency[1] = Counter({"python": 2})
+    index.doc_lengths[1] = 5
+    index.index["python"].add(1)
+
+    score = bm25.calculate_term_score("python", doc_id=1)
+    assert isinstance(score, float)
+
+
+def test_bm25_calculate_raw_idf_n_less_than_df():
+    """Prove that calculate_raw_idf when total_documents N < df does not raise math domain error."""
+    index = InvertedIndex()
+    index.index["python"].add(1)
+    bm25 = BM25(index)
+
+    idf = bm25.calculate_raw_idf("python")
+    assert isinstance(idf, float)


### PR DESCRIPTION
## Summary

Fixes two division-by-zero / math domain errors in the BM25 scorer.

## Changes

- **`chapter3/sparse-embedding/bm25_engine.py`** — `calculate_raw_idf` now clamps `N = max(N, df)` and returns `0.0` when the RSJ value is non-positive, preventing `math.log` of zero/negative. `calculate_term_score` returns `0.0` when `avgdl == 0` instead of dividing by zero.
- **`tests/test_ch3_bm25_zero_avgdl.py`** — Tests for zero avgdl and N < df edge cases.