### PR TITLE
feat(ch6): add RateRampBenchmark with tests

### DIFF
--- a/chapter6/model-benchmark/rate_ramp_benchmark.py
+++ b/chapter6/model-benchmark/rate_ramp_benchmark.py
@@ -57,8 +57,10 @@ class RateRampBenchmark:
         end_rate = int(config.get("end_rate", 50))
         step_rate = int(config.get("step_rate", 5))
 
-        if "rates" in config and isinstance(config["rates"], (list, tuple)):
+        if "rates" in config and isinstance(config["rates"], (list, tuple)) and config["rates"]:
             rates = [int(r) for r in config["rates"]]
+            start_rate = rates[0]
+            end_rate = rates[-1]
         else:
             if start_rate <= end_rate:
                 step = max(1, step_rate)

--- a/chapter6/model-benchmark/rate_ramp_benchmark.py
+++ b/chapter6/model-benchmark/rate_ramp_benchmark.py
@@ -134,7 +134,7 @@ class RateRampBenchmark:
         self, records: Sequence[dict[str, Any]], sample_size: int = 100
     ) -> list[dict[str, Any]]:
         """Compile exactly sample_size (default N=100) evidence items uniformly sampled from raw records."""
-        if not records:
+        if not records or sample_size <= 0:
             return []
 
         if len(records) <= sample_size:
@@ -155,21 +155,24 @@ class RateRampBenchmark:
         total_429 = 0
 
         grouped: dict[int, list[dict[str, Any]]] = {}
+        all_backoffs_count = 0
+        grouped: dict[int, list[dict[str, Any]]] = {}
         for r in records:
-            rate = int(r["target_rate"])
+            rate = int(r.get("target_rate", 0))
             grouped.setdefault(rate, []).append(r)
 
         for rate in sorted(grouped.keys()):
             step_recs = grouped[rate]
             cnt = len(step_recs)
-            hits_429 = sum(1 for r in step_recs if r["status_code"] == 429)
-            backoffs = [float(r["backoff_sec"]) for r in step_recs if r["backoff_sec"] > 0]
+            hits_429 = sum(1 for r in step_recs if r.get("status_code") == 429)
+            backoffs = [float(r.get("backoff_sec", 0.0)) for r in step_recs if float(r.get("backoff_sec", 0.0)) > 0]
 
             avg_backoff = round(sum(backoffs) / len(backoffs), 4) if backoffs else 0.0
             step_max_backoff = max(backoffs, default=0.0)
 
             total_429 += hits_429
             total_backoff_time += sum(backoffs)
+            all_backoffs_count += len(backoffs)
             max_backoff = max(max_backoff, step_max_backoff)
 
             by_rate[rate] = {
@@ -181,7 +184,9 @@ class RateRampBenchmark:
             }
 
         overall_avg_backoff = (
-            round(total_backoff_time / total_429, 4) if total_429 > 0 else 0.0
+            round(total_backoff_time / total_429, 4)
+            if total_429 > 0
+            else (round(total_backoff_time / all_backoffs_count, 4) if all_backoffs_count > 0 else 0.0)
         )
 
         return {

--- a/chapter6/model-benchmark/rate_ramp_benchmark.py
+++ b/chapter6/model-benchmark/rate_ramp_benchmark.py
@@ -136,7 +136,7 @@ class RateRampBenchmark:
         self, records: Sequence[dict[str, Any]], sample_size: int = 100
     ) -> list[dict[str, Any]]:
         """Compile exactly sample_size (default N=100) evidence items uniformly sampled from raw records."""
-        if not records or sample_size <= 0:
+        if not records or not sample_size or sample_size <= 0:
             return []
 
         valid_records = [r for r in records if isinstance(r, dict)]
@@ -156,12 +156,10 @@ class RateRampBenchmark:
     ) -> dict[str, Any]:
         """Compute 429 rate limit backoff curve metrics by request rate level."""
         by_rate: dict[int, dict[str, Any]] = {}
-        total_backoff_time = 0.0
         total_429_backoff_time = 0.0
         max_backoff = 0.0
         total_429 = 0
         total_429_backoff_count = 0
-        all_backoffs_count = 0
 
         grouped: dict[int, list[dict[str, Any]]] = {}
         for r in records:
@@ -182,21 +180,12 @@ class RateRampBenchmark:
                 and r.get("status_code") == 429
                 and float(r.get("backoff_sec") or 0.0) > 0
             ]
-            backoffs = [
-                float(r.get("backoff_sec") or 0.0)
-                for r in step_recs
-                if isinstance(r, dict)
-                and float(r.get("backoff_sec") or 0.0) > 0
-            ]
-
-            avg_backoff = round(sum(backoffs) / len(backoffs), 4) if backoffs else 0.0
-            step_max_backoff = max(backoffs, default=0.0)
+            avg_backoff = round(sum(backoffs_429) / len(backoffs_429), 4) if backoffs_429 else 0.0
+            step_max_backoff = max(backoffs_429, default=0.0)
 
             total_429 += hits_429
             total_429_backoff_count += len(backoffs_429)
             total_429_backoff_time += sum(backoffs_429)
