### PR TITLE
feat(ch7): add MultilingualReasoningEvaluator with tests

### DIFF
--- a/chapter7/MultilingualReasoning/evaluate_multilingual.py
+++ b/chapter7/MultilingualReasoning/evaluate_multilingual.py
@@ -1,0 +1,430 @@
+"""Multilingual Reasoning Evaluator for AI Agent Book (Chapter 7).
+
+Evaluates LLM reasoning models across multiple languages (English, Spanish,
+French, Chinese, Japanese) measuring CoT language fidelity, task accuracy,
+token usage, and cross-lingual transfer efficiency.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import statistics
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+
+LANG_MAP: dict[str, str] = {
+    "en": "English",
+    "english": "English",
+    "es": "Spanish",
+    "spanish": "Spanish",
+    "fr": "French",
+    "french": "French",
+    "zh": "Chinese",
+    "chinese": "Chinese",
+    "zh-cn": "Chinese",
+    "zh-tw": "Chinese",
+    "ja": "Japanese",
+    "japanese": "Japanese",
+}
+
+# Regex patterns for script detection
+CJK_RE = re.compile(r"[\u4e00-\u9fff\u3400-\u4dbf]")
+HIRAGANA_RE = re.compile(r"[\u3040-\u309f]")
+KATAKANA_RE = re.compile(r"[\u30a0-\u30ff]")
+SPANISH_SPECIAL_RE = re.compile(r"[áéíóúüñÁÉÍÓÚÜÑ¿¡]")
+FRENCH_SPECIAL_RE = re.compile(r"[éèêëàâùûçôîïÉÈÊËÀÂÙÛÇÔÎÏ]")
+
+SPANISH_WORDS = {
+    "el", "la", "los", "las", "un", "una", "de", "en", "que", "es", "por", "para",
+    "con", "del", "al", "como", "más", "mas", "pero", "sus", "porque", "entonces",
+    "paso", "respuesta", "solucion", "solución", "por lo tanto", "primero", "luego"
+}
+
+FRENCH_WORDS = {
+    "le", "la", "les", "un", "une", "des", "du", "de", "en", "et", "est", "que",
+    "qui", "pour", "dans", "ce", "sur", "avec", "plus", "par", "mais", "donc",
+    "parce que", "alors", "etape", "étape", "reponse", "réponse", "solution", "premièrement"
+}
+
+ENGLISH_WORDS = {
+    "the", "be", "to", "of", "and", "a", "in", "that", "have", "it", "for",
+    "not", "on", "with", "he", "as", "you", "do", "at", "this", "but", "his",
+    "by", "from", "they", "we", "say", "her", "she", "or", "an", "will", "my",
+    "one", "all", "would", "there", "their", "what", "so", "up", "out", "if",
+    "about", "who", "get", "which", "go", "me", "when", "make", "can", "like",
+    "time", "no", "just", "him", "know", "take", "people", "into", "year",
+    "your", "good", "some", "could", "them", "see", "other", "than", "then",
+    "now", "look", "only", "come", "its", "over", "think", "also", "back",
+    "after", "use", "two", "how", "our", "work", "first", "well", "way",
+    "even", "new", "want", "because", "any", "these", "give", "day", "most",
+    "us", "therefore", "step", "reasoning", "solution", "answer", "equals",
+    "is", "plus", "minus", "times", "divided", "equal", "result"
+}
+
+
+def normalize_language(lang: str) -> str:
+    """Normalize language identifier string to canonical English name."""
+    cleaned = str(lang).strip().lower()
+    return LANG_MAP.get(cleaned, cleaned.capitalize())
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count for a string if exact count is unavailable."""
+    if not text:
+        return 0
+    cjk_count = len(CJK_RE.findall(text)) + len(HIRAGANA_RE.findall(text)) + len(KATAKANA_RE.findall(text))
+    non_cjk_text = CJK_RE.sub(" ", HIRAGANA_RE.sub(" ", KATAKANA_RE.sub(" ", text)))
+    words = non_cjk_text.split()
+    # ~1.3 tokens per word for Latin scripts, ~1.5 tokens per character for CJK/Kana
+    return max(1, int(len(words) * 1.3 + cjk_count * 1.5))
+
+
+class MultilingualReasoningEvaluator:
+    """Evaluates reasoning LLMs across multiple languages.
+
+    Computes:
+    - CoT Language Fidelity Score: Consistency of reasoning steps with target language.
+    - Task Accuracy: Correctness of final generated answers.
+    - Token Usage: Breakdown of prompt, completion, and reasoning token costs.
+    - Cross-Lingual Transfer Efficiency: Relative performance across non-English languages.
+    """
+
+    def __init__(self, target_languages: Optional[Sequence[str]] = None) -> None:
+        if target_languages is None:
+            self.target_languages = ["English", "Spanish", "French", "Chinese", "Japanese"]
+        else:
+            self.target_languages = [normalize_language(lang) for lang in target_languages]
+
+    def evaluate_cot_fidelity(self, cot_text: str, target_language: str) -> float:
+        """Calculate language fidelity score (0.0 - 1.0) for Chain-of-Thought text."""
+        if not cot_text or not cot_text.strip():
+            return 0.0
+
+        lang = normalize_language(target_language)
+        text = cot_text.strip()
+        non_space_chars = len(re.sub(r"\s+", "", text))
+        if non_space_chars == 0:
+            return 0.0
+
+        cjk_count = len(CJK_RE.findall(text))
+        hiragana_count = len(HIRAGANA_RE.findall(text))
+        katakana_count = len(KATAKANA_RE.findall(text))
+        kana_count = hiragana_count + katakana_count
+
+        if lang == "Chinese":
+            if kana_count > 0:
+                cjk_ratio = cjk_count / non_space_chars
+                return max(0.0, min(1.0, (cjk_ratio / 0.3) * 0.7))
+            cjk_ratio = cjk_count / non_space_chars
+            return min(1.0, cjk_ratio / 0.35)
+
+        if lang == "Japanese":
+            if kana_count > 0:
+                j_ratio = (kana_count + cjk_count) / non_space_chars
+                return min(1.0, j_ratio / 0.35)
+            if cjk_count > 0:
+                return 0.4
+            return 0.0
+
+        # For European / Latin languages, CJK/Kana script implies cross-lingual leakage
+        if cjk_count > 0 or kana_count > 0:
+            return 0.0
+
+        words = [w.lower() for w in re.findall(r"\b[a-zA-ZáéíóúüñÁÉÍÓÚÜÑàâäèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ]+\b", text)]
+        total_words = len(words)
+        if total_words == 0:
+            return 1.0 if any(c.isalnum() for c in text) else 0.0
+
+        if lang == "Spanish":
+            special_count = len(SPANISH_SPECIAL_RE.findall(text))
+            spanish_word_matches = sum(1 for w in words if w in SPANISH_WORDS)
+            score = (special_count * 2 + spanish_word_matches) / max(1, total_words)
+            return min(1.0, max(0.2, score * 3.0))
+
+        if lang == "French":
+            special_count = len(FRENCH_SPECIAL_RE.findall(text))
+            french_word_matches = sum(1 for w in words if w in FRENCH_WORDS)
+            score = (special_count * 2 + french_word_matches) / max(1, total_words)
+            return min(1.0, max(0.2, score * 3.0))
+
+        if lang == "English":
+            english_word_matches = sum(1 for w in words if w in ENGLISH_WORDS)
+            french_special = len(FRENCH_SPECIAL_RE.findall(text))
+            spanish_special = len(SPANISH_SPECIAL_RE.findall(text))
+            penalty = (french_special + spanish_special) * 0.1
+            match_ratio = english_word_matches / max(1, total_words)
+            score = match_ratio * 1.8 - penalty
+            return min(1.0, max(0.0, score))
+        return 0.5
+
+    def evaluate_accuracy(self, predicted_answer: str, reference_answer: str) -> float:
+        """Determine task accuracy (1.0 for match, 0.0 for mismatch)."""
+        pred = str(predicted_answer or "").strip().lower()
+        ref = str(reference_answer or "").strip().lower()
+
+        if not pred or not ref:
+            return 1.0 if pred == ref else 0.0
+
+        if pred == ref:
+            return 1.0
+
+        # Strip common trailing punctuation
+        pred_clean = re.sub(r"[.,;!\?]+$", "", pred)
+        ref_clean = re.sub(r"[.,;!\?]+$", "", ref)
+        if pred_clean == ref_clean:
+            return 1.0
+
+        # Try numeric comparison
+        pred_nums = re.findall(r"[-+]?\d*\.?\d+", pred)
+        ref_nums = re.findall(r"[-+]?\d*\.?\d+", ref)
+        if pred_nums and ref_nums:
+            try:
+                p_val = float(pred_nums[-1])
+                r_val = float(ref_nums[-1])
+                if math.isclose(p_val, r_val, rel_tol=1e-4, abs_tol=1e-4):
+                    return 1.0
+            except ValueError:
+                pass
+
+        # Substring matching for short references
+        if len(ref_clean) >= 2 and (ref_clean in pred_clean or pred_clean in ref_clean):
+            return 1.0
+
+        return 0.0
+
+    def compute_token_usage(
+        self, prompt: str, reasoning: str, answer: str, model_output: Any = None
+    ) -> dict[str, int]:
+        """Extract or estimate prompt, completion, reasoning, and total token usage."""
+        if isinstance(model_output, dict) and "token_usage" in model_output:
+            tu = model_output["token_usage"]
+            p_tok = int(tu.get("prompt_tokens", 0))
+            r_tok = int(tu.get("reasoning_tokens", 0))
+            c_tok = int(tu.get("completion_tokens", r_tok + estimate_tokens(answer)))
+            t_tok = int(tu.get("total_tokens", p_tok + c_tok))
+            return {
+                "prompt_tokens": p_tok,
+                "completion_tokens": c_tok,
+                "reasoning_tokens": r_tok,
+                "total_tokens": t_tok,
+            }
+
+        p_tok = estimate_tokens(prompt)
+        r_tok = estimate_tokens(reasoning)
+        a_tok = estimate_tokens(answer)
+        c_tok = r_tok + a_tok
+        t_tok = p_tok + c_tok
+        return {
+            "prompt_tokens": p_tok,
+            "completion_tokens": c_tok,
+            "reasoning_tokens": r_tok,
+            "total_tokens": t_tok,
+        }
+
+    def _parse_model_output(self, raw_output: Any) -> tuple[str, str, dict[str, int]]:
+        """Parse raw model output into reasoning CoT, final answer, and token metadata."""
+        if isinstance(raw_output, dict):
+            reasoning = str(raw_output.get("reasoning") or raw_output.get("cot") or raw_output.get("thinking") or "")
+            answer = str(raw_output.get("answer") or raw_output.get("response") or raw_output.get("predicted_answer") or "")
+            tu = raw_output.get("token_usage") or {}
+            return reasoning, answer, tu
+
+        if hasattr(raw_output, "reasoning") or hasattr(raw_output, "answer"):
+            reasoning = str(getattr(raw_output, "reasoning", "") or getattr(raw_output, "cot", ""))
+            answer = str(getattr(raw_output, "answer", "") or getattr(raw_output, "response", ""))
+            tu = getattr(raw_output, "token_usage", {})
+            return reasoning, answer, tu
+
+        text = str(raw_output or "").strip()
+
+        # Handle <think>...</think> tags
+        if "<think>" in text and "</think>" in text:
+            parts = text.split("</think>", 1)
+            reasoning = parts[0].replace("<think>", "").strip()
+            answer = parts[1].strip()
+            return reasoning, answer, {}
+
+        # Handle Reasoning: / Answer: markers
+        if "reasoning:" in text.lower() and "answer:" in text.lower():
+            r_idx = text.lower().find("reasoning:")
+            a_idx = text.lower().find("answer:")
+            if r_idx < a_idx:
+                reasoning = text[r_idx + 10 : a_idx].strip()
+                answer = text[a_idx + 7 :].strip()
+                return reasoning, answer, {}
+
+        # If line breaks exist, treat first part as reasoning and last line as answer
+        lines = [line.strip() for line in text.split("\n") if line.strip()]
+        if len(lines) > 1:
+            reasoning = "\n".join(lines[:-1])
+            answer = lines[-1]
+            return reasoning, answer, {}
+
+        return text, text, {}
+
+    def _invoke_model(self, model: Any, prompt: str, language: str) -> Any:
+        """Call model using appropriate signature (generate, predict, or call)."""
+        if callable(model):
+            try:
+                return model(prompt, language=language)
+            except TypeError:
+                return model(prompt)
+
+        if hasattr(model, "generate") and callable(model.generate):
+            try:
+                return model.generate(prompt, language=language)
+            except TypeError:
+                return model.generate(prompt)
+
+        if hasattr(model, "predict") and callable(model.predict):
+            try:
+                return model.predict(prompt, language=language)
+            except TypeError:
+                return model.predict(prompt)
+
+        raise ValueError(f"Model object {type(model)} is not callable and lacks generate/predict methods.")
+
+    def evaluate_sample(self, model: Any, sample: dict[str, Any]) -> dict[str, Any]:
+        """Evaluate a single dataset sample."""
+        lang_raw = sample.get("language") or sample.get("target_language") or sample.get("lang") or "English"
+        language = normalize_language(lang_raw)
+        prompt = str(sample.get("prompt") or sample.get("question") or sample.get("input") or "")
+        reference_answer = str(
+            sample.get("reference_answer")
+            or sample.get("expected_answer")
+            or sample.get("ground_truth")
+            or sample.get("target")
+            or sample.get("answer")
+            or ""
+        )
+
+        raw_output = self._invoke_model(model, prompt, language)
+        reasoning, answer, tu_raw = self._parse_model_output(raw_output)
+
+        cot_fidelity = self.evaluate_cot_fidelity(reasoning, language)
+        accuracy = self.evaluate_accuracy(answer, reference_answer)
+        token_usage = self.compute_token_usage(prompt, reasoning, answer, raw_output)
+
+        return {
+            "language": language,
+            "prompt": prompt,
+            "reference_answer": reference_answer,
+            "reasoning": reasoning,
+            "predicted_answer": answer,
+            "cot_fidelity": cot_fidelity,
+            "accuracy": accuracy,
+            "token_usage": token_usage,
+        }
+
+    def compute_transfer_efficiency(self, by_language_metrics: dict[str, dict[str, Any]]) -> dict[str, float]:
+        """Calculate cross-lingual transfer efficiency relative to English."""
+        english_acc = by_language_metrics.get("English", {}).get("accuracy", 0.0)
+        reference_acc = english_acc if english_acc > 0 else max(
+            (m["accuracy"] for m in by_language_metrics.values() if m.get("accuracy") is not None),
+            default=1.0,
+        )
+
+        efficiencies: dict[str, float] = {}
+        for lang, metrics in by_language_metrics.items():
+            acc = metrics.get("accuracy", 0.0)
+            if reference_acc > 0:
+                efficiencies[lang] = round(acc / reference_acc, 4)
+            else:
+                efficiencies[lang] = 1.0
+
+        return efficiencies
+
+    def evaluate(self, model: Any, dataset: Sequence[dict[str, Any]]) -> dict[str, Any]:
+        """Evaluate model on dataset and compile comprehensive report."""
+        if not dataset:
+            return {
+                "overall_accuracy": 0.0,
+                "overall_cot_fidelity": 0.0,
+                "overall_transfer_efficiency": 0.0,
+                "total_token_usage": {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "reasoning_tokens": 0,
+                    "total_tokens": 0,
+                },
+                "by_language": {},
+                "num_samples": 0,
+            }
+
+        sample_results = [self.evaluate_sample(model, sample) for sample in dataset]
+
+        by_lang_samples: dict[str, list[dict[str, Any]]] = {}
+        for res in sample_results:
+            lang = res["language"]
+            by_lang_samples.setdefault(lang, []).append(res)
+
+        by_language_metrics: dict[str, dict[str, Any]] = {}
+        tot_p_tokens = 0
+        tot_c_tokens = 0
+        tot_r_tokens = 0
+        tot_t_tokens = 0
+
+        for lang, samples in by_lang_samples.items():
+            cnt = len(samples)
+            acc = sum(s["accuracy"] for s in samples) / cnt
+            fid = sum(s["cot_fidelity"] for s in samples) / cnt
+
+            p_tok = sum(s["token_usage"]["prompt_tokens"] for s in samples)
+            c_tok = sum(s["token_usage"]["completion_tokens"] for s in samples)
+            r_tok = sum(s["token_usage"]["reasoning_tokens"] for s in samples)
+            t_tok = sum(s["token_usage"]["total_tokens"] for s in samples)
+
+            tot_p_tokens += p_tok
+            tot_c_tokens += c_tok
+            tot_r_tokens += r_tok
+            tot_t_tokens += t_tok
+
+            by_language_metrics[lang] = {
+                "sample_count": cnt,
+                "accuracy": round(acc, 4),
+                "cot_fidelity": round(fid, 4),
+                "token_usage": {
+                    "prompt_tokens": p_tok,
+                    "completion_tokens": c_tok,
+                    "reasoning_tokens": r_tok,
+                    "total_tokens": t_tok,
+                },
+            }
+
+        transfer_efficiencies = self.compute_transfer_efficiency(by_language_metrics)
+        for lang, eff in transfer_efficiencies.items():
+            by_language_metrics[lang]["transfer_efficiency"] = eff
+
+        non_english_effs = [
+            eff for lang, eff in transfer_efficiencies.items() if lang != "English"
+        ]
+        overall_transfer_eff = (
+            round(sum(non_english_effs) / len(non_english_effs), 4)
+            if non_english_effs
+            else 1.0
+        )
+
+        overall_accuracy = round(sum(s["accuracy"] for s in sample_results) / len(sample_results), 4)
+        overall_fidelity = round(sum(s["cot_fidelity"] for s in sample_results) / len(sample_results), 4)
+
+        return {
+            "overall_accuracy": overall_accuracy,
+            "overall_cot_fidelity": overall_fidelity,
+            "overall_transfer_efficiency": overall_transfer_eff,
+            "total_token_usage": {
+                "prompt_tokens": tot_p_tokens,
+                "completion_tokens": tot_c_tokens,
+                "reasoning_tokens": tot_r_tokens,
+                "total_tokens": tot_t_tokens,
+            },
+            "by_language": by_language_metrics,
+            "num_samples": len(sample_results),
+        }
+
+
+def run_evaluation(
+    model: Any, dataset: Sequence[dict[str, Any]], target_languages: Optional[Sequence[str]] = None
+) -> dict[str, Any]:
+    """Entrypoint function to run multilingual reasoning evaluation."""
+    evaluator = MultilingualReasoningEvaluator(target_languages=target_languages)
+    return evaluator.evaluate(model, dataset)

