### PR TITLE
fix(scripts): support various ISO 8601 formats in gen_star_history

### DIFF
--- a/scripts/gen_star_history.py
+++ b/scripts/gen_star_history.py
@@ -117,12 +117,22 @@ def fetch_starred_at(repo: str, refresh: bool) -> list[str]:
     return starred
 
 
+def parse_iso_timestamp(s: str) -> datetime:
+    """Parse ISO-8601 timestamps (including fractional seconds and offsets) into UTC."""
+    s = s.strip()
+    if s.endswith("Z") or s.endswith("z"):
+        s = s[:-1] + "+00:00"
+    dt = datetime.fromisoformat(s)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt
+
+
 def build_series(starred: list[str], start: datetime) -> tuple[np.ndarray, np.ndarray]:
     """Cumulative star count per star event, cropped to `start` (UTC)."""
-    times = [
-        datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
-        for s in starred
-    ]
+    times = [parse_iso_timestamp(s) for s in starred]
     base = sum(1 for t in times if t < start)
     times = [t for t in times if t >= start]
     # Anchor the line at the start date so the curve begins at the axis edge.
@@ -287,7 +297,7 @@ def main() -> None:
     parser.add_argument("--refresh", action="store_true", help="ignore the timestamp cache")
     args = parser.parse_args()
 
-    start = datetime.strptime(args.start_date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    start = parse_iso_timestamp(args.start_date)
     starred = fetch_starred_at(args.repo, refresh=args.refresh)
     x, y = build_series(starred, start)
 

--- a/tests/test_gen_star_history_iso_formats.py
+++ b/tests/test_gen_star_history_iso_formats.py
@@ -1,0 +1,40 @@
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from gen_star_history import build_series, parse_iso_timestamp
+
+
+def test_parse_iso_timestamp_supports_various_iso_formats():
+    """Contract: parse_iso_timestamp parses standard ISO 8601 strings into UTC datetimes."""
+    timestamps = [
+        "2026-07-15T12:34:56Z",
+        "2026-07-15T12:34:56.789Z",
+        "2026-07-15T12:34:56.123456Z",
+        "2026-07-15T12:34:56+02:00",
+        "2026-07-15T12:34:56-05:00",
+        "2026-07-15T12:34:56",
+        "2026-07-15",
+    ]
+    for ts in timestamps:
+        dt = parse_iso_timestamp(ts)
+        assert isinstance(dt, datetime)
+        assert dt.tzinfo == timezone.utc
+
+
+def test_build_series_handles_fractional_and_timezone_iso_strings():
+    """Contract: build_series parses stargazers with fractional seconds and explicit tz offsets without ValueError."""
+    starred = [
+        "2026-07-15T10:00:00.123Z",
+        "2026-07-15T14:00:00+02:00",
+        "2026-07-16T08:00:00Z",
+    ]
+    start = datetime(2026, 7, 15, 0, 0, 0, tzinfo=timezone.utc)
+    x, y = build_series(starred, start)
+
+    assert len(x) == 4  # anchor + 3 points
+    assert len(y) == 4
+    assert y[0] == 0
+    assert y[-1] == 3

--- a/tests/test_gen_star_history_iso_formats.py
+++ b/tests/test_gen_star_history_iso_formats.py
@@ -2,6 +2,10 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
+pytest.importorskip("matplotlib")
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from gen_star_history import build_series, parse_iso_timestamp


### PR DESCRIPTION
## Summary

Fixes `gen_star_history` to parse various ISO 8601 timestamp formats instead of only strict `YYYY-MM-DDTHH:MM:SSZ`.

## Changes

- **`scripts/gen_star_history.py`** — New `parse_iso_timestamp` function handles fractional seconds, `Z`/`z` suffixes, timezone offsets, and naive timestamps (assumed UTC). Both `build_series` and the `--start-date` CLI argument now use it. The old `datetime.strptime` with a single format string is replaced.
- **`tests/test_gen_star_history_iso_formats.py`** — 2 tests for multiple ISO format variants.