### PR TITLE
feat(ch9): add duplex interruption manager for streaming speech

### DIFF
--- a/chapter9/streaming-speech/interruption_manager.py
+++ b/chapter9/streaming-speech/interruption_manager.py
@@ -138,12 +138,9 @@ class DuplexInterruptionManager:
                 elif raw_arr.dtype == np.int16:
                     arr = raw_arr.astype(np.float32) / 32768.0
                 else:
-                    max_abs = float(np.max(np.abs(raw_arr))) if raw_arr.size > 0 else 1.0
-                    if max_abs > 1.0:
-                        scale = 32768.0 if max_abs <= 32768.0 else max_abs
-                        arr = raw_arr.astype(np.float32) / scale
-                    else:
-                        arr = raw_arr.astype(np.float32)
+                    max_abs = float(np.max(np.abs(raw_arr))) if raw_arr.size > 0 else 0.0
+                    scale = 32768.0 if max_abs <= 32768.0 else max_abs
+                    arr = raw_arr.astype(np.float32) / scale
             else:
                 arr = raw_arr.astype(np.float32)
                 max_abs = float(np.max(np.abs(arr))) if arr.size > 0 else 0.0
@@ -161,12 +158,9 @@ class DuplexInterruptionManager:
                 elif audio_data.dtype == np.int16:
                     arr = audio_data.astype(np.float32) / 32768.0
                 else:
-                    max_abs = float(np.max(np.abs(audio_data))) if audio_data.size > 0 else 1.0
-                    if max_abs > 1.0:
-                        scale = 32768.0 if max_abs <= 32768.0 else max_abs
-                        arr = audio_data.astype(np.float32) / scale
-                    else:
-                        arr = audio_data.astype(np.float32)
+                    max_abs = float(np.max(np.abs(audio_data))) if audio_data.size > 0 else 0.0
+                    scale = 32768.0 if max_abs <= 32768.0 else max_abs
+                    arr = audio_data.astype(np.float32) / scale
             else:
                 arr = audio_data.astype(np.float32)
                 max_abs = float(np.max(np.abs(arr))) if arr.size > 0 else 0.0

--- a/chapter9/streaming-speech/interruption_manager.py
+++ b/chapter9/streaming-speech/interruption_manager.py
@@ -152,9 +152,17 @@ class DuplexInterruptionManager:
                     arr = raw_arr.astype(np.float32) / scale
             else:
                 arr = raw_arr.astype(np.float32)
+                # If values are in integer PCM range (>1.0), normalize to [-1, 1].
+                # Use a fixed int16 scale rather than per-chunk max to preserve
+                # relative volume across chunks.
                 max_abs = float(np.max(np.abs(arr))) if arr.size > 0 else 0.0
                 if max_abs > 1.0:
-                    arr = arr / 32768.0
+                    if max_abs <= 128.0:
+                        arr = arr / 128.0
+                    elif max_abs <= 32768.0:
+                        arr = arr / 32768.0
+                    else:
+                        arr = arr / 2147483648.0
         elif isinstance(audio_data, np.ndarray):
             if audio_data.size == 0:
                 return 0.0
@@ -180,7 +188,12 @@ class DuplexInterruptionManager:
                 arr = audio_data.astype(np.float32)
                 max_abs = float(np.max(np.abs(arr))) if arr.size > 0 else 0.0
                 if max_abs > 1.0:
-                    arr = arr / 32768.0
+                    if max_abs <= 128.0:
+                        arr = arr / 128.0
+                    elif max_abs <= 32768.0:
+                        arr = arr / 32768.0
+                    else:
+                        arr = arr / 2147483648.0
         else:
             return 0.0
 

--- a/chapter9/streaming-speech/interruption_manager.py
+++ b/chapter9/streaming-speech/interruption_manager.py
@@ -115,17 +115,17 @@ class DuplexInterruptionManager:
         if isinstance(audio_data, bytes):
             if len(audio_data) == 0:
                 return 0.0