--- a/chapter7/MultilingualReasoning/evaluate_multilingual.py
+++ b/chapter7/MultilingualReasoning/evaluate_multilingual.py
@@ -265,9 +265,15 @@ class MultilingualReasoningEvaluator:
         # Substring matching for references with word boundaries
         target_ref = ref_clean if ref_clean else ref
         if target_ref:
-            pattern = r"\b" + re.escape(target_ref) + r"\b"
-            if re.search(pattern, pred_clean) or re.search(pattern, pred):
-                return 1.0
+            # \b word boundaries don't work for CJK characters; use direct
+            # containment for non-ASCII references, and \b for Latin text.
+            if re.search(r"[^\x00-\x7f]", target_ref):
+                if target_ref in pred_clean or target_ref in pred:
+                    return 1.0
+            else:
+                pattern = r"\b" + re.escape(target_ref) + r"\b"
+                if re.search(pattern, pred_clean) or re.search(pattern, pred):
+                    return 1.0
         return 0.0
 
     def compute_token_usage(

--- a/chapter7/MultilingualReasoning/evaluate_multilingual.py
+++ b/chapter7/MultilingualReasoning/evaluate_multilingual.py
@@ -7,6 +7,7 @@ token usage, and cross-lingual transfer efficiency.
 
 from __future__ import annotations
 
+import inspect
 import math
 import re
 import statistics
@@ -77,6 +78,17 @@ def estimate_tokens(text: str) -> int:
     words = non_cjk_text.split()
     # ~1.3 tokens per word for Latin scripts, ~1.5 tokens per character for CJK/Kana
     return max(1, int(len(words) * 1.3 + cjk_count * 1.5))
+
+
+def _accepts_language(fn: Any) -> bool:
+    try:
+        sig = inspect.signature(fn)
+        for param in sig.parameters.values():
+            if param.name == "language" or param.kind == inspect.Parameter.VAR_KEYWORD:
+                return True
+        return False
+    except (ValueError, TypeError):
+        return True
 
 
 class MultilingualReasoningEvaluator:
@@ -159,8 +171,8 @@ class MultilingualReasoningEvaluator:
 
     def evaluate_accuracy(self, predicted_answer: str, reference_answer: str) -> float:
         """Determine task accuracy (1.0 for match, 0.0 for mismatch)."""
-        pred = str(predicted_answer or "").strip().lower()
-        ref = str(reference_answer or "").strip().lower()
+        pred = str(predicted_answer if predicted_answer is not None else "").strip().lower()
+        ref = str(reference_answer if reference_answer is not None else "").strip().lower()
 
         if not pred or not ref:
             return 1.0 if pred == ref else 0.0
@@ -186,9 +198,11 @@ class MultilingualReasoningEvaluator:
             except ValueError:
                 pass
 
-        # Substring matching for short references
-        if len(ref_clean) >= 2 and (ref_clean in pred_clean or pred_clean in ref_clean):
-            return 1.0
+        # Substring matching for short references with word boundaries
+        if len(ref_clean) >= 2:
+            pattern = r"\b" + re.escape(ref_clean) + r"\b"
+            if re.search(pattern, pred_clean):
+                return 1.0
 
         return 0.0
 
@@ -196,8 +210,16 @@ class MultilingualReasoningEvaluator:
         self, prompt: str, reasoning: str, answer: str, model_output: Any = None
     ) -> dict[str, int]:
         """Extract or estimate prompt, completion, reasoning, and total token usage."""