-            total_backoff_time += sum(backoffs)
-            all_backoffs_count += len(backoffs)
             max_backoff = max(max_backoff, step_max_backoff)
 
             by_rate[rate] = {
@@ -210,13 +199,13 @@ class RateRampBenchmark:
         overall_avg_backoff = (
             round(total_429_backoff_time / total_429_backoff_count, 4)
             if total_429_backoff_count > 0
-            else (round(total_backoff_time / all_backoffs_count, 4) if all_backoffs_count > 0 else 0.0)
+            else 0.0
         )
 
         return {
             "by_rate": by_rate,
             "overall_avg_backoff_sec": overall_avg_backoff,
-            "total_backoff_time_sec": round(total_backoff_time, 4),
+            "total_backoff_time_sec": round(total_429_backoff_time, 4),
             "max_backoff_observed_sec": round(max_backoff, 4),
             "total_429_count": total_429,
         }
@@ -245,16 +234,24 @@ class RateRampBenchmark:
                 step_records.append(rec)
                 all_records.append(rec)
 
-            ttfts = [r["ttft_sec"] for r in step_records if "ttft_sec" in r]
-            hits_429 = sum(1 for r in step_records if r.get("status_code") == 429)
+            ttfts = [float(r.get("ttft_sec", 0.0) or 0.0) for r in step_records if isinstance(r, dict)]
+            hits_429 = sum(1 for r in step_records if isinstance(r, dict) and r.get("status_code") == 429)
             other_errs = sum(
                 1
                 for r in step_records
-                if r.get("status_code") != 200 and r.get("status_code") != 429
+                if isinstance(r, dict)
+                and r.get("status_code") not in (200, 429)
             )
-            successes = sum(1 for r in step_records if r.get("status_code") == 200)
+            successes = sum(1 for r in step_records if isinstance(r, dict) and r.get("status_code") == 200)
 
-            backoff_secs = [float(r.get("backoff_sec", 0.0)) for r in step_records if float(r.get("backoff_sec", 0.0)) > 0]
+            # Only throttled (429) requests contribute backoff time to averages.
+            backoff_secs = [
+                float(r.get("backoff_sec", 0.0) or 0.0)
+                for r in step_records
+                if isinstance(r, dict)
+                and r.get("status_code") == 429
+                and float(r.get("backoff_sec", 0.0) or 0.0) > 0
+            ]
             avg_backoff = (
                 round(sum(backoff_secs) / len(backoff_secs), 4)
                 if backoff_secs
@@ -277,13 +274,13 @@ class RateRampBenchmark:
                 }
             )
 
-        all_ttfts = [r["ttft_sec"] for r in all_records if "ttft_sec" in r]
+        all_ttfts = [float(r.get("ttft_sec", 0.0) or 0.0) for r in all_records if isinstance(r, dict)]
         total_reqs = len(all_records)
-        total_429 = sum(1 for r in all_records if r.get("status_code") == 429)
+        total_429 = sum(1 for r in all_records if isinstance(r, dict) and r.get("status_code") == 429)
         total_other = sum(
-            1 for r in all_records if r.get("status_code") not in (200, 429)
+            1 for r in all_records if isinstance(r, dict) and r.get("status_code") not in (200, 429)
         )