-            if fmt in ("float32", "float") or (not fmt and len(audio_data) % 4 == 0 and len(audio_data) % 2 == 0):
-                if fmt in ("float32", "float"):
-                    arr = np.frombuffer(audio_data, dtype=np.float32)
-                elif len(audio_data) % 2 == 0:
-                    arr = np.frombuffer(audio_data, dtype=np.int16).astype(np.float32) / 32768.0
-                else:
-                    arr = (np.frombuffer(audio_data, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
-            elif fmt == "uint8" or (len(audio_data) % 2 != 0):
+            if fmt in ("float32", "float"):
+                arr = np.frombuffer(audio_data, dtype=np.float32)
+            elif fmt in ("uint8", "u8"):
                 arr = (np.frombuffer(audio_data, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
+            elif fmt in ("int8", "i8"):
+                arr = np.frombuffer(audio_data, dtype=np.int8).astype(np.float32) / 128.0
             else:
-                arr = np.frombuffer(audio_data, dtype=np.int16).astype(np.float32) / 32768.0
+                if len(audio_data) % 2 != 0:
+                    arr = (np.frombuffer(audio_data, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
+                else:
+                    arr = np.frombuffer(audio_data, dtype=np.int16).astype(np.float32) / 32768.0
         elif isinstance(audio_data, (list, tuple)):
             if len(audio_data) == 0:
                 return 0.0
@@ -315,7 +315,7 @@ class DuplexInterruptionManager:
         return {
             "status": "interrupted",
             "barge_in": True,
-            "playback_cancelled": True,
+            "playback_cancelled": was_playing,
             "cancelled_audio_bytes": cancelled_bytes,
             "context_truncated": truncated_turns_count > 0,
             "truncated_turns_count": truncated_turns_count,

--- a/chapter9/streaming-speech/interruption_manager.py
+++ b/chapter9/streaming-speech/interruption_manager.py
@@ -117,11 +117,50 @@ class DuplexInterruptionManager:
         elif isinstance(audio_data, (list, tuple)):
             if len(audio_data) == 0:
                 return 0.0
-            arr = np.array(audio_data, dtype=np.float32)
+            raw_arr = np.array(audio_data)
+            if np.issubdtype(raw_arr.dtype, np.integer):
+                if raw_arr.dtype == np.uint8:
+                    arr = raw_arr.astype(np.float32) / 255.0 - 0.5
+                elif raw_arr.dtype == np.int8:
+                    arr = raw_arr.astype(np.float32) / 128.0
+                elif raw_arr.dtype == np.int16:
+                    arr = raw_arr.astype(np.float32) / 32768.0
+                else:
+                    max_abs = float(np.max(np.abs(raw_arr))) if raw_arr.size > 0 else 1.0
+                    if max_abs > 1.0:
+                        scale = 32768.0 if max_abs <= 32768.0 else max_abs
+                        arr = raw_arr.astype(np.float32) / scale
+                    else:
+                        arr = raw_arr.astype(np.float32)
+            else:
+                arr = raw_arr.astype(np.float32)
+                max_abs = float(np.max(np.abs(arr))) if arr.size > 0 else 0.0
+                if max_abs > 1.0:
+                    scale = 32768.0 if max_abs <= 32768.0 else max_abs
+                    arr = arr / scale
         elif isinstance(audio_data, np.ndarray):
             if audio_data.size == 0:
                 return 0.0
-            arr = audio_data.astype(np.float32)
+            if np.issubdtype(audio_data.dtype, np.integer):
+                if audio_data.dtype == np.uint8:
+                    arr = audio_data.astype(np.float32) / 255.0 - 0.5
+                elif audio_data.dtype == np.int8:
+                    arr = audio_data.astype(np.float32) / 128.0
+                elif audio_data.dtype == np.int16:
+                    arr = audio_data.astype(np.float32) / 32768.0
+                else:
+                    max_abs = float(np.max(np.abs(audio_data))) if audio_data.size > 0 else 1.0
+                    if max_abs > 1.0:
+                        scale = 32768.0 if max_abs <= 32768.0 else max_abs
+                        arr = audio_data.astype(np.float32) / scale
+                    else:
+                        arr = audio_data.astype(np.float32)
+            else:
+                arr = audio_data.astype(np.float32)
+                max_abs = float(np.max(np.abs(arr))) if arr.size > 0 else 0.0
+                if max_abs > 1.0:
+                    scale = 32768.0 if max_abs <= 32768.0 else max_abs
+                    arr = arr / scale
         else:
             return 0.0
 
@@ -181,11 +220,15 @@ class DuplexInterruptionManager:
 
         return {
             "barge_in": False,
-            "is_speech": False,
+            "is_speech": is_speech,
             "energy": energy,
             "vad_threshold": self.vad_threshold,
             "is_playing": True,
-            "message": "No voice activity detected during TTS playback.",
+            "message": (
+                "Voice activity detected; awaiting consecutive frames."
+                if is_speech
+                else "No voice activity detected during TTS playback."
+            ),
         }
 
     def handle_barge_in(

--- a/chapter9/streaming-speech/interruption_manager.py
+++ b/chapter9/streaming-speech/interruption_manager.py
@@ -100,19 +100,19 @@ class DuplexInterruptionManager:
 
     def calculate_energy(
         self,
-        audio_data: Union[np.ndarray, bytes, List[float], List[int]],
+        audio_data: Union[np.ndarray, bytes, bytearray, memoryview, List[float], List[int]],
         sample_format: Optional[str] = None,
     ) -> float:
         """Calculate Root Mean Square (RMS) energy level of an audio chunk.
 
-        Supports numpy arrays, raw bytes (16-bit PCM, uint8, or float32), or float/int lists.
+        Supports numpy arrays, raw bytes/bytearray/memoryview (16-bit PCM, uint8, or float32), or float/int lists.
         sample_format can be 'int16', 'uint8', 'float32', or None for auto detection.
         """
         if audio_data is None:
             return 0.0
 
         fmt = (sample_format or "").lower()
-        if isinstance(audio_data, bytes):
+        if isinstance(audio_data, (bytes, bytearray, memoryview)):
             if len(audio_data) == 0:
                 return 0.0
             if fmt in ("float32", "float"):
@@ -121,6 +121,8 @@ class DuplexInterruptionManager:
                 arr = (np.frombuffer(audio_data, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
             elif fmt in ("int8", "i8"):
                 arr = np.frombuffer(audio_data, dtype=np.int8).astype(np.float32) / 128.0
+            elif fmt in ("int16", "i16"):
+                arr = np.frombuffer(audio_data, dtype=np.int16).astype(np.float32) / 32768.0
             else:
                 if len(audio_data) % 2 != 0:
                     arr = (np.frombuffer(audio_data, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
@@ -131,11 +133,11 @@ class DuplexInterruptionManager:
                 return 0.0
             raw_arr = np.array(audio_data)
             if np.issubdtype(raw_arr.dtype, np.integer):
-                if raw_arr.dtype == np.uint8 or fmt == "uint8":
+                if raw_arr.dtype == np.uint8 or fmt in ("uint8", "u8"):
                     arr = (raw_arr.astype(np.float32) - 128.0) / 128.0
-                elif raw_arr.dtype == np.int8:
+                elif raw_arr.dtype == np.int8 or fmt in ("int8", "i8"):
                     arr = raw_arr.astype(np.float32) / 128.0
-                elif raw_arr.dtype == np.int16:
+                elif raw_arr.dtype == np.int16 or fmt in ("int16", "i16"):
                     arr = raw_arr.astype(np.float32) / 32768.0
                 else:
                     max_abs = float(np.max(np.abs(raw_arr))) if raw_arr.size > 0 else 0.0
@@ -151,11 +153,11 @@ class DuplexInterruptionManager:
             if audio_data.size == 0:
                 return 0.0
             if np.issubdtype(audio_data.dtype, np.integer):
-                if audio_data.dtype == np.uint8 or fmt == "uint8":
+                if audio_data.dtype == np.uint8 or fmt in ("uint8", "u8"):
                     arr = (audio_data.astype(np.float32) - 128.0) / 128.0
-                elif audio_data.dtype == np.int8:
+                elif audio_data.dtype == np.int8 or fmt in ("int8", "i8"):
                     arr = audio_data.astype(np.float32) / 128.0
-                elif audio_data.dtype == np.int16:
+                elif audio_data.dtype == np.int16 or fmt in ("int16", "i16"):
                     arr = audio_data.astype(np.float32) / 32768.0
                 else:
                     max_abs = float(np.max(np.abs(audio_data))) if audio_data.size > 0 else 0.0
@@ -178,7 +180,7 @@ class DuplexInterruptionManager:
 
     def is_voice_active(
         self,
-        audio_data: Union[np.ndarray, bytes, List[float], List[int]],
+        audio_data: Union[np.ndarray, bytes, bytearray, memoryview, List[float], List[int]],
         sample_format: Optional[str] = None,
     ) -> bool:
         """Check if incoming audio chunk exceeds the VAD energy threshold."""
@@ -187,7 +189,7 @@ class DuplexInterruptionManager:
 
     def process_audio_chunk(
         self,
-        audio_data: Union[np.ndarray, bytes, List[float], List[int]],
+        audio_data: Union[np.ndarray, bytes, bytearray, memoryview, List[float], List[int]],
         sample_rate: int = 16000,
         sample_format: Optional[str] = None,
     ) -> Dict[str, Any]:
@@ -207,6 +209,7 @@ class DuplexInterruptionManager:
             return {
                 "barge_in": False,
                 "is_speech": is_speech,
+                "consecutive_frames": 0,
                 "energy": energy,
                 "vad_threshold": self.vad_threshold,
                 "is_playing": False,
@@ -216,6 +219,7 @@ class DuplexInterruptionManager:
         if is_speech:
             self._consecutive_active_frames += 1
             if self._consecutive_active_frames >= self.consecutive_frames_required:
+                current_consecutive = self._consecutive_active_frames
                 # Trigger instant barge-in
                 barge_in_result = self.handle_barge_in(
                     reason="user_barge_in_detected",
@@ -223,6 +227,7 @@ class DuplexInterruptionManager:
                 )
                 barge_in_result["energy"] = energy
                 barge_in_result["is_speech"] = True
+                barge_in_result["consecutive_frames"] = current_consecutive
                 barge_in_result["vad_threshold"] = self.vad_threshold
                 barge_in_result["is_playing"] = False
                 return barge_in_result
@@ -232,6 +237,7 @@ class DuplexInterruptionManager:
         return {
             "barge_in": False,
             "is_speech": is_speech,
+            "consecutive_frames": self._consecutive_active_frames,
             "energy": energy,
             "vad_threshold": self.vad_threshold,
             "is_playing": True,
@@ -259,6 +265,20 @@ class DuplexInterruptionManager:
         was_playing = self.is_playing
         cancelled_bytes = sum(len(b) for b in self.pending_audio_stream)
         self.stop_playback()
+
+        if not was_playing:
+            return {
+                "status": "ignored",
+                "barge_in": False,
+                "playback_cancelled": False,
+                "cancelled_audio_bytes": 0,
+                "context_truncated": False,
+                "truncated_turns_count": 0,
+                "replan_triggered": False,
+                "replan_payload": None,
+                "barge_in_count": self.barge_in_count,
+                "event": None,
+            }
 
         self.barge_in_count += 1
 

--- a/chapter9/streaming-speech/interruption_manager.py
+++ b/chapter9/streaming-speech/interruption_manager.py
@@ -1,0 +1,289 @@
+"""Duplex Interruption Manager for Real-Time Streaming Speech Systems.
+
+Monitors real-time Voice Activity Detection (VAD) energy signals during active TTS audio playback,
+enabling instant audio stream cancellation upon user barge-in, dialogue context truncation,
+and re-planning trigger generation.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Union
+import numpy as np
+
+
+@dataclass
+class InterruptionEvent:
+    """Event payload generated when a user barge-in interrupts active TTS playback."""
+    timestamp: float
+    barge_in_id: int
+    energy_level: float
+    vad_threshold: float
+    truncated_turns: int
+    reason: str
+    replan_triggered: bool
+    cancelled_audio_bytes: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert interruption event to dictionary representation."""
+        return {
+            "timestamp": self.timestamp,
+            "barge_in_id": self.barge_in_id,
+            "energy_level": self.energy_level,
+            "vad_threshold": self.vad_threshold,
+            "truncated_turns": self.truncated_turns,
+            "reason": self.reason,
+            "replan_triggered": self.replan_triggered,
+            "cancelled_audio_bytes": self.cancelled_audio_bytes,
+        }
+
+
+@dataclass
+class DialogueTurn:
+    """Represents a turn in the dialogue context."""
+    role: str
+    content: str
+    status: str = "completed"  # "completed", "interrupted", "pending"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class DuplexInterruptionManager:
+    """Manages real-time interruption (barge-in) detection and handling for duplex speech systems.
+    
+    Monitors user audio input streams via VAD energy analysis while TTS audio is actively playing.
+    If speech is detected during active TTS output, it instantly cancels playback, truncates
+    the dialogue context to match what was actually delivered, and emits a re-planning trigger.
+    """
+
+    def __init__(
+        self,
+        vad_threshold: float = 0.02,
+        consecutive_frames_required: int = 1,
+        on_barge_in: Optional[Callable[[InterruptionEvent], None]] = None,
+        on_replan: Optional[Callable[[Dict[str, Any]], None]] = None,
+    ) -> None:
+        """Initialize the DuplexInterruptionManager.
+
+        Args:
+            vad_threshold: RMS energy threshold above which audio frame is treated as voice active.
+            consecutive_frames_required: Number of consecutive active frames required to trigger barge-in.
+            on_barge_in: Optional callback invoked when a barge-in event occurs.
+            on_replan: Optional callback invoked when re-planning is triggered.
+        """
+        self.vad_threshold = float(vad_threshold)
+        self.consecutive_frames_required = max(1, int(consecutive_frames_required))
+        self.on_barge_in = on_barge_in
+        self.on_replan = on_replan
+
+        # Playback & state management
+        self.is_playing: bool = False
+        self._consecutive_active_frames: int = 0
+        self.barge_in_count: int = 0
+        self.dialogue_context: List[DialogueTurn] = []
+        self.pending_audio_stream: List[bytes] = []
+        self.last_interruption_event: Optional[InterruptionEvent] = None
+        self.replan_triggers: List[Dict[str, Any]] = []
+
+    def start_playback(self, initial_audio_stream: Optional[List[bytes]] = None) -> None:
+        """Mark TTS playback as active and optionally register pending audio stream chunks."""
+        self.is_playing = True
+        self._consecutive_active_frames = 0
+        if initial_audio_stream is not None:
+            self.pending_audio_stream = list(initial_audio_stream)
+
+    def stop_playback(self) -> None:
+        """Mark TTS playback as inactive and clear pending audio stream."""
+        self.is_playing = False
+        self._consecutive_active_frames = 0
+        self.pending_audio_stream.clear()
+
+    def calculate_energy(self, audio_data: Union[np.ndarray, bytes, List[float], List[int]]) -> float:
+        """Calculate Root Mean Square (RMS) energy level of an audio chunk.
+
+        Supports numpy arrays, raw bytes (16-bit PCM or float32), or float/int lists.
+        """
+        if audio_data is None:
+            return 0.0
+
+        if isinstance(audio_data, bytes):
+            if len(audio_data) == 0:
+                return 0.0
+            # Try 16-bit PCM int or uint8
+            if len(audio_data) % 2 == 0:
+                arr = np.frombuffer(audio_data, dtype=np.int16).astype(np.float32) / 32768.0
+            else:
+                arr = np.frombuffer(audio_data, dtype=np.uint8).astype(np.float32) / 255.0 - 0.5
+        elif isinstance(audio_data, (list, tuple)):
+            if len(audio_data) == 0:
+                return 0.0
+            arr = np.array(audio_data, dtype=np.float32)
+        elif isinstance(audio_data, np.ndarray):
+            if audio_data.size == 0:
+                return 0.0
+            arr = audio_data.astype(np.float32)
+        else:
+            return 0.0
+
+        if arr.size == 0:
+            return 0.0
+
+        rms = float(np.sqrt(np.mean(arr ** 2) + 1e-12))
+        return rms
+
+    def is_voice_active(self, audio_data: Union[np.ndarray, bytes, List[float], List[int]]) -> bool:
+        """Check if incoming audio chunk exceeds the VAD energy threshold."""
+        energy = self.calculate_energy(audio_data)
+        return energy >= self.vad_threshold
+
+    def process_audio_chunk(
+        self,
+        audio_data: Union[np.ndarray, bytes, List[float], List[int]],
+        sample_rate: int = 16000,
+    ) -> Dict[str, Any]:
+        """Process real-time incoming audio chunk from user.
+
+        Monitors VAD energy signal during active TTS audio playback.
+        If VAD energy surpasses threshold while playing, triggers barge-in.
+
+        Returns:
+            Dict containing VAD analysis results, playback status, and interruption info.
+        """
+        energy = self.calculate_energy(audio_data)
+        is_speech = energy >= self.vad_threshold
+
+        if not self.is_playing:
+            self._consecutive_active_frames = 0
+            return {
+                "barge_in": False,
+                "is_speech": is_speech,
+                "energy": energy,
+                "vad_threshold": self.vad_threshold,
+                "is_playing": False,
+                "message": "TTS playback inactive; audio processed normally.",
+            }
+
+        if is_speech:
+            self._consecutive_active_frames += 1
+            if self._consecutive_active_frames >= self.consecutive_frames_required:
+                # Trigger instant barge-in
+                barge_in_result = self.handle_barge_in(
+                    reason="user_barge_in_detected",
+                    energy_level=energy,
+                )
+                barge_in_result["energy"] = energy
+                barge_in_result["is_speech"] = True
+                barge_in_result["vad_threshold"] = self.vad_threshold
+                barge_in_result["is_playing"] = False
+                return barge_in_result
+        else:
+            self._consecutive_active_frames = 0
+
+        return {
+            "barge_in": False,
+            "is_speech": False,
+            "energy": energy,
+            "vad_threshold": self.vad_threshold,
+            "is_playing": True,
+            "message": "No voice activity detected during TTS playback.",
+        }
+
+    def handle_barge_in(
+        self,
+        truncated_length: Optional[int] = None,
+        reason: str = "user_barge_in",
+        energy_level: float = 0.0,
+    ) -> Dict[str, Any]:
+        """Handle instant audio stream cancellation, dialogue context truncation, and re-planning.
+
+        Entrypoint called upon barge-in detection or manual invocation.
+
+        Returns:
+            Dict containing complete interruption event outcome details.
+        """
+        # 1. Instant audio stream cancellation
+        was_playing = self.is_playing
+        cancelled_bytes = sum(len(b) for b in self.pending_audio_stream)
+        self.stop_playback()
+
+        self.barge_in_count += 1
+
+        # 2. Dialogue context truncation
+        truncated_turns_count = 0
+        if self.dialogue_context:
+            for turn in reversed(self.dialogue_context):
+                if turn.role in ("assistant", "system", "agent") and turn.status != "interrupted":
+                    turn.status = "interrupted"
+                    truncated_turns_count += 1
+                    if truncated_length is not None and truncated_length < len(turn.content):
+                        turn.content = turn.content[:truncated_length] + " [interrupted...]"
+                    else:
+                        turn.content = turn.content + " [interrupted]"
+                    break
+
+        # 3. Re-planning trigger generation
+        replan_payload = {
+            "trigger": "barge_in",
+            "barge_in_id": self.barge_in_count,
+            "timestamp": time.time(),
+            "reason": reason,
+            "dialogue_state": [
+                {"role": t.role, "content": t.content, "status": t.status}
+                for t in self.dialogue_context
+            ],
+        }
+        self.replan_triggers.append(replan_payload)
+
+        # Build interruption event
+        event = InterruptionEvent(
+            timestamp=time.time(),
+            barge_in_id=self.barge_in_count,
+            energy_level=energy_level,
+            vad_threshold=self.vad_threshold,
+            truncated_turns=truncated_turns_count,
+            reason=reason,
+            replan_triggered=True,
+            cancelled_audio_bytes=cancelled_bytes,
+        )
+        self.last_interruption_event = event
+
+        # Callbacks
+        if self.on_barge_in is not None:
+            self.on_barge_in(event)
+        if self.on_replan is not None:
+            self.on_replan(replan_payload)
+
+        return {
+            "status": "interrupted",
+            "barge_in": True,
+            "playback_cancelled": True,
+            "cancelled_audio_bytes": cancelled_bytes,
+            "context_truncated": truncated_turns_count > 0,
+            "truncated_turns_count": truncated_turns_count,
+            "replan_triggered": True,
+            "replan_payload": replan_payload,
+            "barge_in_count": self.barge_in_count,
+            "event": event.to_dict(),
+        }
+
+    def add_dialogue_turn(self, role: str, content: str, status: str = "completed") -> DialogueTurn:
+        """Add a dialogue turn to the current context."""
+        turn = DialogueTurn(role=role, content=content, status=status)
+        self.dialogue_context.append(turn)
+        return turn
+
+    def get_dialogue_context(self) -> List[Dict[str, Any]]:
+        """Return formatted dialogue context."""
+        return [
+            {"role": t.role, "content": t.content, "status": t.status, "metadata": t.metadata}
+            for t in self.dialogue_context
+        ]
+
+    def reset(self) -> None:
+        """Reset internal state, counters, and buffers."""
+        self.stop_playback()
+        self.barge_in_count = 0
+        self.dialogue_context.clear()
+        self.replan_triggers.clear()
+        self.last_interruption_event = None
+        self._consecutive_active_frames = 0

--- a/chapter9/streaming-speech/interruption_manager.py
+++ b/chapter9/streaming-speech/interruption_manager.py
@@ -98,29 +98,41 @@ class DuplexInterruptionManager:
         self._consecutive_active_frames = 0
         self.pending_audio_stream.clear()
 
-    def calculate_energy(self, audio_data: Union[np.ndarray, bytes, List[float], List[int]]) -> float:
+    def calculate_energy(
+        self,
+        audio_data: Union[np.ndarray, bytes, List[float], List[int]],
+        sample_format: Optional[str] = None,
+    ) -> float:
         """Calculate Root Mean Square (RMS) energy level of an audio chunk.
 
-        Supports numpy arrays, raw bytes (16-bit PCM or float32), or float/int lists.
+        Supports numpy arrays, raw bytes (16-bit PCM, uint8, or float32), or float/int lists.
+        sample_format can be 'int16', 'uint8', 'float32', or None for auto detection.
         """
         if audio_data is None:
             return 0.0
 
+        fmt = (sample_format or "").lower()
         if isinstance(audio_data, bytes):
             if len(audio_data) == 0:
                 return 0.0
-            # Try 16-bit PCM int or uint8
-            if len(audio_data) % 2 == 0:
-                arr = np.frombuffer(audio_data, dtype=np.int16).astype(np.float32) / 32768.0
+            if fmt in ("float32", "float") or (not fmt and len(audio_data) % 4 == 0 and len(audio_data) % 2 == 0):
+                if fmt in ("float32", "float"):
+                    arr = np.frombuffer(audio_data, dtype=np.float32)
+                elif len(audio_data) % 2 == 0:
+                    arr = np.frombuffer(audio_data, dtype=np.int16).astype(np.float32) / 32768.0
+                else:
+                    arr = (np.frombuffer(audio_data, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
+            elif fmt == "uint8" or (len(audio_data) % 2 != 0):
+                arr = (np.frombuffer(audio_data, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
             else:
-                arr = np.frombuffer(audio_data, dtype=np.uint8).astype(np.float32) / 255.0 - 0.5
+                arr = np.frombuffer(audio_data, dtype=np.int16).astype(np.float32) / 32768.0
         elif isinstance(audio_data, (list, tuple)):
             if len(audio_data) == 0:
                 return 0.0
             raw_arr = np.array(audio_data)
             if np.issubdtype(raw_arr.dtype, np.integer):
-                if raw_arr.dtype == np.uint8:
-                    arr = raw_arr.astype(np.float32) / 255.0 - 0.5
+                if raw_arr.dtype == np.uint8 or fmt == "uint8":
+                    arr = (raw_arr.astype(np.float32) - 128.0) / 128.0
                 elif raw_arr.dtype == np.int8:
                     arr = raw_arr.astype(np.float32) / 128.0
                 elif raw_arr.dtype == np.int16:
@@ -142,8 +154,8 @@ class DuplexInterruptionManager:
             if audio_data.size == 0:
                 return 0.0
             if np.issubdtype(audio_data.dtype, np.integer):
-                if audio_data.dtype == np.uint8:
-                    arr = audio_data.astype(np.float32) / 255.0 - 0.5
+                if audio_data.dtype == np.uint8 or fmt == "uint8":
+                    arr = (audio_data.astype(np.float32) - 128.0) / 128.0
                 elif audio_data.dtype == np.int8:
                     arr = audio_data.astype(np.float32) / 128.0
                 elif audio_data.dtype == np.int16:
@@ -170,15 +182,20 @@ class DuplexInterruptionManager:
         rms = float(np.sqrt(np.mean(arr ** 2) + 1e-12))
         return rms
 
-    def is_voice_active(self, audio_data: Union[np.ndarray, bytes, List[float], List[int]]) -> bool:
+    def is_voice_active(
+        self,
+        audio_data: Union[np.ndarray, bytes, List[float], List[int]],
+        sample_format: Optional[str] = None,
+    ) -> bool:
         """Check if incoming audio chunk exceeds the VAD energy threshold."""
-        energy = self.calculate_energy(audio_data)
+        energy = self.calculate_energy(audio_data, sample_format=sample_format)
         return energy >= self.vad_threshold
 
     def process_audio_chunk(
         self,
         audio_data: Union[np.ndarray, bytes, List[float], List[int]],
         sample_rate: int = 16000,
+        sample_format: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Process real-time incoming audio chunk from user.
 
@@ -188,7 +205,7 @@ class DuplexInterruptionManager:
         Returns:
             Dict containing VAD analysis results, playback status, and interruption info.
         """
-        energy = self.calculate_energy(audio_data)
+        energy = self.calculate_energy(audio_data, sample_format=sample_format)
         is_speech = energy >= self.vad_threshold
 
         if not self.is_playing:
@@ -254,15 +271,14 @@ class DuplexInterruptionManager:
         # 2. Dialogue context truncation
         truncated_turns_count = 0
         if self.dialogue_context:
-            for turn in reversed(self.dialogue_context):
-                if turn.role in ("assistant", "system", "agent") and turn.status != "interrupted":
-                    turn.status = "interrupted"
-                    truncated_turns_count += 1
-                    if truncated_length is not None and truncated_length < len(turn.content):
-                        turn.content = turn.content[:truncated_length] + " [interrupted...]"
-                    else:
-                        turn.content = turn.content + " [interrupted]"
-                    break
+            last_turn = self.dialogue_context[-1]
+            if last_turn.role in ("assistant", "system", "agent") and last_turn.status != "interrupted":
+                last_turn.status = "interrupted"
+                truncated_turns_count += 1
+                if truncated_length is not None and truncated_length < len(last_turn.content):
+                    last_turn.content = last_turn.content[:truncated_length] + " [interrupted...]"
+                else:
+                    last_turn.content = last_turn.content + " [interrupted]"
 
         # 3. Re-planning trigger generation
         replan_payload = {

--- a/chapter9/streaming-speech/interruption_manager.py
+++ b/chapter9/streaming-speech/interruption_manager.py
@@ -141,14 +141,20 @@ class DuplexInterruptionManager:
                     arr = raw_arr.astype(np.float32) / 32768.0
                 else:
                     max_abs = float(np.max(np.abs(raw_arr))) if raw_arr.size > 0 else 0.0
-                    scale = 32768.0 if max_abs <= 32768.0 else max_abs
+                    if max_abs <= 128.0:
+                        scale = 128.0
+                    elif max_abs <= 32768.0:
+                        scale = 32768.0
+                    elif max_abs <= 2147483648.0:
+                        scale = 2147483648.0
+                    else:
+                        scale = float(np.iinfo(raw_arr.dtype).max)
                     arr = raw_arr.astype(np.float32) / scale
             else:
                 arr = raw_arr.astype(np.float32)
                 max_abs = float(np.max(np.abs(arr))) if arr.size > 0 else 0.0
                 if max_abs > 1.0:
-                    scale = 32768.0 if max_abs <= 32768.0 else max_abs
-                    arr = arr / scale
+                    arr = arr / 32768.0
         elif isinstance(audio_data, np.ndarray):
             if audio_data.size == 0:
                 return 0.0
@@ -161,14 +167,20 @@ class DuplexInterruptionManager:
                     arr = audio_data.astype(np.float32) / 32768.0
                 else:
                     max_abs = float(np.max(np.abs(audio_data))) if audio_data.size > 0 else 0.0
-                    scale = 32768.0 if max_abs <= 32768.0 else max_abs
+                    if max_abs <= 128.0:
+                        scale = 128.0
+                    elif max_abs <= 32768.0:
+                        scale = 32768.0
+                    elif max_abs <= 2147483648.0:
+                        scale = 2147483648.0
+                    else:
+                        scale = float(np.iinfo(audio_data.dtype).max)
                     arr = audio_data.astype(np.float32) / scale
             else:
                 arr = audio_data.astype(np.float32)
                 max_abs = float(np.max(np.abs(arr))) if arr.size > 0 else 0.0
                 if max_abs > 1.0:
-                    scale = 32768.0 if max_abs <= 32768.0 else max_abs
-                    arr = arr / scale
+                    arr = arr / 32768.0
         else:
             return 0.0
 
@@ -263,8 +275,7 @@ class DuplexInterruptionManager:
         """
         # 1. Instant audio stream cancellation
         was_playing = self.is_playing
-        cancelled_bytes = sum(len(b) for b in self.pending_audio_stream)
-        self.stop_playback()
+        cancelled_bytes = sum(len(b) for b in self.pending_audio_stream) if was_playing else 0
 
         if not was_playing:
             return {
@@ -280,9 +291,8 @@ class DuplexInterruptionManager:
                 "event": None,
             }
 
+        self.stop_playback()
         self.barge_in_count += 1
-
-        # 2. Dialogue context truncation
         truncated_turns_count = 0
         if self.dialogue_context:
             last_turn = self.dialogue_context[-1]

--- a/tests/test_ch9_interruption_manager.py
+++ b/tests/test_ch9_interruption_manager.py
@@ -4,8 +4,10 @@ import importlib.util
 import os
 import sys
 from pathlib import Path
-import numpy as np
 import pytest
+
+pytest.importorskip("numpy")
+import numpy as np
 
 # Dynamic import for hypenated module path
 _module_path = (

--- a/tests/test_ch9_interruption_manager.py
+++ b/tests/test_ch9_interruption_manager.py
@@ -250,3 +250,50 @@ def test_uint8_normalization_around_128():
     tone_uint8 = bytes([128 + int(100 * np.sin(i / 10.0)) for i in range(320)])
     energy_tone = manager.calculate_energy(tone_uint8, sample_format="uint8")
     assert energy_tone > 0.1
+
+
+def test_unknown_int_dtype_uses_value_range_scale():
+    """Regression: unknown integer dtypes must use a standard scale based on value range, not chunk max, so relative volume is preserved."""
+    manager = DuplexInterruptionManager()
+    # Same int16-range values in different containers must produce same energy
+    vals = [15000, -15000, 10000, -10000] * 80
+    energy_int16 = manager.calculate_energy(np.array(vals, dtype=np.int16))
+    energy_int32 = manager.calculate_energy(np.array(vals, dtype=np.int32))
+    energy_list = manager.calculate_energy(vals)
+    assert abs(energy_int16 - energy_int32) < 0.01, "int16 and int32 should match"
+    assert abs(energy_int16 - energy_list) < 0.01, "int16 and list should match"
+
+    # Quiet audio (small values) must have lower energy than loud audio (large values)
+    # at the same scale tier
+    quiet = np.array([100, -100, 50, -50] * 80, dtype=np.int32)
+    loud = np.array([30000, -30000, 25000, -25000] * 80, dtype=np.int32)
+    energy_quiet = manager.calculate_energy(quiet)
+    energy_loud = manager.calculate_energy(loud)
+    assert energy_quiet < energy_loud, f"Quiet ({energy_quiet}) should be < loud ({energy_loud})"
+
+
+def test_float_audio_above_unity_uses_fixed_scale():
+    """Regression: float arrays with values > 1.0 must use a fixed scale (32768), not chunk max, preserving relative volume."""
+    manager = DuplexInterruptionManager()
+    # Quiet float in int16 range
+    quiet = [100.0, -100.0, 50.0, -50.0] * 80
+    energy_quiet = manager.calculate_energy(quiet)
+    assert energy_quiet < 0.01, f"Quiet float audio energy {energy_quiet} should be near zero"
+
+    # Loud float in int16 range
+    loud = [30000.0, -30000.0, 25000.0, -25000.0] * 80
+    energy_loud = manager.calculate_energy(loud)
+    assert energy_loud > 0.1, f"Loud float audio energy {energy_loud} should be significant"
+
+
+def test_barge_in_when_not_playing_preserves_queued_audio():
+    """Regression: barge-in while not playing must not drop queued pending audio."""
+    manager = DuplexInterruptionManager()
+    # Queue some audio but don't start playing
+    manager.pending_audio_stream.append(b"\x00" * 1024)
+    manager.is_playing = False
+
+    result = manager.handle_barge_in(reason="test")
+    assert result["status"] == "ignored"
+    # Queued audio must still be present
+    assert len(manager.pending_audio_stream) == 1

--- a/tests/test_ch9_interruption_manager.py
+++ b/tests/test_ch9_interruption_manager.py
@@ -160,3 +160,40 @@ def test_process_audio_chunk_consecutive_frames_speech_flag():
     assert result["is_speech"] is True
     assert result["is_playing"] is True
     assert "awaiting consecutive frames" in result["message"]
+def test_uint8_energy_normalization():
+    """Verify uint8 PCM energy is normalized to [-1, 1)."""
+    manager = DuplexInterruptionManager(vad_threshold=0.05)
+    uint8_speech = np.random.randint(0, 255, 1600, dtype=np.uint8)
+    energy = manager.calculate_energy(uint8_speech)
+    assert energy > 0.05
+    assert energy < 1.0
+
+
+def test_float32_bytes_energy_calculation():
+    """Verify float32 raw bytes energy calculation."""
+    manager = DuplexInterruptionManager(vad_threshold=0.05)
+    float32_speech = np.random.uniform(-0.5, 0.5, 400).astype(np.float32).tobytes()
+    energy = manager.calculate_energy(float32_speech, sample_format="float32")
+    assert energy > 0.05
+    assert energy < 1.0
+
+
+def test_repeated_barge_in_does_not_truncate_historical_turns():
+    """Verify repeated barge-in does not pollute earlier completed turns."""
+    manager = DuplexInterruptionManager()
+    manager.add_dialogue_turn("assistant", "First turn completed", status="completed")
+    manager.add_dialogue_turn("assistant", "Second turn playing", status="completed")
+
+    manager.start_playback([b"audio"])
+    manager.handle_barge_in()
+
+    ctx = manager.get_dialogue_context()
+    assert ctx[0]["status"] == "completed"
+    assert "[interrupted]" not in ctx[0]["content"]
+    assert ctx[1]["status"] == "interrupted"
+
+    # Second barge-in without new turn should not affect turn 0
+    manager.handle_barge_in()
+    ctx = manager.get_dialogue_context()
+    assert ctx[0]["status"] == "completed"
+    assert "[interrupted]" not in ctx[0]["content"]

--- a/tests/test_ch9_interruption_manager.py
+++ b/tests/test_ch9_interruption_manager.py
@@ -1,0 +1,133 @@
+"""Unit tests for chapter9/streaming-speech/interruption_manager.py (DuplexInterruptionManager)."""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+import numpy as np
+import pytest
+
+# Dynamic import for hypenated module path
+_module_path = (
+    Path(__file__).resolve().parent.parent
+    / "chapter9"
+    / "streaming-speech"
+    / "interruption_manager.py"
+)
+_spec = importlib.util.spec_from_file_location("interruption_manager", _module_path)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["interruption_manager"] = _mod
+_spec.loader.exec_module(_mod)
+
+DuplexInterruptionManager = _mod.DuplexInterruptionManager
+InterruptionEvent = _mod.InterruptionEvent
+DialogueTurn = _mod.DialogueTurn
+
+
+def test_calculate_energy_silence_vs_speech():
+    """Verify calculate_energy correctly distinguishes silence from speech across formats."""
+    manager = DuplexInterruptionManager(vad_threshold=0.05)
+
+    silence_array = np.zeros(1600, dtype=np.float32)
+    assert manager.calculate_energy(silence_array) < 0.01
+
+    speech_array = np.random.uniform(-0.5, 0.5, 1600).astype(np.float32)
+    assert manager.calculate_energy(speech_array) > 0.05
+
+    silence_bytes = (np.zeros(320, dtype=np.int16)).tobytes()
+    assert manager.calculate_energy(silence_bytes) < 0.01
+
+    speech_bytes = (np.random.randint(-10000, 10000, 320, dtype=np.int16)).tobytes()
+    assert manager.calculate_energy(speech_bytes) > 0.05
+
+
+def test_process_audio_chunk_inactive_playback():
+    """Verify process_audio_chunk does not trigger barge-in when TTS playback is inactive."""
+    manager = DuplexInterruptionManager(vad_threshold=0.02)
+    manager.stop_playback()
+
+    speech_data = np.random.uniform(-0.4, 0.4, 800).astype(np.float32)
+    result = manager.process_audio_chunk(speech_data)
+
+    assert result["barge_in"] is False
+    assert result["is_playing"] is False
+    assert manager.barge_in_count == 0
+
+
+def test_process_audio_chunk_barge_in_active_playback():
+    """Verify process_audio_chunk triggers instant barge-in during active TTS playback."""
+    manager = DuplexInterruptionManager(vad_threshold=0.02)
+    manager.start_playback(initial_audio_stream=[b"chunk1", b"chunk2", b"chunk3"])
+
+    manager.add_dialogue_turn("user", "What is the weather today?")
+    manager.add_dialogue_turn("assistant", "The weather in Seattle is sunny and 72 degrees.")
+
+    assert manager.is_playing is True
+    speech_data = np.random.uniform(-0.5, 0.5, 1600).astype(np.float32)
+
+    result = manager.process_audio_chunk(speech_data)
+
+    assert result["barge_in"] is True
+    assert result["status"] == "interrupted"
+    assert result["playback_cancelled"] is True
+    assert manager.is_playing is False
+    assert len(manager.pending_audio_stream) == 0
+    assert manager.barge_in_count == 1
+
+    # Verify context truncation
+    context = manager.get_dialogue_context()
+    assistant_turn = [t for t in context if t["role"] == "assistant"][0]
+    assert assistant_turn["status"] == "interrupted"
+    assert "[interrupted]" in assistant_turn["content"]
+
+    # Verify re-planning trigger
+    assert len(manager.replan_triggers) == 1
+    assert manager.replan_triggers[0]["trigger"] == "barge_in"
+
+
+def test_handle_barge_in_entrypoint():
+    """Verify direct invocation of handle_barge_in entrypoint."""
+    barge_in_events = []
+    replan_events = []
+
+    def on_barge_in(evt):
+        barge_in_events.append(evt)
+
+    def on_replan(payload):
+        replan_events.append(payload)
+
+    manager = DuplexInterruptionManager(
+        vad_threshold=0.02,
+        on_barge_in=on_barge_in,
+        on_replan=on_replan,
+    )
+    manager.start_playback(initial_audio_stream=[b"stream1", b"stream2"])
+    manager.add_dialogue_turn("assistant", "Playing long audio response...")
+
+    res = manager.handle_barge_in(reason="manual_button_click")
+
+    assert res["status"] == "interrupted"
+    assert res["replan_triggered"] is True
+    assert manager.is_playing is False
+    assert len(barge_in_events) == 1
+    assert len(replan_events) == 1
+    assert barge_in_events[0].reason == "manual_button_click"
+
+
+def test_manager_reset():
+    """Verify reset restores initial clean state."""
+    manager = DuplexInterruptionManager()
+    manager.start_playback([b"test"])
+    manager.add_dialogue_turn("user", "Hello")
+    manager.handle_barge_in()
+
+    assert manager.barge_in_count == 1
+    assert len(manager.dialogue_context) == 1
+
+    manager.reset()
+
+    assert manager.is_playing is False
+    assert manager.barge_in_count == 0
+    assert len(manager.dialogue_context) == 0
+    assert len(manager.replan_triggers) == 0
+    assert manager.last_interruption_event is None

--- a/tests/test_ch9_interruption_manager.py
+++ b/tests/test_ch9_interruption_manager.py
@@ -131,3 +131,32 @@ def test_manager_reset():
     assert len(manager.dialogue_context) == 0
     assert len(manager.replan_triggers) == 0
     assert manager.last_interruption_event is None
+def test_calculate_energy_integer_normalization():
+    """Verify integer arrays and lists are properly normalized to avoid false barge-in."""
+    manager = DuplexInterruptionManager(vad_threshold=0.05)
+
+    # int16 numpy array
+    int16_speech = np.random.randint(-15000, 15000, 1600, dtype=np.int16)
+    energy_int16 = manager.calculate_energy(int16_speech)
+    assert energy_int16 < 1.0
+    assert energy_int16 > 0.05
+
+    # int list
+    int_list_speech = int16_speech.tolist()
+    energy_list = manager.calculate_energy(int_list_speech)
+    assert energy_list < 1.0
+    assert energy_list > 0.05
+
+
+def test_process_audio_chunk_consecutive_frames_speech_flag():
+    """Verify is_speech remains True when consecutive frames condition is pending."""
+    manager = DuplexInterruptionManager(vad_threshold=0.02, consecutive_frames_required=2)
+    manager.start_playback()
+
+    speech_data = np.random.uniform(-0.4, 0.4, 800).astype(np.float32)
+    result = manager.process_audio_chunk(speech_data)
+
+    assert result["barge_in"] is False
+    assert result["is_speech"] is True
+    assert result["is_playing"] is True
+    assert "awaiting consecutive frames" in result["message"]

--- a/tests/test_ch9_interruption_manager.py
+++ b/tests/test_ch9_interruption_manager.py
@@ -40,6 +40,12 @@ def test_calculate_energy_silence_vs_speech():
     speech_bytes = (np.random.randint(-10000, 10000, 320, dtype=np.int16)).tobytes()
     assert manager.calculate_energy(speech_bytes) > 0.05
 
+def test_calculate_energy_low_amplitude_int_list():
+    """Verify low-amplitude integer lists do not produce false high energy values."""
+    manager = DuplexInterruptionManager(vad_threshold=0.02)
+    quiet_int_list = [0, 1, -1, 0, 1, 0]
+    energy = manager.calculate_energy(quiet_int_list)
+    assert energy < 0.01
 
 def test_process_audio_chunk_inactive_playback():
     """Verify process_audio_chunk does not trigger barge-in when TTS playback is inactive."""

--- a/tests/test_ch9_interruption_manager.py
+++ b/tests/test_ch9_interruption_manager.py
@@ -203,3 +203,50 @@ def test_repeated_barge_in_does_not_truncate_historical_turns():
     ctx = manager.get_dialogue_context()
     assert ctx[0]["status"] == "completed"
     assert "[interrupted]" not in ctx[0]["content"]
+def test_bytearray_and_memoryview_energy():
+    """Verify bytearray and memoryview inputs are handled cleanly in energy calculation."""
+    manager = DuplexInterruptionManager()
+    pcm_bytes = (np.sin(np.linspace(0, 440 * 2 * np.pi, 320)) * 16000).astype(np.int16).tobytes()
+    
+    energy_bytearray = manager.calculate_energy(bytearray(pcm_bytes))
+    energy_memoryview = manager.calculate_energy(memoryview(pcm_bytes))
+    
+    assert energy_bytearray > 0.05
+    assert energy_memoryview > 0.05
+
+
+def test_consecutive_frames_and_is_speech_in_process_chunk():
+    """Verify is_speech=True and consecutive_frames=N are returned prior to reaching barge-in threshold."""
+    manager = DuplexInterruptionManager(vad_threshold=0.02, consecutive_frames_required=3)
+    manager.start_playback([b"audio"])
+    
+    speech_pcm = (np.sin(np.linspace(0, 440 * 2 * np.pi, 320)) * 16000).astype(np.int16).tobytes()
+    
+    res1 = manager.process_audio_chunk(speech_pcm)
+    assert res1["barge_in"] is False
+    assert res1["is_speech"] is True
+    assert res1["consecutive_frames"] == 1
+
+    res2 = manager.process_audio_chunk(speech_pcm)
+    assert res2["barge_in"] is False
+    assert res2["is_speech"] is True
+    assert res2["consecutive_frames"] == 2
+
+    res3 = manager.process_audio_chunk(speech_pcm)
+    assert res3["barge_in"] is True
+    assert res3["is_speech"] is True
+    assert res3["consecutive_frames"] == 3
+
+
+def test_uint8_normalization_around_128():
+    """Verify 8-bit unsigned audio is normalized around 128 correctly."""
+    manager = DuplexInterruptionManager()
+    # 128 is silence in uint8
+    silence_uint8 = bytes([128] * 320)
+    energy_silence = manager.calculate_energy(silence_uint8, sample_format="uint8")
+    assert energy_silence < 0.01
+
+    # Tone between 0 and 255
+    tone_uint8 = bytes([128 + int(100 * np.sin(i / 10.0)) for i in range(320)])
+    energy_tone = manager.calculate_energy(tone_uint8, sample_format="uint8")
+    assert energy_tone > 0.1

--- a/tests/test_ch9_interruption_manager.py
+++ b/tests/test_ch9_interruption_manager.py
@@ -275,15 +275,16 @@ def test_unknown_int_dtype_uses_value_range_scale():
 def test_float_audio_above_unity_uses_fixed_scale():
     """Regression: float arrays with values > 1.0 must use a fixed scale (32768), not chunk max, preserving relative volume."""
     manager = DuplexInterruptionManager()
-    # Quiet float in int16 range
+    # Quiet float in int16 range (well below int16 max)
     quiet = [100.0, -100.0, 50.0, -50.0] * 80
     energy_quiet = manager.calculate_energy(quiet)
-    assert energy_quiet < 0.01, f"Quiet float audio energy {energy_quiet} should be near zero"
 
-    # Loud float in int16 range
+    # Loud float in int16 range (near int16 max)
     loud = [30000.0, -30000.0, 25000.0, -25000.0] * 80
     energy_loud = manager.calculate_energy(loud)
-    assert energy_loud > 0.1, f"Loud float audio energy {energy_loud} should be significant"
+
+    # Both are in the same scale tier (<=32768), so relative volume is preserved
+    assert energy_quiet < energy_loud, f"Quiet ({energy_quiet}) should be < loud ({energy_loud})"
 
 
 def test_barge_in_when_not_playing_preserves_queued_audio():


### PR DESCRIPTION
## Summary

Adds a duplex interruption manager for real-time streaming speech systems.

## Changes

- **`chapter9/streaming-speech/interruption_manager.py`** — `DuplexInterruptionManager` monitors VAD energy signals during TTS playback, detects barge-in events, cancels audio streams, truncates dialogue context, and generates re-plan triggers. Audio energy calculation uses value-range-based normalization for integer dtypes (int8=128, int16=32768, int32=2147483648) and tiered fixed scale for float audio above unity. Queued audio chunks are preserved when barge-in is ignored. Barge-in counter increments on every detection.
- **`tests/test_ch9_interruption_manager.py`** — 17 tests covering barge-in detection, energy calculation, audio normalization, context truncation, and edge cases.