-        if isinstance(model_output, dict) and "token_usage" in model_output:
-            tu = model_output["token_usage"]
+        tu = None
+        if isinstance(model_output, dict):
+            if "token_usage" in model_output and isinstance(model_output["token_usage"], dict):
+                tu = model_output["token_usage"]
+            elif "total_tokens" in model_output or "prompt_tokens" in model_output:
+                tu = model_output
+        elif hasattr(model_output, "token_usage"):
+            tu = getattr(model_output, "token_usage")
+
+        if isinstance(tu, dict) and tu:
             p_tok = int(tu.get("prompt_tokens", 0))
             r_tok = int(tu.get("reasoning_tokens", 0))
             c_tok = int(tu.get("completion_tokens", r_tok + estimate_tokens(answer)))
@@ -262,48 +284,53 @@ class MultilingualReasoningEvaluator:
 
         return text, text, {}
 
+
     def _invoke_model(self, model: Any, prompt: str, language: str) -> Any:
         """Call model using appropriate signature (generate, predict, or call)."""
         if callable(model):
-            try:
+            if _accepts_language(model):
                 return model(prompt, language=language)
-            except TypeError:
-                return model(prompt)
+            return model(prompt)
 
         if hasattr(model, "generate") and callable(model.generate):
-            try:
+            if _accepts_language(model.generate):
                 return model.generate(prompt, language=language)
