### PR TITLE
fix(ch9): allow non-serializable objects in _redact_secrets

### DIFF
--- a/chapter9/phone-agent/agent.py
+++ b/chapter9/phone-agent/agent.py
@@ -70,7 +70,7 @@ def _sha256_json(value: Any) -> str:
 
 def _redact_secrets(value: Any) -> Any:
     """Remove credential values before any provider request/response is retained."""
-    serialized = json.dumps(value, ensure_ascii=False)
+    serialized = json.dumps(value, ensure_ascii=False, default=str)
     for name, secret in os.environ.items():
         if (
             any(marker in name.upper() for marker in ("KEY", "TOKEN", "SECRET", "PASSWORD"))

--- a/tests/test_ch9_phone_agent_redact_secrets_non_serializable.py
+++ b/tests/test_ch9_phone_agent_redact_secrets_non_serializable.py
@@ -12,6 +12,7 @@ _module_path = (
 )
 _spec = importlib.util.spec_from_file_location("phone_agent", _module_path)
 _module = importlib.util.module_from_spec(_spec)
+sys.modules["phone_agent"] = _module
 _spec.loader.exec_module(_module)
 _redact_secrets = _module._redact_secrets
 

--- a/tests/test_ch9_phone_agent_redact_secrets_non_serializable.py
+++ b/tests/test_ch9_phone_agent_redact_secrets_non_serializable.py
@@ -4,6 +4,9 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
+pytest.importorskip("openai")
 _module_path = (
     Path(__file__).resolve().parent.parent / "chapter9" / "phone-agent" / "agent.py"
 )

--- a/tests/test_ch9_phone_agent_redact_secrets_non_serializable.py
+++ b/tests/test_ch9_phone_agent_redact_secrets_non_serializable.py
@@ -1,12 +1,16 @@
 import datetime
+import importlib.util
 import os
 import sys
 from pathlib import Path
 
-# Add chapter9/phone-agent to sys.path
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "chapter9" / "phone-agent"))
-
-from agent import _redact_secrets
+_module_path = (
+    Path(__file__).resolve().parent.parent / "chapter9" / "phone-agent" / "agent.py"
+)
+_spec = importlib.util.spec_from_file_location("phone_agent", _module_path)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+_redact_secrets = _module._redact_secrets
 
 
 class CustomObject:

--- a/tests/test_ch9_phone_agent_redact_secrets_non_serializable.py
+++ b/tests/test_ch9_phone_agent_redact_secrets_non_serializable.py
@@ -1,0 +1,35 @@
+import datetime
+import os
+import sys
+from pathlib import Path
+
+# Add chapter9/phone-agent to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "chapter9" / "phone-agent"))
+
+from agent import _redact_secrets
+
+
+class CustomObject:
+    def __str__(self):
+        return "CustomObjectRepresentation"
+
+
+def test_redact_secrets_non_serializable(monkeypatch):
+    monkeypatch.setenv("MY_API_KEY", "secret_key_12345678")
+
+    now = datetime.datetime(2026, 1, 1, 12, 0, 0)
+    data = {
+        "timestamp": now,
+        "tags": {"tag1", "tag2"},
+        "custom": CustomObject(),
+        "api_key": "secret_key_12345678",
+        "openai_key": "sk-12345678901234567890",
+    }
+
+    sanitized = _redact_secrets(data)
+
+    assert sanitized["api_key"] == "[REDACTED]"
+    assert sanitized["openai_key"] == "[REDACTED]"
+    assert sanitized["timestamp"] == str(now)
+    assert sanitized["custom"] == "CustomObjectRepresentation"
+    assert isinstance(sanitized["tags"], str) or isinstance(sanitized["tags"], list)


### PR DESCRIPTION
## Summary

Fixes `_redact_secrets` to handle non-JSON-serializable objects without raising `TypeError`.

## Changes

- **`chapter9/phone-agent/agent.py`** — `json.dumps` in `_redact_secrets` now uses `default=str`, so datetime objects, sets, bytes, and custom classes are serialized to their string representation instead of crashing. Secret redaction still works correctly on the resulting string.
- **`tests/test_ch9_phone_agent_redact_secrets_non_serializable.py`** — Test with datetime, set, custom object, and secret env vars confirming redaction still works.