-        total_success = sum(1 for r in all_records if r.get("status_code") == 200)
+        total_success = sum(1 for r in all_records if isinstance(r, dict) and r.get("status_code") == 200)
 
         backoff_curves = self.calculate_backoff_curves(all_records)
         evidence_package = self.compile_evidence_package(

--- a/chapter6/model-benchmark/rate_ramp_benchmark.py
+++ b/chapter6/model-benchmark/rate_ramp_benchmark.py
@@ -139,13 +139,17 @@ class RateRampBenchmark:
         if not records or sample_size <= 0:
             return []
 
-        if len(records) <= sample_size:
-            return [dict(r) for r in records]
+        valid_records = [r for r in records if isinstance(r, dict)]
+        if not valid_records:
+            return []
+
+        if len(valid_records) <= sample_size:
+            return [dict(r) for r in valid_records]
 
         # Uniformly sample across the records to cover all rate tiers
-        step = len(records) / float(sample_size)
+        step = len(valid_records) / float(sample_size)
         indices = [int(i * step) for i in range(sample_size)]
-        return [dict(records[idx]) for idx in indices]
+        return [dict(valid_records[idx]) for idx in indices]
 
     def calculate_backoff_curves(
         self, records: Sequence[dict[str, Any]]
@@ -156,24 +160,40 @@ class RateRampBenchmark:
         total_429_backoff_time = 0.0
         max_backoff = 0.0
         total_429 = 0
+        total_429_backoff_count = 0
         all_backoffs_count = 0
 
         grouped: dict[int, list[dict[str, Any]]] = {}
         for r in records:
-            rate = int(r.get("target_rate", 0))
+            if not isinstance(r, dict):
+                continue
+            rate = int(r.get("target_rate", 0) or 0)
             grouped.setdefault(rate, []).append(r)
 
         for rate in sorted(grouped.keys()):
             step_recs = grouped[rate]
             cnt = len(step_recs)
-            hits_429 = sum(1 for r in step_recs if r.get("status_code") == 429)
-            backoffs_429 = [float(r.get("backoff_sec", 0.0)) for r in step_recs if r.get("status_code") == 429 and float(r.get("backoff_sec", 0.0)) > 0]
-            backoffs = [float(r.get("backoff_sec", 0.0)) for r in step_recs if float(r.get("backoff_sec", 0.0)) > 0]
+            hits_429 = sum(1 for r in step_recs if isinstance(r, dict) and r.get("status_code") == 429)
+            
+            backoffs_429 = [
+                float(r.get("backoff_sec") or 0.0)
+                for r in step_recs
+                if isinstance(r, dict)
+                and r.get("status_code") == 429
+                and float(r.get("backoff_sec") or 0.0) > 0
+            ]
+            backoffs = [
+                float(r.get("backoff_sec") or 0.0)
+                for r in step_recs
+                if isinstance(r, dict)
+                and float(r.get("backoff_sec") or 0.0) > 0
+            ]
 
             avg_backoff = round(sum(backoffs) / len(backoffs), 4) if backoffs else 0.0
             step_max_backoff = max(backoffs, default=0.0)
 
             total_429 += hits_429
+            total_429_backoff_count += len(backoffs_429)
             total_429_backoff_time += sum(backoffs_429)
             total_backoff_time += sum(backoffs)
             all_backoffs_count += len(backoffs)
@@ -188,8 +208,8 @@ class RateRampBenchmark:
             }
 
         overall_avg_backoff = (
-            round(total_429_backoff_time / total_429, 4)
-            if total_429 > 0
+            round(total_429_backoff_time / total_429_backoff_count, 4)
+            if total_429_backoff_count > 0
             else (round(total_backoff_time / all_backoffs_count, 4) if all_backoffs_count > 0 else 0.0)
         )
 

--- a/chapter6/model-benchmark/rate_ramp_benchmark.py
+++ b/chapter6/model-benchmark/rate_ramp_benchmark.py
@@ -1,0 +1,295 @@
+"""Rate Ramp Benchmark for LLM Endpoints (Chapter 6).
+
+Simulates multi-concurrency load testing (1 to 50 req/s) against LLM endpoints,
+measuring 429 rate limit backoff curves, TTFT percentiles (p50, p95, p99),
+error rates, and compiling N=100 evidence packages.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import math
+import random
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+
+
+def utc_timestamp() -> str:
+    """Return ISO 8601 formatted UTC timestamp."""
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def calculate_percentile(values: Sequence[float], percentile: float) -> float:
+    """Calculate percentile (0-100) using linear interpolation."""
+    if not values:
+        return 0.0
+    sorted_vals = sorted(values)
+    if len(sorted_vals) == 1:
+        return float(sorted_vals[0])
+
+    p = max(0.0, min(100.0, percentile))
+    k = (len(sorted_vals) - 1) * (p / 100.0)
+    f = math.floor(k)
+    c = math.ceil(k)
+
+    if f == c:
+        return float(sorted_vals[int(k)])
+
+    d0 = sorted_vals[int(f)] * (c - k)
+    d1 = sorted_vals[int(c)] * (k - f)
+    return round(float(d0 + d1), 4)
+
+
+class RateRampBenchmark:
+    """Simulates or executes multi-concurrency rate-ramping load tests on LLM endpoints.
+
+    Measures:
+    - 429 rate limit backoff curves (attempts, rate limit hits, backoff delays).
+    - Time To First Token (TTFT) percentiles: p50, p95, p99.
+    - Error rates across load levels.
+    - Compiles N=100 evidence packages.
+    """
+
+    def __init__(self, config: Optional[dict[str, Any]] = None) -> None:
+        self.config = self._parse_config(config or {})
+
+    def _parse_config(self, config: dict[str, Any]) -> dict[str, Any]:
+        start_rate = int(config.get("start_rate", 1))
+        end_rate = int(config.get("end_rate", 50))
+        step_rate = int(config.get("step_rate", 5))
+
+        if "rates" in config and isinstance(config["rates"], (list, tuple)):
+            rates = [int(r) for r in config["rates"]]
+        else:
+            if start_rate <= end_rate:
+                step = max(1, step_rate)
+                rates = list(range(start_rate, end_rate + 1, step))
+            else:
+                step = -max(1, abs(step_rate))
+                rates = list(range(start_rate, end_rate - 1, step))
+            if not rates or rates[-1] != end_rate:
+                rates.append(end_rate)
+        return {
+            "start_rate": start_rate,
+            "end_rate": end_rate,
+            "step_rate": step_rate,
+            "rates": rates,
+            "requests_per_step": int(config.get("requests_per_step", 15)),
+            "sample_size": int(config.get("sample_size", 100)),
+            "endpoint_url": str(config.get("endpoint_url", "https://api.openai.com/v1/chat/completions")),
+            "model": str(config.get("model", "gpt-4o")),
+            "max_backoff_sec": float(config.get("max_backoff_sec", 8.0)),
+            "request_fn": config.get("request_fn"),
+        }
+
+    def simulate_request(
+        self, target_rate: int, concurrency: int, request_idx: int
+    ) -> dict[str, Any]:
+        """Simulate a single endpoint request under load when no live request_fn is provided."""
+        # Seed deterministically for test consistency
+        rng = random.Random(target_rate * 1000 + request_idx)
+
+        # Base TTFT increases slightly with rate/concurrency
+        base_ttft = 0.05 + (target_rate / 100.0) * 0.35 + rng.uniform(0.01, 0.05)
+        ttft_sec = round(base_ttft, 4)
+
+        # 429 probability ramps up as target_rate exceeds 25 req/s
+        prob_429 = max(0.0, (target_rate - 20) / 40.0) if target_rate > 20 else 0.0
+        is_429 = rng.random() < prob_429
+
+        prob_5xx = 0.03 if target_rate > 40 else 0.01
+        is_5xx = not is_429 and (rng.random() < prob_5xx)
+
+        if is_429:
+            status_code = 429
+            retry_count = rng.randint(1, 3)
+            backoff_sec = round(min(self.config["max_backoff_sec"], 0.4 * (2 ** (retry_count - 1)) + rng.uniform(0.05, 0.2)), 4)
+            error_type = "rate_limit_429"
+        elif is_5xx:
+            status_code = 500
+            retry_count = 0
+            backoff_sec = 0.0
+            error_type = "server_error_500"
+        else:
+            status_code = 200
+            retry_count = 0
+            backoff_sec = 0.0
+            error_type = None
+
+        total_latency_sec = round(ttft_sec + rng.uniform(0.1, 0.3) + backoff_sec, 4)
+
+        return {
+            "request_id": f"req-{target_rate:02d}-{request_idx:03d}",
+            "timestamp": utc_timestamp(),
+            "target_rate": target_rate,
+            "concurrency": concurrency,
+            "status_code": status_code,
+            "ttft_sec": ttft_sec,
+            "total_latency_sec": total_latency_sec,
+            "backoff_sec": backoff_sec,
+            "retry_count": retry_count,
+            "error_type": error_type,
+        }
+
+    def compile_evidence_package(
+        self, records: Sequence[dict[str, Any]], sample_size: int = 100
+    ) -> list[dict[str, Any]]:
+        """Compile exactly sample_size (default N=100) evidence items uniformly sampled from raw records."""
+        if not records:
+            return []
+
+        if len(records) <= sample_size:
+            return [dict(r) for r in records]
+
+        # Uniformly sample across the records to cover all rate tiers
+        step = len(records) / float(sample_size)
+        indices = [int(i * step) for i in range(sample_size)]
+        return [dict(records[idx]) for idx in indices]
+
+    def calculate_backoff_curves(
+        self, records: Sequence[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """Compute 429 rate limit backoff curve metrics by request rate level."""
+        by_rate: dict[int, dict[str, Any]] = {}
+        total_backoff_time = 0.0
+        max_backoff = 0.0
+        total_429 = 0
+
+        grouped: dict[int, list[dict[str, Any]]] = {}
+        for r in records:
+            rate = int(r["target_rate"])
+            grouped.setdefault(rate, []).append(r)
+
+        for rate in sorted(grouped.keys()):
+            step_recs = grouped[rate]
+            cnt = len(step_recs)
+            hits_429 = sum(1 for r in step_recs if r["status_code"] == 429)
+            backoffs = [float(r["backoff_sec"]) for r in step_recs if r["backoff_sec"] > 0]
+
+            avg_backoff = round(sum(backoffs) / len(backoffs), 4) if backoffs else 0.0
+            step_max_backoff = max(backoffs, default=0.0)
+
+            total_429 += hits_429
+            total_backoff_time += sum(backoffs)
+            max_backoff = max(max_backoff, step_max_backoff)
+
+            by_rate[rate] = {
+                "total_requests": cnt,
+                "429_count": hits_429,
+                "backoff_ratio": round(hits_429 / cnt, 4) if cnt > 0 else 0.0,
+                "avg_backoff_sec": avg_backoff,
+                "max_backoff_sec": round(step_max_backoff, 4),
+            }
+
+        overall_avg_backoff = (
+            round(total_backoff_time / total_429, 4) if total_429 > 0 else 0.0
+        )
+
+        return {
+            "by_rate": by_rate,
+            "overall_avg_backoff_sec": overall_avg_backoff,
+            "total_backoff_time_sec": round(total_backoff_time, 4),
+            "max_backoff_observed_sec": round(max_backoff, 4),
+            "total_429_count": total_429,
+        }
+
+    def run(self, config: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+        """Execute rate ramp benchmark and return structured benchmark metrics."""
+        if config is not None:
+            self.config = self._parse_config(config)
+
+        rates = self.config["rates"]
+        reqs_per_step = self.config["requests_per_step"]
+        request_fn: Optional[Callable] = self.config["request_fn"]
+
+        all_records: list[dict[str, Any]] = []
+        ramp_steps_summary: list[dict[str, Any]] = []
+
+        for rate in rates:
+            concurrency = rate
+            step_records: list[dict[str, Any]] = []
+
+            for i in range(reqs_per_step):
+                if callable(request_fn):
+                    rec = request_fn(rate, concurrency, i)
+                else:
+                    rec = self.simulate_request(rate, concurrency, i)
+                step_records.append(rec)
+                all_records.append(rec)
+
+            ttfts = [r["ttft_sec"] for r in step_records if "ttft_sec" in r]
+            hits_429 = sum(1 for r in step_records if r.get("status_code") == 429)
+            other_errs = sum(
+                1
+                for r in step_records
+                if r.get("status_code") != 200 and r.get("status_code") != 429
+            )
+            successes = sum(1 for r in step_records if r.get("status_code") == 200)
+
+            backoff_secs = [r.get("backoff_sec", 0.0) for r in step_records]
+            avg_backoff = (
+                round(sum(backoff_secs) / len(backoff_secs), 4)
+                if backoff_secs
+                else 0.0
+            )
+
+            ramp_steps_summary.append(
+                {
+                    "rate_req_per_sec": rate,
+                    "concurrency": concurrency,
+                    "total_requests": len(step_records),
+                    "successful_requests": successes,
+                    "rate_limit_errors": hits_429,
+                    "other_errors": other_errs,
+                    "error_rate": round((hits_429 + other_errs) / max(1, len(step_records)), 4),
+                    "ttft_p50": calculate_percentile(ttfts, 50),
+                    "ttft_p95": calculate_percentile(ttfts, 95),
+                    "ttft_p99": calculate_percentile(ttfts, 99),
+                    "avg_backoff_sec": avg_backoff,
+                }
+            )
+
+        all_ttfts = [r["ttft_sec"] for r in all_records if "ttft_sec" in r]
+        total_reqs = len(all_records)
+        total_429 = sum(1 for r in all_records if r.get("status_code") == 429)
+        total_other = sum(
+            1 for r in all_records if r.get("status_code") not in (200, 429)
+        )
+        total_success = sum(1 for r in all_records if r.get("status_code") == 200)
+
+        backoff_curves = self.calculate_backoff_curves(all_records)
+        evidence_package = self.compile_evidence_package(
+            all_records, sample_size=self.config["sample_size"]
+        )
+
+        overall_metrics = {
+            "total_requests": total_reqs,
+            "successful_requests": total_success,
+            "total_errors": total_429 + total_other,
+            "error_rate": round((total_429 + total_other) / max(1, total_reqs), 4),
+            "rate_limit_429_count": total_429,
+            "ttft_p50": calculate_percentile(all_ttfts, 50),
+            "ttft_p95": calculate_percentile(all_ttfts, 95),
+            "ttft_p99": calculate_percentile(all_ttfts, 99),
+            "avg_backoff_sec": backoff_curves["overall_avg_backoff_sec"],
+        }
+
+        return {
+            "config": {
+                "start_rate": self.config["start_rate"],
+                "end_rate": self.config["end_rate"],
+                "step_rate": self.config["step_rate"],
+                "sample_size": self.config["sample_size"],
+                "endpoint_url": self.config["endpoint_url"],
+                "model": self.config["model"],
+            },
+            "ramp_steps": ramp_steps_summary,
+            "overall_metrics": overall_metrics,
+            "backoff_curves": backoff_curves,
+            "evidence_package": evidence_package,
+        }
+
+
+def run_benchmark(config: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    """Entrypoint function to run rate ramp benchmark and return structured metrics."""
+    bench = RateRampBenchmark(config)
+    return bench.run()

--- a/chapter6/model-benchmark/rate_ramp_benchmark.py
+++ b/chapter6/model-benchmark/rate_ramp_benchmark.py
@@ -234,13 +234,13 @@ class RateRampBenchmark:
                 step_records.append(rec)
                 all_records.append(rec)
 
-            ttfts = [float(r.get("ttft_sec", 0.0) or 0.0) for r in step_records if isinstance(r, dict)]
+            ttfts = [float(r["ttft_sec"]) for r in step_records if isinstance(r, dict) and r.get("ttft_sec") is not None]
             hits_429 = sum(1 for r in step_records if isinstance(r, dict) and r.get("status_code") == 429)
             other_errs = sum(
                 1
                 for r in step_records
-                if isinstance(r, dict)
-                and r.get("status_code") not in (200, 429)
+                if not isinstance(r, dict)
+                or r.get("status_code") not in (200, 429)
             )
             successes = sum(1 for r in step_records if isinstance(r, dict) and r.get("status_code") == 200)
 

--- a/chapter6/model-benchmark/rate_ramp_benchmark.py
+++ b/chapter6/model-benchmark/rate_ramp_benchmark.py
@@ -151,11 +151,11 @@ class RateRampBenchmark:
         """Compute 429 rate limit backoff curve metrics by request rate level."""
         by_rate: dict[int, dict[str, Any]] = {}
         total_backoff_time = 0.0
+        total_429_backoff_time = 0.0
         max_backoff = 0.0
         total_429 = 0
-
-        grouped: dict[int, list[dict[str, Any]]] = {}
         all_backoffs_count = 0
+
         grouped: dict[int, list[dict[str, Any]]] = {}
         for r in records:
             rate = int(r.get("target_rate", 0))
@@ -165,12 +165,14 @@ class RateRampBenchmark:
             step_recs = grouped[rate]
             cnt = len(step_recs)
             hits_429 = sum(1 for r in step_recs if r.get("status_code") == 429)
+            backoffs_429 = [float(r.get("backoff_sec", 0.0)) for r in step_recs if r.get("status_code") == 429 and float(r.get("backoff_sec", 0.0)) > 0]
             backoffs = [float(r.get("backoff_sec", 0.0)) for r in step_recs if float(r.get("backoff_sec", 0.0)) > 0]
 
             avg_backoff = round(sum(backoffs) / len(backoffs), 4) if backoffs else 0.0
             step_max_backoff = max(backoffs, default=0.0)
 
             total_429 += hits_429
+            total_429_backoff_time += sum(backoffs_429)
             total_backoff_time += sum(backoffs)
             all_backoffs_count += len(backoffs)
             max_backoff = max(max_backoff, step_max_backoff)
@@ -184,7 +186,7 @@ class RateRampBenchmark:
             }
 
         overall_avg_backoff = (
-            round(total_backoff_time / total_429, 4)
+            round(total_429_backoff_time / total_429, 4)
             if total_429 > 0
             else (round(total_backoff_time / all_backoffs_count, 4) if all_backoffs_count > 0 else 0.0)
         )
@@ -230,7 +232,7 @@ class RateRampBenchmark:
             )
             successes = sum(1 for r in step_records if r.get("status_code") == 200)
 
-            backoff_secs = [r.get("backoff_sec", 0.0) for r in step_records]
+            backoff_secs = [float(r.get("backoff_sec", 0.0)) for r in step_records if float(r.get("backoff_sec", 0.0)) > 0]
             avg_backoff = (
                 round(sum(backoff_secs) / len(backoff_secs), 4)
                 if backoff_secs

--- a/tests/test_ch6_rate_ramp_benchmark.py
+++ b/tests/test_ch6_rate_ramp_benchmark.py
@@ -134,3 +134,11 @@ def test_calculate_backoff_curves_missing_fields():
     res = bench.calculate_backoff_curves(sparse_records)
     assert res["total_429_count"] == 2
     assert res["overall_avg_backoff_sec"] == 1.0
+
+
+def test_explicit_rates_config_parsing():
+    bench = RateRampBenchmark({"rates": [10, 20, 30]})
+    cfg = bench.config
+    assert cfg["start_rate"] == 10
+    assert cfg["end_rate"] == 30
+    assert cfg["rates"] == [10, 20, 30]

--- a/tests/test_ch6_rate_ramp_benchmark.py
+++ b/tests/test_ch6_rate_ramp_benchmark.py
@@ -142,3 +142,14 @@ def test_explicit_rates_config_parsing():
     assert cfg["start_rate"] == 10
     assert cfg["end_rate"] == 30
     assert cfg["rates"] == [10, 20, 30]
+def test_backoff_curves_with_non_dict_and_zero_backoff_429():
+    bench = RateRampBenchmark()
+    records = [
+        "not_a_dict",
+        {"status_code": 429, "backoff_sec": 0.0},  # 429 without backoff
+        {"status_code": 429, "backoff_sec": 2.0},  # 429 with backoff
+    ]
+    res = bench.calculate_backoff_curves(records)
+    assert res["total_429_count"] == 2
+    # overall_avg_backoff should be based on requests with backoff > 0 (2.0 / 1 = 2.0)
+    assert res["overall_avg_backoff_sec"] == 2.0

--- a/tests/test_ch6_rate_ramp_benchmark.py
+++ b/tests/test_ch6_rate_ramp_benchmark.py
@@ -121,3 +121,16 @@ def test_compile_evidence_package_sample_size():
     raw_records = [{"id": i, "target_rate": 10} for i in range(250)]
     evidence = bench.compile_evidence_package(raw_records, sample_size=100)
     assert len(evidence) == 100
+
+    assert bench.compile_evidence_package(raw_records, sample_size=0) == []
+
+
+def test_calculate_backoff_curves_missing_fields():
+    bench = RateRampBenchmark()
+    sparse_records = [
+        {"backoff_sec": 1.5},
+        {"status_code": 429, "backoff_sec": 0.5},
+    ]
+    res = bench.calculate_backoff_curves(sparse_records)
+    assert res["total_429_count"] == 1
+    assert res["overall_avg_backoff_sec"] == 2.0

--- a/tests/test_ch6_rate_ramp_benchmark.py
+++ b/tests/test_ch6_rate_ramp_benchmark.py
@@ -128,9 +128,9 @@ def test_compile_evidence_package_sample_size():
 def test_calculate_backoff_curves_missing_fields():
     bench = RateRampBenchmark()
     sparse_records = [
-        {"backoff_sec": 1.5},
+        {"status_code": 429, "backoff_sec": 1.5},
         {"status_code": 429, "backoff_sec": 0.5},
     ]
     res = bench.calculate_backoff_curves(sparse_records)
-    assert res["total_429_count"] == 1
-    assert res["overall_avg_backoff_sec"] == 2.0
+    assert res["total_429_count"] == 2
+    assert res["overall_avg_backoff_sec"] == 1.0

--- a/tests/test_ch6_rate_ramp_benchmark.py
+++ b/tests/test_ch6_rate_ramp_benchmark.py
@@ -1,0 +1,123 @@
+"""Unit tests for chapter6/model-benchmark/rate_ramp_benchmark.py."""
+
+from pathlib import Path
+import sys
+
+# Ensure chapter6/model-benchmark is in sys.path
+ch6_dir = Path(__file__).resolve().parent.parent / "chapter6" / "model-benchmark"
+if str(ch6_dir) not in sys.path:
+    sys.path.insert(0, str(ch6_dir))
+
+from rate_ramp_benchmark import (
+    RateRampBenchmark,
+    calculate_percentile,
+    run_benchmark,
+)
+
+
+def test_calculate_percentile():
+    assert calculate_percentile([], 50) == 0.0
+    assert calculate_percentile([42.0], 95) == 42.0
+
+    vals = list(range(1, 101))  # 1 to 100
+    assert abs(calculate_percentile(vals, 50) - 50.5) < 0.1
+    assert abs(calculate_percentile(vals, 95) - 95.05) < 0.1
+    assert abs(calculate_percentile(vals, 99) - 99.01) < 0.1
+
+
+def test_rate_ramp_benchmark_default_run():
+    config = {
+        "start_rate": 1,
+        "end_rate": 50,
+        "step_rate": 10,
+        "requests_per_step": 5,
+        "sample_size": 100,
+    }
+    metrics = run_benchmark(config)
+
+    assert "config" in metrics
+    assert "ramp_steps" in metrics
+    assert "overall_metrics" in metrics
+    assert "backoff_curves" in metrics
+    assert "evidence_package" in metrics
+
+    # Check ramp steps cover rate progression
+    rates = [step["rate_req_per_sec"] for step in metrics["ramp_steps"]]
+    assert 1 in rates
+    assert 50 in rates
+
+    # Check overall metrics structure
+    overall = metrics["overall_metrics"]
+    assert overall["total_requests"] == len(metrics["ramp_steps"]) * 5
+    assert "ttft_p50" in overall
+    assert "ttft_p95" in overall
+    assert "ttft_p99" in overall
+    assert "error_rate" in overall
+    assert "rate_limit_429_count" in overall
+
+    # Check evidence package
+    evidence = metrics["evidence_package"]
+    assert len(evidence) <= 100
+    assert len(evidence) > 0
+    assert "request_id" in evidence[0]
+    assert "ttft_sec" in evidence[0]
+    assert "status_code" in evidence[0]
+
+
+def test_rate_ramp_benchmark_custom_request_fn():
+    # Custom request function that triggers 429 rate limit at high rates
+    def mock_request_fn(rate, concurrency, req_idx):
+        if rate >= 30:
+            return {
+                "request_id": f"mock-{rate}-{req_idx}",
+                "timestamp": "2026-08-09T12:00:00.000Z",
+                "target_rate": rate,
+                "concurrency": concurrency,
+                "status_code": 429,
+                "ttft_sec": 0.25,
+                "total_latency_sec": 1.5,
+                "backoff_sec": 1.0,
+                "retry_count": 2,
+                "error_type": "rate_limit_429",
+            }
+        return {
+            "request_id": f"mock-{rate}-{req_idx}",
+            "timestamp": "2026-08-09T12:00:00.000Z",
+            "target_rate": rate,
+            "concurrency": concurrency,
+            "status_code": 200,
+            "ttft_sec": 0.10,
+            "total_latency_sec": 0.30,
+            "backoff_sec": 0.0,
+            "retry_count": 0,
+            "error_type": None,
+        }
+
+    config = {
+        "rates": [10, 20, 30, 40, 50],
+        "requests_per_step": 4,
+        "sample_size": 20,
+        "request_fn": mock_request_fn,
+    }
+
+    bench = RateRampBenchmark(config)
+    metrics = bench.run()
+
+    # Rates 10 and 20 are 200 OK (8 reqs), Rates 30, 40, 50 are 429 (12 reqs)
+    overall = metrics["overall_metrics"]
+    assert overall["total_requests"] == 20
+    assert overall["successful_requests"] == 8
+    assert overall["rate_limit_429_count"] == 12
+    assert overall["error_rate"] == 0.6
+
+    backoff = metrics["backoff_curves"]
+    assert backoff["total_429_count"] == 12
+    assert backoff["by_rate"][30]["429_count"] == 4
+    assert backoff["by_rate"][30]["avg_backoff_sec"] == 1.0
+
+
+def test_compile_evidence_package_sample_size():
+    bench = RateRampBenchmark({"sample_size": 100})
+    raw_records = [{"id": i, "target_rate": 10} for i in range(250)]
+    evidence = bench.compile_evidence_package(raw_records, sample_size=100)
+    assert len(evidence) == 100

--- a/tests/test_ch6_rate_ramp_benchmark.py
+++ b/tests/test_ch6_rate_ramp_benchmark.py
@@ -153,3 +153,109 @@ def test_backoff_curves_with_non_dict_and_zero_backoff_429():
     assert res["total_429_count"] == 2
     # overall_avg_backoff should be based on requests with backoff > 0 (2.0 / 1 = 2.0)
     assert res["overall_avg_backoff_sec"] == 2.0
+
+
+def test_backoff_averages_exclude_non_throttled_requests():
+    """Findings #2/#4/#6: only 429 (throttled) requests contribute to backoff averages.
+
+    Regression: the pre-fix code averaged every record with backoff_sec > 0, so a
+    non-throttled 200 carrying backoff inflated per-rate and total backoff metrics.
+    """
+    bench = RateRampBenchmark()
+    records = [
+        {"target_rate": 10, "status_code": 200, "backoff_sec": 5.0},   # non-throttled backoff -> ignored
+        {"target_rate": 10, "status_code": 429, "backoff_sec": 0.0},   # throttled, zero backoff
+        {"target_rate": 20, "status_code": 429, "backoff_sec": 2.0},   # throttled backoff
+        {"target_rate": 20, "status_code": 429, "backoff_sec": 4.0},   # throttled backoff
+    ]
+    res = bench.calculate_backoff_curves(records)
+    # Rate 10 has no 429 backoff > 0 -> 0.0, not 5.0 (old code returned 5.0).
+    assert res["by_rate"][10]["avg_backoff_sec"] == 0.0
+    # Rate 20 averages only its two throttled backoffs: (2.0 + 4.0) / 2 = 3.0.
+    assert res["by_rate"][20]["avg_backoff_sec"] == 3.0
+    # Overall averages only throttled backoffs: (2.0 + 4.0) / 2 = 3.0.
+    assert res["overall_avg_backoff_sec"] == 3.0
+    # Total backoff time counts only throttled backoff: 6.0 (old code returned 11.0).
+    assert res["total_backoff_time_sec"] == 6.0
+
+
+def test_overall_avg_backoff_zero_when_no_throttled_backoff():
+    """Finding #2: with no 429 backoff > 0, overall avg is 0.0, not inflated by non-throttled backoffs.
+
+    Regression: the pre-fix code fell back to averaging all backoff-bearing records,
+    yielding 5.0 here instead of 0.0.
+    """
+    bench = RateRampBenchmark()
+    records = [
+        {"target_rate": 10, "status_code": 200, "backoff_sec": 5.0},
+        {"target_rate": 10, "status_code": 429, "backoff_sec": 0.0},
+    ]
+    res = bench.calculate_backoff_curves(records)
+    assert res["overall_avg_backoff_sec"] == 0.0
+
+
+def test_run_step_summary_backoff_only_counts_throttled():
+    """Finding #4: ramp_steps avg_backoff counts only 429 requests.
+
+    Regression: the pre-fix run() step summary averaged every record with
+    backoff_sec > 0, so a 200 carrying backoff yielded 9.0 at rate 10.
+    """
+    def fn(rate, concurrency, idx):
+        if rate >= 20:
+            return {"target_rate": rate, "status_code": 429, "ttft_sec": 0.2, "backoff_sec": 2.0}
+        return {"target_rate": rate, "status_code": 200, "ttft_sec": 0.1, "backoff_sec": 9.0}
+
+    bench = RateRampBenchmark({"rates": [10, 20], "requests_per_step": 2, "request_fn": fn, "sample_size": 5})
+    metrics = bench.run()
+    step10 = next(s for s in metrics["ramp_steps"] if s["rate_req_per_sec"] == 10)
+    step20 = next(s for s in metrics["ramp_steps"] if s["rate_req_per_sec"] == 20)
+    assert step10["avg_backoff_sec"] == 0.0  # old code: 9.0
+    assert step20["avg_backoff_sec"] == 2.0
+
+
+def test_run_custom_fn_missing_fields_non_dict_and_none_backoff():
+    """Findings #1/#7: run() must not crash on records missing fields, non-dict records, or None backoff.
+
+    Regression: the pre-fix code used ``r["ttft_sec"]`` / ``"ttft_sec" in r`` (crashes on
+    non-dict) and ``float(r.get("backoff_sec", 0.0))`` (crashes on None backoff).
+    """
+    def fn(rate, concurrency, idx):
+        if idx == 0:
+            return {"target_rate": rate, "status_code": 429, "backoff_sec": None}
+        if idx == 1:
+            return None  # non-dict record
+        return {"target_rate": rate, "status_code": 429, "backoff_sec": 1.0, "ttft_sec": 0.3}
+
+    bench = RateRampBenchmark({"rates": [10], "requests_per_step": 3, "request_fn": fn, "sample_size": 5})
+    metrics = bench.run()  # must not raise
+    # None backoff treated as 0 -> only the 1.0 record counts toward the average.
+    assert metrics["overall_metrics"]["avg_backoff_sec"] == 1.0
+    # The non-dict record has no status_code; only idx 0 and idx 2 are 429.
+    assert metrics["overall_metrics"]["rate_limit_429_count"] == 2
+
+
+def test_evidence_package_zero_and_none_sample_size_no_division_error():
+    """Finding #3: zero/None sample_size must not cause division by zero.
+
+    Regression: the pre-fix guard ``sample_size <= 0`` raised TypeError on None.
+    """
+    bench = RateRampBenchmark()
+    raw = [{"id": i, "target_rate": 10} for i in range(50)]
+    assert bench.compile_evidence_package(raw, sample_size=0) == []
+    assert bench.compile_evidence_package(raw, sample_size=None) == []
+    assert bench.compile_evidence_package([], sample_size=100) == []
+
+
+def test_custom_rates_reflected_in_report_config():
+    """Finding #5: report config start/end must match a custom rates list, not defaults.
+
+    Regression: the pre-fix _parse_config kept default start_rate=1/end_rate=50 when a
+    custom rates list was supplied, so the report showed the wrong range.
+    """
+    def fn(rate, concurrency, idx):
+        return {"target_rate": rate, "status_code": 200, "ttft_sec": 0.1, "backoff_sec": 0.0}
+
+    bench = RateRampBenchmark({"rates": [7, 13, 29], "requests_per_step": 1, "request_fn": fn, "sample_size": 5})
+    metrics = bench.run()
+    assert metrics["config"]["start_rate"] == 7
+    assert metrics["config"]["end_rate"] == 29


### PR DESCRIPTION
## Summary

Adds a rate ramp benchmark module for LLM endpoints that simulates multi-concurrency load testing.

## Changes

- **`chapter6/model-benchmark/rate_ramp_benchmark.py`** — `RateRampBenchmark` simulates 1-50 req/s load against LLM endpoints, measuring 429 rate limit backoff curves, TTFT percentiles (p50/p95/p99), and error rates. Tasks missing TTFT measurements are excluded from percentile calculations. Non-dict response records are counted as errors. Compiles N=100 evidence packages with ISO 8601 UTC timestamps.
- **`tests/test_ch6_rate_ramp_benchmark.py`** — 13 tests covering percentile calculation, load simulation, error handling, and evidence packaging.