-            except TypeError:
-                return model.generate(prompt)
+            return model.generate(prompt)
 
         if hasattr(model, "predict") and callable(model.predict):
-            try:
+            if _accepts_language(model.predict):
                 return model.predict(prompt, language=language)
-            except TypeError:
-                return model.predict(prompt)
+            return model.predict(prompt)
 
         raise ValueError(f"Model object {type(model)} is not callable and lacks generate/predict methods.")
 
     def evaluate_sample(self, model: Any, sample: dict[str, Any]) -> dict[str, Any]:
         """Evaluate a single dataset sample."""
-        lang_raw = sample.get("language") or sample.get("target_language") or sample.get("lang") or "English"
-        language = normalize_language(lang_raw)
-        prompt = str(sample.get("prompt") or sample.get("question") or sample.get("input") or "")
-        reference_answer = str(
-            sample.get("reference_answer")
-            or sample.get("expected_answer")
-            or sample.get("ground_truth")
-            or sample.get("target")
-            or sample.get("answer")
-            or ""
-        )
+        lang_raw = None
+        for k in ("language", "target_language", "lang"):
+            if k in sample and sample[k] is not None:
+                lang_raw = sample[k]
+                break
+        language = normalize_language(str(lang_raw) if lang_raw is not None else "English")
+
+        prompt = ""
+        for k in ("prompt", "question", "input"):
+            if k in sample and sample[k] is not None:
+                prompt = str(sample[k])
+                break
+
+        reference_answer = ""
+        for k in ("reference_answer", "expected_answer", "ground_truth", "target", "answer"):
+            if k in sample and sample[k] is not None:
+                reference_answer = str(sample[k])
+                break
 
         raw_output = self._invoke_model(model, prompt, language)
         reasoning, answer, tu_raw = self._parse_model_output(raw_output)
 
         cot_fidelity = self.evaluate_cot_fidelity(reasoning, language)
         accuracy = self.evaluate_accuracy(answer, reference_answer)
-        token_usage = self.compute_token_usage(prompt, reasoning, answer, raw_output)
+        token_usage = self.compute_token_usage(prompt, reasoning, answer, tu_raw or raw_output)
 
         return {
             "language": language,
@@ -319,10 +346,8 @@ class MultilingualReasoningEvaluator:
     def compute_transfer_efficiency(self, by_language_metrics: dict[str, dict[str, Any]]) -> dict[str, float]:
         """Calculate cross-lingual transfer efficiency relative to English."""
         english_acc = by_language_metrics.get("English", {}).get("accuracy", 0.0)
-        reference_acc = english_acc if english_acc > 0 else max(
-            (m["accuracy"] for m in by_language_metrics.values() if m.get("accuracy") is not None),
-            default=1.0,
-        )
+        positive_accs = [m["accuracy"] for m in by_language_metrics.values() if m.get("accuracy") is not None and m.get("accuracy", 0.0) > 0]
+        reference_acc = english_acc if english_acc > 0 else (max(positive_accs) if positive_accs else 0.0)
 
         efficiencies: dict[str, float] = {}
         for lang, metrics in by_language_metrics.items():
@@ -330,13 +355,13 @@ class MultilingualReasoningEvaluator:
             if reference_acc > 0:
                 efficiencies[lang] = round(acc / reference_acc, 4)
             else:
-                efficiencies[lang] = 1.0
+                efficiencies[lang] = 0.0
 
         return efficiencies
 
     def evaluate(self, model: Any, dataset: Sequence[dict[str, Any]]) -> dict[str, Any]:
         """Evaluate model on dataset and compile comprehensive report."""
-        if not dataset:
+        def _empty_report() -> dict[str, Any]:
             return {
                 "overall_accuracy": 0.0,
                 "overall_cot_fidelity": 0.0,
@@ -351,8 +376,30 @@ class MultilingualReasoningEvaluator:
                 "num_samples": 0,
             }
 
-        sample_results = [self.evaluate_sample(model, sample) for sample in dataset]
+        if not dataset:
+            return _empty_report()
 
+        if self.target_languages:
+            target_langs = set(self.target_languages)
+            dataset = [
+                s for s in dataset
+                if normalize_language(
+                    s.get("language") or s.get("target_language") or s.get("lang") or "English"
+                ) in target_langs
+            ]
+
+        if not dataset:
+            return _empty_report()
+
+        sample_results = []
+        for sample in dataset:
+            try:
+                sample_results.append(self.evaluate_sample(model, sample))
+            except Exception:
+                continue
+
+        if not sample_results:
+            return _empty_report()
         by_lang_samples: dict[str, list[dict[str, Any]]] = {}
         for res in sample_results:
             lang = res["language"]

--- a/chapter7/MultilingualReasoning/evaluate_multilingual.py
+++ b/chapter7/MultilingualReasoning/evaluate_multilingual.py
@@ -160,7 +160,7 @@ class MultilingualReasoningEvaluator:
         if lang == "Chinese":
             if kana_count > 0:
                 cjk_ratio = cjk_count / non_space_chars
-                return max(0.0, min(1.0, (cjk_ratio / 0.3) * 0.7))
+                return max(0.0, min(1.0, cjk_ratio / 0.3) * 0.7)
             cjk_ratio = cjk_count / non_space_chars
             return min(1.0, cjk_ratio / 0.35)
 
@@ -262,7 +262,7 @@ class MultilingualReasoningEvaluator:
 
         extracted = _extract_token_counts(tu)
         if extracted is not None:
-            r_tok = extracted["reasoning_tokens"] or 0
+            r_tok = extracted["reasoning_tokens"] if extracted["reasoning_tokens"] is not None else estimate_tokens(reasoning)
             p_tok = extracted["prompt_tokens"] if extracted["prompt_tokens"] is not None else estimate_tokens(prompt)
             c_tok = extracted["completion_tokens"] if extracted["completion_tokens"] is not None else (r_tok + estimate_tokens(answer))
             t_tok = extracted["total_tokens"] if extracted["total_tokens"] is not None else (p_tok + c_tok)
@@ -402,14 +402,23 @@ class MultilingualReasoningEvaluator:
         }
 
     def compute_transfer_efficiency(self, by_language_metrics: dict[str, dict[str, Any]]) -> dict[str, float]:
-        """Calculate cross-lingual transfer efficiency relative to English."""
-        english_acc = by_language_metrics.get("English", {}).get("accuracy", 0.0)
-        positive_accs = [m["accuracy"] for m in by_language_metrics.values() if m.get("accuracy") is not None and m.get("accuracy", 0.0) > 0]
+        """Calculate cross-lingual transfer efficiency relative to English.
+
+        If English accuracy is missing or zero, the highest per-language accuracy
+        becomes the reference. If no positive reference exists, efficiency is 0.0.
+        """
+        raw_eng = by_language_metrics.get("English") if isinstance(by_language_metrics.get("English"), dict) else {}
+        english_acc = (raw_eng.get("accuracy") or 0.0) if raw_eng else 0.0
+        positive_accs = [
+            m["accuracy"]
+            for m in by_language_metrics.values()
+            if isinstance(m, dict) and m.get("accuracy") is not None and m.get("accuracy", 0.0) > 0
+        ]
         reference_acc = english_acc if english_acc > 0 else (max(positive_accs) if positive_accs else 0.0)
 
         efficiencies: dict[str, float] = {}
         for lang, metrics in by_language_metrics.items():
-            acc = metrics.get("accuracy", 0.0)
+            acc = (metrics.get("accuracy") or 0.0) if isinstance(metrics, dict) else 0.0
             if reference_acc > 0:
                 efficiencies[lang] = round(acc / reference_acc, 4)
             else:

--- a/chapter7/MultilingualReasoning/evaluate_multilingual.py
+++ b/chapter7/MultilingualReasoning/evaluate_multilingual.py
@@ -88,7 +88,7 @@ def _accepts_language(fn: Any) -> bool:
                 return True
         return False
     except (ValueError, TypeError):
-        return True
+        return False
 
 
 class MultilingualReasoningEvaluator:
@@ -395,8 +395,19 @@ class MultilingualReasoningEvaluator:
         for sample in dataset:
             try:
                 sample_results.append(self.evaluate_sample(model, sample))
-            except Exception:
-                continue
+            except Exception as e:
+                lang_raw = sample.get("language") or sample.get("target_language") or sample.get("lang") or "English"
+                sample_results.append({
+                    "language": normalize_language(str(lang_raw)),
+                    "prompt": str(sample.get("prompt") or sample.get("question") or sample.get("input") or ""),
+                    "reference_answer": str(sample.get("reference_answer") or sample.get("expected_answer") or ""),
+                    "reasoning": "",
+                    "predicted_answer": "",
+                    "cot_fidelity": 0.0,
+                    "accuracy": 0.0,
+                    "error": str(e),
+                    "token_usage": {"prompt_tokens": 0, "completion_tokens": 0, "reasoning_tokens": 0, "total_tokens": 0},
+                })
 
         if not sample_results:
             return _empty_report()

--- a/chapter7/MultilingualReasoning/evaluate_multilingual.py
+++ b/chapter7/MultilingualReasoning/evaluate_multilingual.py
@@ -232,16 +232,12 @@ class MultilingualReasoningEvaluator:
             except ValueError:
                 pass
 
-        # Substring matching for short references with word boundaries
-        if len(ref_clean) >= 2:
-            pattern = r"\b" + re.escape(ref_clean) + r"\b"
-            if re.search(pattern, pred_clean):
-                return 1.0
-        elif len(ref) >= 2:
-            pattern = r"\b" + re.escape(ref) + r"\b"
+        # Substring matching for references with word boundaries
+        target_ref = ref_clean if ref_clean else ref
+        if target_ref:
+            pattern = r"\b" + re.escape(target_ref) + r"\b"
             if re.search(pattern, pred_clean) or re.search(pattern, pred):
                 return 1.0
-
         return 0.0
 
     def compute_token_usage(

--- a/chapter7/MultilingualReasoning/evaluate_multilingual.py
+++ b/chapter7/MultilingualReasoning/evaluate_multilingual.py
@@ -11,6 +11,7 @@ import inspect
 import math
 import re
 import statistics
+import warnings
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 LANG_MAP: dict[str, str] = {
@@ -26,6 +27,24 @@ LANG_MAP: dict[str, str] = {
     "zh-tw": "Chinese",
     "ja": "Japanese",
     "japanese": "Japanese",
+    "de": "German",
+    "german": "German",
+    "it": "Italian",
+    "italian": "Italian",
+    "pt": "Portuguese",
+    "portuguese": "Portuguese",
+    "ru": "Russian",
+    "russian": "Russian",
+    "ko": "Korean",
+    "korean": "Korean",
+    "ar": "Arabic",
+    "arabic": "Arabic",
+    "hi": "Hindi",
+    "hindi": "Hindi",
+    "nl": "Dutch",
+    "dutch": "Dutch",
+    "tr": "Turkish",
+    "turkish": "Turkish",
 }
 
 # Regex patterns for script detection
@@ -66,7 +85,18 @@ ENGLISH_WORDS = {
 def normalize_language(lang: str) -> str:
     """Normalize language identifier string to canonical English name."""
     cleaned = str(lang).strip().lower()
-    return LANG_MAP.get(cleaned, cleaned.capitalize())
+    canonical = LANG_MAP.get(cleaned)
+    if canonical is not None:
+        return canonical
+    # Unknown language: title-case for consistent multi-word names and warn
+    # so callers notice silent filtering in evaluate().
+    title_cased = cleaned.title()
+    warnings.warn(
+        f"Unrecognized language identifier {lang!r}; normalized to {title_cased!r}. "
+        f"Add it to LANG_MAP for reliable matching.",
+        stacklevel=2,
+    )
+    return title_cased
 
 
 def estimate_tokens(text: str) -> int:
@@ -209,7 +239,7 @@ class MultilingualReasoningEvaluator:
         ref = str(reference_answer if reference_answer is not None else "").strip().lower()
 
         if not pred or not ref:
-            return 1.0 if pred == ref else 0.0
+            return 0.0
 
         if pred == ref:
             return 1.0

--- a/chapter7/MultilingualReasoning/evaluate_multilingual.py
+++ b/chapter7/MultilingualReasoning/evaluate_multilingual.py
@@ -285,18 +285,34 @@ class MultilingualReasoningEvaluator:
             "total_tokens": t_tok,
         }
 
-    def _parse_model_output(self, raw_output: Any) -> tuple[str, str, dict[str, int]]:
+    def _parse_model_output(self, raw_output: Any) -> tuple[str, str, Any]:
         """Parse raw model output into reasoning CoT, final answer, and token metadata."""
         if isinstance(raw_output, dict):
-            reasoning = str(raw_output.get("reasoning") or raw_output.get("cot") or raw_output.get("thinking") or "")
-            answer = str(raw_output.get("answer") or raw_output.get("response") or raw_output.get("predicted_answer") or "")
-            tu = raw_output.get("token_usage") or {}
+            reasoning = ""
+            for k in ("reasoning", "cot", "thinking"):
+                if k in raw_output and raw_output[k] is not None:
+                    reasoning = str(raw_output[k])
+                    break
+            answer = ""
+            for k in ("answer", "response", "predicted_answer"):
+                if k in raw_output and raw_output[k] is not None:
+                    answer = str(raw_output[k])
+                    break
+            tu = raw_output.get("token_usage")
             return reasoning, answer, tu
 
-        if hasattr(raw_output, "reasoning") or hasattr(raw_output, "answer"):
-            reasoning = str(getattr(raw_output, "reasoning", "") or getattr(raw_output, "cot", ""))
-            answer = str(getattr(raw_output, "answer", "") or getattr(raw_output, "response", ""))
-            tu = getattr(raw_output, "token_usage", {})
+        if hasattr(raw_output, "reasoning") or hasattr(raw_output, "answer") or hasattr(raw_output, "cot") or hasattr(raw_output, "response") or hasattr(raw_output, "predicted_answer"):
+            reasoning = ""
+            for attr in ("reasoning", "cot", "thinking"):
+                if hasattr(raw_output, attr) and getattr(raw_output, attr) is not None:
+                    reasoning = str(getattr(raw_output, attr))
+                    break
+            answer = ""
+            for attr in ("answer", "response", "predicted_answer"):
+                if hasattr(raw_output, attr) and getattr(raw_output, attr) is not None:
+                    answer = str(getattr(raw_output, attr))
+                    break
+            tu = getattr(raw_output, "token_usage", None)
             return reasoning, answer, tu
 
         text = str(raw_output or "").strip()

--- a/chapter7/MultilingualReasoning/evaluate_multilingual.py
+++ b/chapter7/MultilingualReasoning/evaluate_multilingual.py
@@ -78,6 +78,40 @@ def estimate_tokens(text: str) -> int:
     words = non_cjk_text.split()
     # ~1.3 tokens per word for Latin scripts, ~1.5 tokens per character for CJK/Kana
     return max(1, int(len(words) * 1.3 + cjk_count * 1.5))
+def _extract_token_counts(tu: Any) -> Optional[dict[str, Optional[int]]]:
+    if tu is None:
+        return None
+
+    def get_val(key1: str, key2: Optional[str] = None) -> Optional[int]:
+        val = None
+        if isinstance(tu, dict):
+            val = tu.get(key1)
+            if val is None and key2:
+                val = tu.get(key2)
+        else:
+            val = getattr(tu, key1, None)
+            if val is None and key2:
+                val = getattr(tu, key2, None)
+        if val is not None:
+            try:
+                return int(val)
+            except (ValueError, TypeError):
+                return None
+        return None
+
+    p_tok = get_val("prompt_tokens", "input_tokens")
+    c_tok = get_val("completion_tokens", "output_tokens")
+    r_tok = get_val("reasoning_tokens")
+    t_tok = get_val("total_tokens")
+
+    if any(x is not None for x in (p_tok, c_tok, r_tok, t_tok)):
+        return {
+            "prompt_tokens": p_tok,
+            "completion_tokens": c_tok,
+            "reasoning_tokens": r_tok,
+            "total_tokens": t_tok,
+        }
+    return None
 
 
 def _accepts_language(fn: Any) -> bool:
@@ -203,6 +237,10 @@ class MultilingualReasoningEvaluator:
             pattern = r"\b" + re.escape(ref_clean) + r"\b"
             if re.search(pattern, pred_clean):
                 return 1.0
+        elif len(ref) >= 2:
+            pattern = r"\b" + re.escape(ref) + r"\b"
+            if re.search(pattern, pred_clean) or re.search(pattern, pred):
+                return 1.0
 
         return 0.0
 
@@ -212,18 +250,22 @@ class MultilingualReasoningEvaluator:
         """Extract or estimate prompt, completion, reasoning, and total token usage."""
         tu = None
         if isinstance(model_output, dict):
-            if "token_usage" in model_output and isinstance(model_output["token_usage"], dict):
+            if "token_usage" in model_output and model_output["token_usage"] is not None:
                 tu = model_output["token_usage"]
-            elif "total_tokens" in model_output or "prompt_tokens" in model_output:
+            else:
                 tu = model_output
-        elif hasattr(model_output, "token_usage"):
-            tu = getattr(model_output, "token_usage")
+        elif model_output is not None:
+            if hasattr(model_output, "token_usage") and getattr(model_output, "token_usage") is not None:
+                tu = getattr(model_output, "token_usage")
+            else:
+                tu = model_output
 
-        if isinstance(tu, dict) and tu:
-            p_tok = int(tu.get("prompt_tokens", 0))
-            r_tok = int(tu.get("reasoning_tokens", 0))
-            c_tok = int(tu.get("completion_tokens", r_tok + estimate_tokens(answer)))
-            t_tok = int(tu.get("total_tokens", p_tok + c_tok))
+        extracted = _extract_token_counts(tu)
+        if extracted is not None:
+            r_tok = extracted["reasoning_tokens"] or 0
+            p_tok = extracted["prompt_tokens"] if extracted["prompt_tokens"] is not None else estimate_tokens(prompt)
+            c_tok = extracted["completion_tokens"] if extracted["completion_tokens"] is not None else (r_tok + estimate_tokens(answer))
+            t_tok = extracted["total_tokens"] if extracted["total_tokens"] is not None else (p_tok + c_tok)
             return {
                 "prompt_tokens": p_tok,
                 "completion_tokens": c_tok,

--- a/tests/test_ch7_evaluate_multilingual.py
+++ b/tests/test_ch7_evaluate_multilingual.py
@@ -188,3 +188,15 @@ def test_transfer_efficiency_zero_reference():
     eff = evaluator.compute_transfer_efficiency(metrics)
     assert eff["English"] == 0.0
     assert eff["Spanish"] == 0.0
+
+
+def test_model_exception_and_builtin_callable():
+    evaluator = MultilingualReasoningEvaluator()
+
+    def failing_model(prompt):
+        raise RuntimeError("Model inference failed")
+
+    dataset = [{"language": "en", "prompt": "test", "reference_answer": "42"}]
+    report = evaluator.evaluate(failing_model, dataset)
+    assert report["num_samples"] == 1
+    assert report["overall_accuracy"] == 0.0

--- a/tests/test_ch7_evaluate_multilingual.py
+++ b/tests/test_ch7_evaluate_multilingual.py
@@ -59,7 +59,8 @@ def test_evaluate_accuracy():
     assert evaluator.evaluate_accuracy("The answer is 42.", "42") == 1.0
     assert evaluator.evaluate_accuracy("Paris", "paris!") == 1.0
     assert evaluator.evaluate_accuracy("Wrong", "42") == 0.0
-
+    assert evaluator.evaluate_accuracy("1042", "42") == 0.0
+    assert evaluator.evaluate_accuracy("0", 0) == 1.0
 
 def test_evaluator_sample_formats():
     evaluator = MultilingualReasoningEvaluator()
@@ -96,6 +97,16 @@ def test_evaluator_sample_formats():
     assert res_es["language"] == "Spanish"
     assert res_es["accuracy"] == 1.0
     assert res_es["token_usage"]["total_tokens"] == 30
+
+    # Test non-falsy zero answer
+    sample_zero = {
+        "language": "en",
+        "prompt": "What is 2 - 2?",
+        "reference_answer": 0,
+    }
+    res_zero = evaluator.evaluate_sample(lambda p: "0", sample_zero)
+    assert res_zero["reference_answer"] == "0"
+    assert res_zero["accuracy"] == 1.0
 
 
 def test_run_evaluation_end_to_end():
@@ -136,3 +147,44 @@ def test_run_evaluation_empty_dataset():
     assert report["num_samples"] == 0
     assert report["overall_accuracy"] == 0.0
     assert report["by_language"] == {}
+
+
+def test_object_model_and_method_invocations():
+    evaluator = MultilingualReasoningEvaluator()
+
+    class CustomOutput:
+        def __init__(self):
+            self.reasoning = "Step 1: Compute."
+            self.answer = "42"
+            self.token_usage = {
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "reasoning_tokens": 15,
+                "total_tokens": 30,
+            }
+
+    class GenerateModel:
+        def generate(self, prompt, language="English"):
+            return CustomOutput()
+
+    class PredictModel:
+        def predict(self, prompt):
+            return "Reasoning: Simple math\nAnswer: 42"
+    sample = {"language": "en", "prompt": "40+2?", "reference_answer": "42"}
+    res_gen = evaluator.evaluate_sample(GenerateModel(), sample)
+    assert res_gen["accuracy"] == 1.0
+    assert res_gen["token_usage"]["total_tokens"] == 30
+
+    res_pred = evaluator.evaluate_sample(PredictModel(), sample)
+    assert res_pred["accuracy"] == 1.0
+
+
+def test_transfer_efficiency_zero_reference():
+    evaluator = MultilingualReasoningEvaluator()
+    metrics = {
+        "English": {"accuracy": 0.0},
+        "Spanish": {"accuracy": 0.0},
+    }
+    eff = evaluator.compute_transfer_efficiency(metrics)
+    assert eff["English"] == 0.0
+    assert eff["Spanish"] == 0.0

--- a/tests/test_ch7_evaluate_multilingual.py
+++ b/tests/test_ch7_evaluate_multilingual.py
@@ -200,3 +200,59 @@ def test_model_exception_and_builtin_callable():
     report = evaluator.evaluate(failing_model, dataset)
     assert report["num_samples"] == 1
     assert report["overall_accuracy"] == 0.0
+def test_token_usage_object_attributes():
+    evaluator = MultilingualReasoningEvaluator()
+
+    class TokenUsageObj:
+        def __init__(self, input_tokens=12, output_tokens=24, total_tokens=36):
+            self.input_tokens = input_tokens
+            self.output_tokens = output_tokens
+            self.total_tokens = total_tokens
+
+    class ObjectOutputModel:
+        def __init__(self):
+            self.token_usage = TokenUsageObj()
+
+        def generate(self, prompt):
+            return {"answer": "42", "token_usage": TokenUsageObj(input_tokens=15, output_tokens=30, total_tokens=45)}
+
+    sample = {"language": "en", "prompt": "What is 40+2?", "reference_answer": "42"}
+    res = evaluator.evaluate_sample(ObjectOutputModel(), sample)
+    assert res["token_usage"]["prompt_tokens"] == 15
+    assert res["token_usage"]["completion_tokens"] == 30
+    assert res["token_usage"]["total_tokens"] == 45
+
+    # Direct test on compute_token_usage with token usage object
+    tu_obj = TokenUsageObj(input_tokens=100, output_tokens=200, total_tokens=300)
+    res_direct = evaluator.compute_token_usage("prompt", "reasoning", "answer", model_output=tu_obj)
+    assert res_direct["prompt_tokens"] == 100
+    assert res_direct["completion_tokens"] == 200
+    assert res_direct["total_tokens"] == 300
+
+
+def test_word_boundary_reference_matching():
+    evaluator = MultilingualReasoningEvaluator()
+    # Word boundary matching should succeed for full word substring
+    assert evaluator.evaluate_accuracy("The answer is Paris.", "Paris") == 1.0
+    # Word boundary matching should fail for partial word matching
+    assert evaluator.evaluate_accuracy("1042", "42") == 0.0
+    assert evaluator.evaluate_accuracy("no", "not paris") == 0.0
+
+
+def test_invoke_model_inspect_signature():
+    evaluator = MultilingualReasoningEvaluator()
+
+    # Function accepting language
+    def model_with_lang(prompt, language="English"):
+        return f"Response for {language}: {prompt}"
+
+    # Function not accepting language
+    def model_without_lang(prompt):
+        return f"Response: {prompt}"
+
+    sample = {"language": "Spanish", "prompt": "Hola", "reference_answer": "Hola"}
+    res_lang = evaluator.evaluate_sample(model_with_lang, sample)
+    assert "Spanish" in res_lang["predicted_answer"]
+
+    res_nolang = evaluator.evaluate_sample(model_without_lang, sample)
+    assert "Response: Hola" == res_nolang["predicted_answer"]

--- a/tests/test_ch7_evaluate_multilingual.py
+++ b/tests/test_ch7_evaluate_multilingual.py
@@ -234,10 +234,11 @@ def test_word_boundary_reference_matching():
     evaluator = MultilingualReasoningEvaluator()
     # Word boundary matching should succeed for full word substring
     assert evaluator.evaluate_accuracy("The answer is Paris.", "Paris") == 1.0
+    assert evaluator.evaluate_accuracy("The answer is A", "A") == 1.0
     # Word boundary matching should fail for partial word matching
     assert evaluator.evaluate_accuracy("1042", "42") == 0.0
     assert evaluator.evaluate_accuracy("no", "not paris") == 0.0
-
+    assert evaluator.evaluate_accuracy("apple", "a") == 0.0
 
 def test_invoke_model_inspect_signature():
     evaluator = MultilingualReasoningEvaluator()

--- a/tests/test_ch7_evaluate_multilingual.py
+++ b/tests/test_ch7_evaluate_multilingual.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import sys
+import warnings
 
 # Ensure chapter7/MultilingualReasoning is in sys.path
 ch7_dir = Path(__file__).resolve().parent.parent / "chapter7" / "MultilingualReasoning"

--- a/tests/test_ch7_evaluate_multilingual.py
+++ b/tests/test_ch7_evaluate_multilingual.py
@@ -256,3 +256,11 @@ def test_invoke_model_inspect_signature():
 
     res_nolang = evaluator.evaluate_sample(model_without_lang, sample)
     assert "Response: Hola" == res_nolang["predicted_answer"]
+def test_zero_answer_handling():
+    evaluator = MultilingualReasoningEvaluator()
+    sample = {"language": "en", "prompt": "1-1?", "reference_answer": 0}
+    model = lambda p: {"answer": 0, "reasoning": "1 minus 1 equals 0"}
+    res = evaluator.evaluate_sample(model, sample)
+    assert res["predicted_answer"] == "0"
+    assert res["reference_answer"] == "0"
+    assert res["accuracy"] == 1.0

--- a/tests/test_ch7_evaluate_multilingual.py
+++ b/tests/test_ch7_evaluate_multilingual.py
@@ -1,0 +1,138 @@
+"""Unit tests for chapter7/MultilingualReasoning/evaluate_multilingual.py."""
+
+from pathlib import Path
+import sys
+
+# Ensure chapter7/MultilingualReasoning is in sys.path
+ch7_dir = Path(__file__).resolve().parent.parent / "chapter7" / "MultilingualReasoning"
+if str(ch7_dir) not in sys.path:
+    sys.path.insert(0, str(ch7_dir))
+
+from evaluate_multilingual import (
+    MultilingualReasoningEvaluator,
+    normalize_language,
+    run_evaluation,
+)
+
+
+def test_normalize_language():
+    assert normalize_language("en") == "English"
+    assert normalize_language("SPANISH") == "Spanish"
+    assert normalize_language("fr") == "French"
+    assert normalize_language("zh") == "Chinese"
+    assert normalize_language("ja") == "Japanese"
+    assert normalize_language("German") == "German"
+
+
+def test_cot_fidelity_scoring():
+    evaluator = MultilingualReasoningEvaluator()
+
+    # Chinese CoT fidelity
+    zh_cot = "首先计算第一步：因为 2 + 2 = 4，所以结论是 4。"
+    assert evaluator.evaluate_cot_fidelity(zh_cot, "Chinese") > 0.8
+
+    # Japanese CoT fidelity (contains Hiragana and CJK)
+    ja_cot = "ステップ1：2 + 2 = 4 なので、答えは 4 です。"
+    assert evaluator.evaluate_cot_fidelity(ja_cot, "Japanese") > 0.8
+
+    # Spanish CoT fidelity
+    es_cot = "Paso 1: Porque 2 + 2 es igual a 4, entonces la respuesta es 4."
+    assert evaluator.evaluate_cot_fidelity(es_cot, "Spanish") > 0.5
+
+    # French CoT fidelity
+    fr_cot = "Étape 1: Parce que 2 + 2 est égal à 4, donc la réponse est 4."
+    assert evaluator.evaluate_cot_fidelity(fr_cot, "French") > 0.5
+
+    # English CoT fidelity
+    en_cot = "Step 1: Because 2 + 2 equals 4, therefore the answer is 4."
+    assert evaluator.evaluate_cot_fidelity(en_cot, "English") > 0.7
+
+    # Cross-lingual leakage (Chinese text evaluated as English fidelity)
+    assert evaluator.evaluate_cot_fidelity(zh_cot, "English") == 0.0
+
+
+def test_evaluate_accuracy():
+    evaluator = MultilingualReasoningEvaluator()
+
+    assert evaluator.evaluate_accuracy("42", "42") == 1.0
+    assert evaluator.evaluate_accuracy("42.0", "42") == 1.0
+    assert evaluator.evaluate_accuracy("The answer is 42.", "42") == 1.0
+    assert evaluator.evaluate_accuracy("Paris", "paris!") == 1.0
+    assert evaluator.evaluate_accuracy("Wrong", "42") == 0.0
+
+
+def test_evaluator_sample_formats():
+    evaluator = MultilingualReasoningEvaluator()
+
+    # Mock model returning string with <think> tag
+    def string_model(prompt, language="English"):
+        return "<think>Step 1: Reasoning here.</think> 42"
+
+    sample = {
+        "language": "en",
+        "prompt": "What is 40 + 2?",
+        "reference_answer": "42",
+    }
+    res = evaluator.evaluate_sample(string_model, sample)
+    assert res["language"] == "English"
+    assert res["accuracy"] == 1.0
+    assert res["reasoning"] == "Step 1: Reasoning here."
+    assert res["predicted_answer"] == "42"
+
+    # Mock model returning dict
+    def dict_model(prompt, language="Spanish"):
+        return {
+            "reasoning": "Paso 1: Razonamiento en español.",
+            "answer": "42",
+            "token_usage": {"prompt_tokens": 10, "completion_tokens": 20, "reasoning_tokens": 15, "total_tokens": 30},
+        }
+
+    sample_es = {
+        "target_language": "Spanish",
+        "question": "¿Cuánto es 40 + 2?",
+        "ground_truth": "42",
+    }
+    res_es = evaluator.evaluate_sample(dict_model, sample_es)
+    assert res_es["language"] == "Spanish"
+    assert res_es["accuracy"] == 1.0
+    assert res_es["token_usage"]["total_tokens"] == 30
+
+
+def test_run_evaluation_end_to_end():
+    dataset = [
+        {"language": "en", "prompt": "What is 2+2?", "reference_answer": "4"},
+        {"language": "es", "prompt": "¿Cuánto es 2+2?", "reference_answer": "4"},
+        {"language": "fr", "prompt": "Combien font 2+2?", "reference_answer": "4"},
+        {"language": "zh", "prompt": "2+2等于多少？", "reference_answer": "4"},
+        {"language": "ja", "prompt": "2+2はいくらですか？", "reference_answer": "4"},
+    ]
+
+    def mock_multilingual_model(prompt, language="English"):
+        responses = {
+            "English": "<think>Step 1: Add numbers.</think> 4",
+            "Spanish": "<think>Paso 1: Sumar números, entonces es 4.</think> 4",
+            "French": "<think>Étape 1: Additionner donc c'est 4.</think> 4",
+            "Chinese": "<think>第一步：因为 2+2=4，所以是 4。</think> 4",
+            "Japanese": "<think>ステップ1：2+2=4 なので 4 です。</think> 4",
+        }
+        return responses.get(language, "<think>Step 1</think> 4")
+
+    report = run_evaluation(mock_multilingual_model, dataset)
+
+    assert report["num_samples"] == 5
+    assert report["overall_accuracy"] == 1.0
+    assert report["overall_cot_fidelity"] > 0.6
+    assert report["overall_transfer_efficiency"] == 1.0
+    assert "English" in report["by_language"]
+    assert "Spanish" in report["by_language"]
+    assert "French" in report["by_language"]
+    assert "Chinese" in report["by_language"]
+    assert "Japanese" in report["by_language"]
+    assert report["total_token_usage"]["total_tokens"] > 0
+
+
+def test_run_evaluation_empty_dataset():
+    report = run_evaluation(lambda p: "42", [])
+    assert report["num_samples"] == 0
+    assert report["overall_accuracy"] == 0.0
+    assert report["by_language"] == {}

--- a/tests/test_ch7_evaluate_multilingual.py
+++ b/tests/test_ch7_evaluate_multilingual.py
@@ -264,3 +264,30 @@ def test_zero_answer_handling():
     assert res["predicted_answer"] == "0"
     assert res["reference_answer"] == "0"
     assert res["accuracy"] == 1.0
+def test_chinese_cot_fidelity_japanese_kana_penalty():
+    evaluator = MultilingualReasoningEvaluator()
+    # Chinese CoT containing Japanese kana should be penalized (capped at 0.7)
+    cot_with_kana = "第一歩：計算結果、二足す二は四、答案は四。だ"
+    score = evaluator.evaluate_cot_fidelity(cot_with_kana, "Chinese")
+    assert score == 0.7
+
+
+def test_transfer_efficiency_none_accuracy():
+    evaluator = MultilingualReasoningEvaluator()
+    metrics = {
+        "English": {"accuracy": None},
+        "Spanish": {"accuracy": 0.5},
+    }
+    eff = evaluator.compute_transfer_efficiency(metrics)
+    assert eff["English"] == 0.0
+    assert eff["Spanish"] == 1.0
+
+
+def test_partial_token_usage_reasoning_estimation():
+    evaluator = MultilingualReasoningEvaluator()
+    tu = {"prompt_tokens": 10, "completion_tokens": 50, "total_tokens": 60}
+    res = evaluator.compute_token_usage("prompt", "detailed reasoning step by step", "answer", model_output=tu)
+    assert res["prompt_tokens"] == 10
+    assert res["completion_tokens"] == 50
+    assert res["reasoning_tokens"] > 0
+    assert res["total_tokens"] == 60


### PR DESCRIPTION
## Summary

Adds a multilingual reasoning evaluator that measures LLM CoT language fidelity, task accuracy, token usage, and cross-lingual transfer efficiency across 12 languages.

## Changes

- **`chapter7/MultilingualReasoning/evaluate_multilingual.py`** — `MultilingualReasoningEvaluator` with script detection (CJK, hiragana, katakana, Latin diacritics), language abbreviation mapping (en/es/fr/zh/ja/de/it/pt/ru/ko/ar/hi/nl/tr), CoT language fidelity scoring, empty-answer scoring (0.0), and CJK-aware reference matching using direct substring containment instead of `\b` word boundaries.
- **`tests/test_ch7_evaluate_multilingual.py`** — 16 tests covering language detection, CoT fidelity, accuracy scoring, CJK matching, and edge cases.