### PR TITLE
feat(ch3): add hybrid structured retriever for raptor trees and graphrag summaries

### DIFF
--- a/chapter3/structured-index/hybrid_retriever.py
+++ b/chapter3/structured-index/hybrid_retriever.py
@@ -113,7 +113,7 @@ class HybridStructuredRetriever:
             "text": str(text),
             "summary": str(summary or text),
             "embedding": embedding,
-            "children": list(children or []),
+            "children": [str(c) for c in (children or [])],
             "parent": parent,
             "source_type": "raptor_tree",
         }
@@ -175,7 +175,7 @@ class HybridStructuredRetriever:
         """Add a GraphRAG community summary node to the index."""
         record = {
             "id": str(community_id),
-            "entity_ids": list(entity_ids),
+            "entity_ids": [str(e) for e in (entity_ids or [])],
             "summary": str(summary),
             "level": int(level),
             "embedding": embedding,
@@ -291,7 +291,7 @@ class HybridStructuredRetriever:
         elif src_type == "graphrag_entity":
             text_content = f"{node.get('name', '')} {node.get('type', '')} {node.get('description', '')}"
         elif src_type == "graphrag_relation":
-            text_content = f"{node.get('source', '')} {node.get('type', '')} {node.get('description', '')}"
+            text_content = f"{node.get('source', '')} {node.get('type', '')} {node.get('target', '')} {node.get('description', '')}"
         elif src_type == "graphrag_community":
             text_content = f"{node.get('summary', '')}"
 
@@ -304,6 +304,7 @@ class HybridStructuredRetriever:
                 n_emb = node.get("embedding")
                 if n_emb is None and self.embedding_fn is not None:
                     n_emb = self.embedding_fn(text_content)
+                    node["embedding"] = n_emb
                 if n_emb is not None:
                     q_norm = np.linalg.norm(query_vector)
                     n_norm = np.linalg.norm(n_emb)
@@ -321,10 +322,11 @@ class HybridStructuredRetriever:
         for w in words:
             word_counts[w] += 1
 
-        matches = sum(word_counts[qt] for qt in query_terms if qt in word_counts)
-        precision = matches / len(query_terms)
+        matched_terms = [qt for qt in query_terms if qt in word_counts]
+        matches = sum(word_counts[qt] for qt in matched_terms)
+        precision = len(matched_terms) / len(query_terms)
         coverage = matches / len(words)
-        return float(precision * 0.8 + coverage * 0.2)
+        return float(precision * 0.8 + min(1.0, coverage) * 0.2)
 
     def _build_citation(self, node: Dict[str, Any]) -> EvidenceCitation:
         """Construct structured evidence citation tracking provenance for a node."""
@@ -338,7 +340,7 @@ class HybridStructuredRetriever:
             if node.get("parent"):
                 lineage.append(f"Parent: {node['parent']}")
             if node.get("children"):
-                lineage.append(f"Children: {', '.join(node['children'])}")
+                lineage.append(f"Children: {', '.join(str(c) for c in node['children'])}")
             snippet = node.get("summary") or node.get("text") or ""
             return EvidenceCitation(
                 source_type="raptor_tree",
@@ -388,7 +390,7 @@ class HybridStructuredRetriever:
                 node_id=n_id,
                 citation_label=label,
                 community_level=lvl,
-                lineage=[f"Entities: {', '.join(e_ids[:5])}"],
+                lineage=[f"Entities: {', '.join(str(e) for e in e_ids[:5])}"],
                 snippet=snippet[:200],
             )
 
@@ -420,12 +422,14 @@ class HybridStructuredRetriever:
 
         # 1. Rank RAPTOR tree summary nodes
         raptor_scores: List[Tuple[str, float]] = []
+        raw_scores: Dict[str, float] = {}
         for key, node in self.unified_nodes.items():
             if node.get("source_type") == "raptor_tree":
                 score = self._compute_relevance_score(query, query_terms, query_vector, node)
                 if score > 0:
                     raptor_scores.append((key, score))
-        raptor_scores.sort(key=lambda x: x[1], reverse=True)
+                    raw_scores[key] = score
+        raptor_scores.sort(key=lambda x: (x[1], x[0]), reverse=True)
 
         # 2. Rank GraphRAG graph summary nodes
         graphrag_scores: List[Tuple[str, float]] = []
@@ -434,13 +438,14 @@ class HybridStructuredRetriever:
                 score = self._compute_relevance_score(query, query_terms, query_vector, node)
                 if score > 0:
                     graphrag_scores.append((key, score))
-        graphrag_scores.sort(key=lambda x: x[1], reverse=True)
+                    raw_scores[key] = score
+        graphrag_scores.sort(key=lambda x: (x[1], x[0]), reverse=True)
         # Build rank lookups (1-indexed ranks)
         raptor_ranks = {item_key: rank + 1 for rank, (item_key, _) in enumerate(raptor_scores)}
         graphrag_ranks = {item_key: rank + 1 for rank, (item_key, _) in enumerate(graphrag_scores)}
 
         # 3. Perform Reciprocal Rank Fusion (RRF) scoring
-        all_candidate_keys = set(raptor_ranks.keys()).union(set(graphrag_ranks.keys()))
+        all_candidate_keys = sorted(set(raptor_ranks.keys()).union(set(graphrag_ranks.keys())))
         rrf_scores: Dict[str, float] = {}
 
         for key in all_candidate_keys:
@@ -451,9 +456,12 @@ class HybridStructuredRetriever:
                 score += 1.0 / (k_val + graphrag_ranks[key])
             rrf_scores[key] = score
 
-        # Sort candidate keys by RRF score descending
-        sorted_keys = sorted(rrf_scores.keys(), key=lambda k: rrf_scores[k], reverse=True)
-
+        # Sort candidate keys deterministically: RRF score desc, raw relevance score desc, key asc
+        sorted_keys = sorted(
+            all_candidate_keys,
+            key=lambda k: (rrf_scores[k], raw_scores.get(k, 0.0), k),
+            reverse=True,
+        )
         # 4. Construct final SearchResult objects with citations
         results: List[SearchResult] = []
         for key in sorted_keys[:top_k]:

--- a/chapter3/structured-index/hybrid_retriever.py
+++ b/chapter3/structured-index/hybrid_retriever.py
@@ -344,8 +344,11 @@ class HybridStructuredRetriever:
             if has_vector:
                 final_score = float(semantic_score * 0.7 + lexical_score * 0.3)
             else:
+                # No vector available for this item: use lexical score at the
+                # same weight as the no-query-vector path (0.8) so textually matching
+                # items are not penalized below non-matching vectorized items.
                 semantic_score = 0.0
-                final_score = float(lexical_score * 0.3)
+                final_score = float(lexical_score * 0.8)
         else:
             semantic_score = coverage_score
             final_score = float(lexical_score * 0.8 + coverage_score * 0.2)

--- a/chapter3/structured-index/hybrid_retriever.py
+++ b/chapter3/structured-index/hybrid_retriever.py
@@ -114,7 +114,7 @@ class HybridStructuredRetriever:
             "summary": str(summary or text),
             "embedding": embedding,
             "children": [str(c) for c in (children or [])],
-            "parent": parent,
+            "parent": str(parent) if parent is not None else None,
             "source_type": "raptor_tree",
         }
         self.raptor_nodes[str(node_id)] = record
@@ -364,7 +364,7 @@ class HybridStructuredRetriever:
             lvl = node.get("level", 0)
             label = f"[RAPTOR Tree Level {lvl} Node: {n_id}]"
             lineage = []
-            if node.get("parent"):
+            if node.get("parent") is not None:
                 lineage.append(f"Parent: {node['parent']}")
             if node.get("children"):
                 lineage.append(f"Children: {', '.join(str(c) for c in node['children'])}")

--- a/chapter3/structured-index/hybrid_retriever.py
+++ b/chapter3/structured-index/hybrid_retriever.py
@@ -340,8 +340,12 @@ class HybridStructuredRetriever:
                 has_vector = False
                 semantic_score = 0.0
 
-        if has_vector:
-            final_score = float(semantic_score * 0.7 + lexical_score * 0.3)
+        if query_vector is not None:
+            if has_vector:
+                final_score = float(semantic_score * 0.7 + lexical_score * 0.3)
+            else:
+                semantic_score = 0.0
+                final_score = float(lexical_score * 0.3)
         else:
             semantic_score = coverage_score
             final_score = float(lexical_score * 0.8 + coverage_score * 0.2)
@@ -443,7 +447,12 @@ class HybridStructuredRetriever:
             return []
 
         query_terms = set(re.findall(r"\w+", query.lower()))
-        query_vector = self.embedding_fn(query) if self.embedding_fn is not None else None
+        query_vector = None
+        if self.embedding_fn is not None:
+            try:
+                query_vector = self.embedding_fn(query)
+            except Exception:
+                query_vector = None
 
         candidates: Dict[str, Tuple[float, float, float]] = {}
         for key, node in self.unified_nodes.items():

--- a/chapter3/structured-index/hybrid_retriever.py
+++ b/chapter3/structured-index/hybrid_retriever.py
@@ -188,7 +188,7 @@ class HybridStructuredRetriever:
         """Bulk ingest RAPTOR tree nodes (objects or dicts)."""
         for node in nodes:
             if isinstance(node, dict):
-                n_id = node.get("id") or node.get("node_id")
+                n_id = node.get("id") if node.get("id") is not None else node.get("node_id")
                 level = node.get("level", 0)
                 text = node.get("text", "")
                 summary = node.get("summary", text)
@@ -196,7 +196,9 @@ class HybridStructuredRetriever:
                 children = node.get("children", [])
                 parent = node.get("parent")
             else:
-                n_id = getattr(node, "id", getattr(node, "node_id", None))
+                n_id = getattr(node, "id", None)
+                if n_id is None:
+                    n_id = getattr(node, "node_id", None)
                 level = getattr(node, "level", 0)
                 text = getattr(node, "text", "")
                 summary = getattr(node, "summary", text)
@@ -276,12 +278,12 @@ class HybridStructuredRetriever:
                 if c_id is not None:
                     self.add_graphrag_community(c_id, e_ids, summ, lvl, emb)
 
-    def _compute_relevance_score(
+    def _compute_scores(
         self, query: str, query_terms: set[str], query_vector: Optional[np.ndarray], node: Dict[str, Any]
-    ) -> float:
-        """Compute relevance score between query and node text/summary."""
+    ) -> Tuple[float, float, float]:
+        """Compute (final_score, lexical_score, semantic_score) for a node."""
         if not query_terms:
-            return 0.0
+            return 0.0, 0.0, 0.0
 
         # Construct textual content for evaluation
         text_content = ""
@@ -296,9 +298,22 @@ class HybridStructuredRetriever:
             text_content = f"{node.get('summary', '')}"
 
         if not text_content.strip():
-            return 0.0
+            return 0.0, 0.0, 0.0
 
-        # Vector similarity if embeddings available
+        words = re.findall(r"\w+", text_content.lower())
+        if not words:
+            return 0.0, 0.0, 0.0
+
+        word_counts = defaultdict(int)
+        for w in words:
+            word_counts[w] += 1
+
+        matched_terms = [qt for qt in query_terms if qt in word_counts]
+        lexical_score = len(matched_terms) / len(query_terms) if query_terms else 0.0
+        matches = sum(word_counts[qt] for qt in matched_terms)
+        coverage_score = min(1.0, matches / len(words)) if words else 0.0
+
+        semantic_score = 0.0
         if query_vector is not None:
             try:
                 n_emb = node.get("embedding")
@@ -310,24 +325,22 @@ class HybridStructuredRetriever:
                     n_norm = np.linalg.norm(n_emb)
                     if q_norm > 0 and n_norm > 0:
                         cos_sim = float(np.dot(query_vector, n_emb) / (q_norm * n_norm))
-                        return max(0.0, cos_sim)
+                        semantic_score = max(0.0, cos_sim)
             except Exception:
                 pass
-        # Term overlap + TF-IDF-like scoring
-        words = re.findall(r"\w+", text_content.lower())
-        if not words:
-            return 0.0
 
-        word_counts = defaultdict(int)
-        for w in words:
-            word_counts[w] += 1
+        if semantic_score > 0:
+            final_score = float(semantic_score * 0.7 + lexical_score * 0.3)
+        else:
+            semantic_score = coverage_score
+            final_score = float(lexical_score * 0.8 + coverage_score * 0.2)
 
-        matched_terms = [qt for qt in query_terms if qt in word_counts]
-        matches = sum(word_counts[qt] for qt in matched_terms)
-        precision = len(matched_terms) / len(query_terms)
-        coverage = matches / len(words)
-        return float(precision * 0.8 + min(1.0, coverage) * 0.2)
+        return final_score, lexical_score, semantic_score
 
+    def _compute_relevance_score(
+        self, query: str, query_terms: set[str], query_vector: Optional[np.ndarray], node: Dict[str, Any]
+    ) -> float:
+        return self._compute_scores(query, query_terms, query_vector, node)[0]
     def _build_citation(self, node: Dict[str, Any]) -> EvidenceCitation:
         """Construct structured evidence citation tracking provenance for a node."""
         src_type = node.get("source_type", "unknown")
@@ -411,7 +424,7 @@ class HybridStructuredRetriever:
         Returns:
             List of SearchResult items ordered descending by fused RRF score.
         """
-        k_val = rrf_k if rrf_k is not None else self.rrf_k
+        k_val = max(1, int(rrf_k)) if rrf_k is not None else self.rrf_k
         top_k = max(1, int(top_k))
 
         if not query or not query.strip():
@@ -420,48 +433,35 @@ class HybridStructuredRetriever:
         query_terms = set(re.findall(r"\w+", query.lower()))
         query_vector = self.embedding_fn(query) if self.embedding_fn is not None else None
 
-        # 1. Rank RAPTOR tree summary nodes
-        raptor_scores: List[Tuple[str, float]] = []
-        raw_scores: Dict[str, float] = {}
+        candidates: Dict[str, Tuple[float, float, float]] = {}
         for key, node in self.unified_nodes.items():
-            if node.get("source_type") == "raptor_tree":
-                score = self._compute_relevance_score(query, query_terms, query_vector, node)
-                if score > 0:
-                    raptor_scores.append((key, score))
-                    raw_scores[key] = score
-        raptor_scores.sort(key=lambda x: (x[1], x[0]), reverse=True)
+            final_sc, lex_sc, sem_sc = self._compute_scores(query, query_terms, query_vector, node)
+            if final_sc > 0:
+                candidates[key] = (final_sc, lex_sc, sem_sc)
 
-        # 2. Rank GraphRAG graph summary nodes
-        graphrag_scores: List[Tuple[str, float]] = []
-        for key, node in self.unified_nodes.items():
-            if node.get("source_type") in ("graphrag_entity", "graphrag_relation", "graphrag_community"):
-                score = self._compute_relevance_score(query, query_terms, query_vector, node)
-                if score > 0:
-                    graphrag_scores.append((key, score))
-                    raw_scores[key] = score
-        graphrag_scores.sort(key=lambda x: (x[1], x[0]), reverse=True)
-        # Build rank lookups (1-indexed ranks)
-        raptor_ranks = {item_key: rank + 1 for rank, (item_key, _) in enumerate(raptor_scores)}
-        graphrag_ranks = {item_key: rank + 1 for rank, (item_key, _) in enumerate(graphrag_scores)}
+        if not candidates:
+            return []
 
-        # 3. Perform Reciprocal Rank Fusion (RRF) scoring
-        all_candidate_keys = sorted(set(raptor_ranks.keys()).union(set(graphrag_ranks.keys())))
+        # 1. Lexical ranking across all candidates
+        lexical_sorted = sorted(candidates.keys(), key=lambda k: (candidates[k][1], candidates[k][0], k), reverse=True)
+        lexical_ranks = {k: r + 1 for r, k in enumerate(lexical_sorted)}
+
+        # 2. Semantic/Coverage ranking across all candidates
+        semantic_sorted = sorted(candidates.keys(), key=lambda k: (candidates[k][2], candidates[k][0], k), reverse=True)
+        semantic_ranks = {k: r + 1 for r, k in enumerate(semantic_sorted)}
+
+        # 3. Reciprocal Rank Fusion (RRF) scoring across identical candidate set
+        all_candidate_keys = sorted(candidates.keys())
         rrf_scores: Dict[str, float] = {}
-
         for key in all_candidate_keys:
-            score = 0.0
-            if key in raptor_ranks:
-                score += 1.0 / (k_val + raptor_ranks[key])
-            if key in graphrag_ranks:
-                score += 1.0 / (k_val + graphrag_ranks[key])
-            rrf_scores[key] = score
+            rrf_scores[key] = (1.0 / (k_val + lexical_ranks[key])) + (1.0 / (k_val + semantic_ranks[key]))
 
-        # Sort candidate keys deterministically: RRF score desc, raw relevance score desc, key asc
         sorted_keys = sorted(
             all_candidate_keys,
-            key=lambda k: (rrf_scores[k], raw_scores.get(k, 0.0), k),
+            key=lambda k: (rrf_scores[k], candidates[k][0], k),
             reverse=True,
         )
+
         # 4. Construct final SearchResult objects with citations
         results: List[SearchResult] = []
         for key in sorted_keys[:top_k]:
@@ -480,8 +480,8 @@ class HybridStructuredRetriever:
                 source_type=src_type,
                 citation=citation,
                 metadata={
-                    "raptor_rank": raptor_ranks.get(key),
-                    "graphrag_rank": graphrag_ranks.get(key),
+                    "lexical_rank": lexical_ranks.get(key),
+                    "semantic_rank": semantic_ranks.get(key),
                     "raw_node": {k: v for k, v in node.items() if k != "embedding"},
                 },
             )

--- a/chapter3/structured-index/hybrid_retriever.py
+++ b/chapter3/structured-index/hybrid_retriever.py
@@ -1,0 +1,482 @@
+"""Hybrid Structured Retriever for RAPTOR Hierarchical Trees and GraphRAG Knowledge Graphs.
+
+Merges RAPTOR tree summary nodes and GraphRAG entity-relation summaries into a unified retrieval index.
+Performs Reciprocal Rank Fusion (RRF) scoring and evidence citation tracking across hierarchical and graph chunks.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+import numpy as np
+
+
+@dataclass
+class EvidenceCitation:
+    """Represents evidence citation metadata tracking hierarchical and graph provenance."""
+    source_type: str  # "raptor_tree", "graphrag_entity", "graphrag_relation", "graphrag_community"
+    node_id: str
+    citation_label: str
+    hierarchical_level: Optional[int] = None
+    entity_type: Optional[str] = None
+    relation_type: Optional[str] = None
+    community_level: Optional[int] = None
+    lineage: List[str] = field(default_factory=list)
+    snippet: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert evidence citation to dictionary format."""
+        return {
+            "source_type": self.source_type,
+            "node_id": self.node_id,
+            "citation_label": self.citation_label,
+            "hierarchical_level": self.hierarchical_level,
+            "entity_type": self.entity_type,
+            "relation_type": self.relation_type,
+            "community_level": self.community_level,
+            "lineage": self.lineage,
+            "snippet": self.snippet,
+        }
+
+
+@dataclass
+class SearchResult:
+    """Represents a unified hybrid search result item with RRF score and citation."""
+    node_id: str
+    text: str
+    summary: str
+    score: float  # Fused RRF score
+    source_type: str
+    citation: EvidenceCitation
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert search result to dictionary format."""
+        return {
+            "node_id": self.node_id,
+            "text": self.text,
+            "summary": self.summary,
+            "score": self.score,
+            "source_type": self.source_type,
+            "citation": self.citation.to_dict(),
+            "metadata": self.metadata,
+        }
+
+
+class HybridStructuredRetriever:
+    """Retriever that merges RAPTOR tree summaries and GraphRAG graph summaries into a hybrid index.
+    
+    Supports Reciprocal Rank Fusion (RRF) across hierarchical (RAPTOR) and knowledge graph (GraphRAG)
+    indexes with evidence citation tracking for full auditability.
+    """
+
+    def __init__(
+        self,
+        rrf_k: int = 60,
+        embedding_fn: Optional[Callable[[str], np.ndarray]] = None,
+    ) -> None:
+        """Initialize the HybridStructuredRetriever.
+
+        Args:
+            rrf_k: Smoothing constant for Reciprocal Rank Fusion (RRF). Default 60.
+            embedding_fn: Optional callable to convert text into vector embeddings.
+        """
+        self.rrf_k = max(1, int(rrf_k))
+        self.embedding_fn = embedding_fn
+
+        # Internal node stores
+        self.raptor_nodes: Dict[str, Dict[str, Any]] = {}
+        self.graphrag_entities: Dict[str, Dict[str, Any]] = {}
+        self.graphrag_relations: Dict[str, Dict[str, Any]] = {}
+        self.graphrag_communities: Dict[str, Dict[str, Any]] = {}
+
+        # Unified document registry
+        self.unified_nodes: Dict[str, Dict[str, Any]] = {}
+
+    def add_raptor_node(
+        self,
+        node_id: str,
+        level: int,
+        text: str,
+        summary: str = "",
+        embedding: Optional[np.ndarray] = None,
+        children: Optional[List[str]] = None,
+        parent: Optional[str] = None,
+    ) -> None:
+        """Add a RAPTOR tree summary node to the index."""
+        record = {
+            "id": str(node_id),
+            "level": int(level),
+            "text": str(text),
+            "summary": str(summary or text),
+            "embedding": embedding,
+            "children": list(children or []),
+            "parent": parent,
+            "source_type": "raptor_tree",
+        }
+        self.raptor_nodes[str(node_id)] = record
+        self.unified_nodes[f"raptor_{node_id}"] = record
+
+    def add_graphrag_entity(
+        self,
+        entity_id: str,
+        name: str,
+        type: str = "GENERIC",
+        description: str = "",
+        embedding: Optional[np.ndarray] = None,
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Add a GraphRAG entity node to the index."""
+        record = {
+            "id": str(entity_id),
+            "name": str(name),
+            "type": str(type),
+            "description": str(description),
+            "embedding": embedding,
+            "attributes": dict(attributes or {}),
+            "source_type": "graphrag_entity",
+        }
+        self.graphrag_entities[str(entity_id)] = record
+        self.unified_nodes[f"entity_{entity_id}"] = record
+
+    def add_graphrag_relationship(
+        self,
+        relation_id: str,
+        source: str,
+        target: str,
+        type: str = "RELATED_TO",
+        description: str = "",
+        weight: float = 1.0,
+    ) -> None:
+        """Add a GraphRAG relationship summary node to the index."""
+        record = {
+            "id": str(relation_id),
+            "source": str(source),
+            "target": str(target),
+            "type": str(type),
+            "description": str(description),
+            "weight": float(weight),
+            "source_type": "graphrag_relation",
+        }
+        self.graphrag_relations[str(relation_id)] = record
+        self.unified_nodes[f"rel_{relation_id}"] = record
+
+    def add_graphrag_community(
+        self,
+        community_id: str,
+        entity_ids: List[str],
+        summary: str,
+        level: int = 0,
+        embedding: Optional[np.ndarray] = None,
+    ) -> None:
+        """Add a GraphRAG community summary node to the index."""
+        record = {
+            "id": str(community_id),
+            "entity_ids": list(entity_ids),
+            "summary": str(summary),
+            "level": int(level),
+            "embedding": embedding,
+            "source_type": "graphrag_community",
+        }
+        self.graphrag_communities[str(community_id)] = record
+        self.unified_nodes[f"community_{community_id}"] = record
+
+    def index_raptor_nodes(self, nodes: Sequence[Any]) -> None:
+        """Bulk ingest RAPTOR tree nodes (objects or dicts)."""
+        for node in nodes:
+            if isinstance(node, dict):
+                n_id = node.get("id") or node.get("node_id")
+                level = node.get("level", 0)
+                text = node.get("text", "")
+                summary = node.get("summary", text)
+                embedding = node.get("embedding")
+                children = node.get("children", [])
+                parent = node.get("parent")
+            else:
+                n_id = getattr(node, "id", getattr(node, "node_id", None))
+                level = getattr(node, "level", 0)
+                text = getattr(node, "text", "")
+                summary = getattr(node, "summary", text)
+                embedding = getattr(node, "embedding", None)
+                children = getattr(node, "children", [])
+                parent = getattr(node, "parent", None)
+            if n_id is not None:
+                self.add_raptor_node(
+                    node_id=str(n_id),
+                    level=level,
+                    text=text,
+                    summary=summary,
+                    embedding=embedding,
+                    children=children,
+                    parent=parent,
+                )
+
+    def index_graphrag_data(
+        self,
+        entities: Optional[Sequence[Any]] = None,
+        relationships: Optional[Sequence[Any]] = None,
+        communities: Optional[Sequence[Any]] = None,
+    ) -> None:
+        """Bulk ingest GraphRAG entities, relationships, and communities."""
+        if entities:
+            for item in entities:
+                if isinstance(item, dict):
+                    e_id = item.get("id", item.get("entity_id"))
+                    name = item.get("name", e_id)
+                    e_type = item.get("type", "GENERIC")
+                    desc = item.get("description", "")
+                    emb = item.get("embedding")
+                    attrs = item.get("attributes", {})
+                else:
+                    e_id = getattr(item, "id", getattr(item, "entity_id", None))
+                    name = getattr(item, "name", str(e_id))
+                    e_type = getattr(item, "type", "GENERIC")
+                    desc = getattr(item, "description", "")
+                    emb = getattr(item, "embedding", None)
+                    attrs = getattr(item, "attributes", {})
+                if e_id is not None:
+                    self.add_graphrag_entity(e_id, name, e_type, desc, emb, attrs)
+
+        if relationships:
+            for item in relationships:
+                if isinstance(item, dict):
+                    r_id = item.get("id", item.get("relation_id"))
+                    src = item.get("source", "")
+                    tgt = item.get("target", "")
+                    r_type = item.get("type", "RELATED_TO")
+                    desc = item.get("description", "")
+                    wt = item.get("weight", 1.0)
+                else:
+                    r_id = getattr(item, "id", getattr(item, "relation_id", None))
+                    src = getattr(item, "source", "")
+                    tgt = getattr(item, "target", "")
+                    r_type = getattr(item, "type", "RELATED_TO")
+                    desc = getattr(item, "description", "")
+                    wt = getattr(item, "weight", 1.0)
+                if r_id is not None:
+                    self.add_graphrag_relationship(r_id, src, tgt, r_type, desc, wt)
+
+        if communities:
+            for item in communities:
+                if isinstance(item, dict):
+                    c_id = item.get("id", item.get("community_id"))
+                    e_ids = item.get("entity_ids", [])
+                    summ = item.get("summary", "")
+                    lvl = item.get("level", 0)
+                    emb = item.get("embedding")
+                else:
+                    c_id = getattr(item, "id", getattr(item, "community_id", None))
+                    e_ids = getattr(item, "entity_ids", [])
+                    summ = getattr(item, "summary", "")
+                    lvl = getattr(item, "level", 0)
+                    emb = getattr(item, "embedding", None)
+                if c_id is not None:
+                    self.add_graphrag_community(c_id, e_ids, summ, lvl, emb)
+
+    def _compute_relevance_score(
+        self, query: str, query_terms: set[str], query_vector: Optional[np.ndarray], node: Dict[str, Any]
+    ) -> float:
+        """Compute relevance score between query and node text/summary."""
+        if not query_terms:
+            return 0.0
+
+        # Construct textual content for evaluation
+        text_content = ""
+        src_type = node.get("source_type")
+        if src_type == "raptor_tree":
+            text_content = f"{node.get('summary', '')} {node.get('text', '')}"
+        elif src_type == "graphrag_entity":
+            text_content = f"{node.get('name', '')} {node.get('type', '')} {node.get('description', '')}"
+        elif src_type == "graphrag_relation":
+            text_content = f"{node.get('source', '')} {node.get('type', '')} {node.get('description', '')}"
+        elif src_type == "graphrag_community":
+            text_content = f"{node.get('summary', '')}"
+
+        if not text_content.strip():
+            return 0.0
+
+        # Vector similarity if embeddings available
+        if query_vector is not None:
+            try:
+                n_emb = node.get("embedding")
+                if n_emb is None and self.embedding_fn is not None:
+                    n_emb = self.embedding_fn(text_content)
+                if n_emb is not None:
+                    q_norm = np.linalg.norm(query_vector)
+                    n_norm = np.linalg.norm(n_emb)
+                    if q_norm > 0 and n_norm > 0:
+                        cos_sim = float(np.dot(query_vector, n_emb) / (q_norm * n_norm))
+                        return max(0.0, cos_sim)
+            except Exception:
+                pass
+        # Term overlap + TF-IDF-like scoring
+        words = re.findall(r"\w+", text_content.lower())
+        if not words:
+            return 0.0
+
+        word_counts = defaultdict(int)
+        for w in words:
+            word_counts[w] += 1
+
+        matches = sum(word_counts[qt] for qt in query_terms if qt in word_counts)
+        precision = matches / len(query_terms)
+        coverage = matches / len(words)
+        return float(precision * 0.8 + coverage * 0.2)
+
+    def _build_citation(self, node: Dict[str, Any]) -> EvidenceCitation:
+        """Construct structured evidence citation tracking provenance for a node."""
+        src_type = node.get("source_type", "unknown")
+        n_id = str(node.get("id", ""))
+
+        if src_type == "raptor_tree":
+            lvl = node.get("level", 0)
+            label = f"[RAPTOR Tree Level {lvl} Node: {n_id}]"
+            lineage = []
+            if node.get("parent"):
+                lineage.append(f"Parent: {node['parent']}")
+            if node.get("children"):
+                lineage.append(f"Children: {', '.join(node['children'])}")
+            snippet = node.get("summary") or node.get("text") or ""
+            return EvidenceCitation(
+                source_type="raptor_tree",
+                node_id=n_id,
+                citation_label=label,
+                hierarchical_level=lvl,
+                lineage=lineage,
+                snippet=snippet[:200],
+            )
+
+        elif src_type == "graphrag_entity":
+            e_type = node.get("type", "GENERIC")
+            e_name = node.get("name", n_id)
+            label = f"[GraphRAG Entity: {e_name} (Type: {e_type})]"
+            snippet = node.get("description", "")
+            return EvidenceCitation(
+                source_type="graphrag_entity",
+                node_id=n_id,
+                citation_label=label,
+                entity_type=e_type,
+                lineage=[f"EntityName: {e_name}"],
+                snippet=snippet[:200],
+            )
+
+        elif src_type == "graphrag_relation":
+            r_type = node.get("type", "RELATED_TO")
+            src = node.get("source", "")
+            tgt = node.get("target", "")
+            label = f"[GraphRAG Relation: {src} --({r_type})--> {tgt}]"
+            snippet = node.get("description", "")
+            return EvidenceCitation(
+                source_type="graphrag_relation",
+                node_id=n_id,
+                citation_label=label,
+                relation_type=r_type,
+                lineage=[f"Source: {src}", f"Target: {tgt}"],
+                snippet=snippet[:200],
+            )
+
+        elif src_type == "graphrag_community":
+            lvl = node.get("level", 0)
+            e_ids = node.get("entity_ids", [])
+            label = f"[GraphRAG Community Level {lvl}: {n_id}]"
+            snippet = node.get("summary", "")
+            return EvidenceCitation(
+                source_type="graphrag_community",
+                node_id=n_id,
+                citation_label=label,
+                community_level=lvl,
+                lineage=[f"Entities: {', '.join(e_ids[:5])}"],
+                snippet=snippet[:200],
+            )
+
+        return EvidenceCitation(
+            source_type=src_type,
+            node_id=n_id,
+            citation_label=f"[Source: {src_type} Node: {n_id}]",
+        )
+
+    def retrieve(self, query: str, top_k: int = 5, rrf_k: Optional[int] = None) -> List[SearchResult]:
+        """Retrieve and rank hybrid results using Reciprocal Rank Fusion (RRF).
+
+        Args:
+            query: The search query string.
+            top_k: Number of top ranked results to return.
+            rrf_k: Optional override for RRF k constant.
+
+        Returns:
+            List of SearchResult items ordered descending by fused RRF score.
+        """
+        k_val = rrf_k if rrf_k is not None else self.rrf_k
+        top_k = max(1, int(top_k))
+
+        if not query or not query.strip():
+            return []
+
+        query_terms = set(re.findall(r"\w+", query.lower()))
+        query_vector = self.embedding_fn(query) if self.embedding_fn is not None else None
+
+        # 1. Rank RAPTOR tree summary nodes
+        raptor_scores: List[Tuple[str, float]] = []
+        for key, node in self.unified_nodes.items():
+            if node.get("source_type") == "raptor_tree":
+                score = self._compute_relevance_score(query, query_terms, query_vector, node)
+                if score > 0:
+                    raptor_scores.append((key, score))
+        raptor_scores.sort(key=lambda x: x[1], reverse=True)
+
+        # 2. Rank GraphRAG graph summary nodes
+        graphrag_scores: List[Tuple[str, float]] = []
+        for key, node in self.unified_nodes.items():
+            if node.get("source_type") in ("graphrag_entity", "graphrag_relation", "graphrag_community"):
+                score = self._compute_relevance_score(query, query_terms, query_vector, node)
+                if score > 0:
+                    graphrag_scores.append((key, score))
+        graphrag_scores.sort(key=lambda x: x[1], reverse=True)
+        # Build rank lookups (1-indexed ranks)
+        raptor_ranks = {item_key: rank + 1 for rank, (item_key, _) in enumerate(raptor_scores)}
+        graphrag_ranks = {item_key: rank + 1 for rank, (item_key, _) in enumerate(graphrag_scores)}
+
+        # 3. Perform Reciprocal Rank Fusion (RRF) scoring
+        all_candidate_keys = set(raptor_ranks.keys()).union(set(graphrag_ranks.keys()))
+        rrf_scores: Dict[str, float] = {}
+
+        for key in all_candidate_keys:
+            score = 0.0
+            if key in raptor_ranks:
+                score += 1.0 / (k_val + raptor_ranks[key])
+            if key in graphrag_ranks:
+                score += 1.0 / (k_val + graphrag_ranks[key])
+            rrf_scores[key] = score
+
+        # Sort candidate keys by RRF score descending
+        sorted_keys = sorted(rrf_scores.keys(), key=lambda k: rrf_scores[k], reverse=True)
+
+        # 4. Construct final SearchResult objects with citations
+        results: List[SearchResult] = []
+        for key in sorted_keys[:top_k]:
+            node = self.unified_nodes[key]
+            citation = self._build_citation(node)
+
+            src_type = node.get("source_type", "unknown")
+            text = node.get("text") or node.get("description") or node.get("summary") or ""
+            summary = node.get("summary") or node.get("description") or text
+
+            res = SearchResult(
+                node_id=str(node.get("id")),
+                text=text,
+                summary=summary,
+                score=rrf_scores[key],
+                source_type=src_type,
+                citation=citation,
+                metadata={
+                    "raptor_rank": raptor_ranks.get(key),
+                    "graphrag_rank": graphrag_ranks.get(key),
+                    "raw_node": {k: v for k, v in node.items() if k != "embedding"},
+                },
+            )
+            results.append(res)
+
+        return results

--- a/chapter3/structured-index/hybrid_retriever.py
+++ b/chapter3/structured-index/hybrid_retriever.py
@@ -330,14 +330,15 @@ class HybridStructuredRetriever:
                     n_emb = self.embedding_fn(text_content)
                     node["embedding"] = n_emb
                 if n_emb is not None:
-                    has_vector = True
                     q_norm = np.linalg.norm(query_vector)
                     n_norm = np.linalg.norm(n_emb)
                     if q_norm > 0 and n_norm > 0:
                         cos_sim = float(np.dot(query_vector, n_emb) / (q_norm * n_norm))
                         semantic_score = max(0.0, cos_sim)
+                        has_vector = True
             except Exception:
-                pass
+                has_vector = False
+                semantic_score = 0.0
 
         if has_vector:
             final_score = float(semantic_score * 0.7 + lexical_score * 0.3)

--- a/chapter3/structured-index/hybrid_retriever.py
+++ b/chapter3/structured-index/hybrid_retriever.py
@@ -322,6 +322,7 @@ class HybridStructuredRetriever:
         coverage_score = min(1.0, matches / len(words)) if words else 0.0
 
         semantic_score = 0.0
+        has_vector = False
         if query_vector is not None:
             try:
                 n_emb = node.get("embedding")
@@ -329,6 +330,7 @@ class HybridStructuredRetriever:
                     n_emb = self.embedding_fn(text_content)
                     node["embedding"] = n_emb
                 if n_emb is not None:
+                    has_vector = True
                     q_norm = np.linalg.norm(query_vector)
                     n_norm = np.linalg.norm(n_emb)
                     if q_norm > 0 and n_norm > 0:
@@ -337,12 +339,11 @@ class HybridStructuredRetriever:
             except Exception:
                 pass
 
-        if semantic_score > 0:
+        if has_vector:
             final_score = float(semantic_score * 0.7 + lexical_score * 0.3)
         else:
             semantic_score = coverage_score
             final_score = float(lexical_score * 0.8 + coverage_score * 0.2)
-
         return final_score, lexical_score, semantic_score
 
     def _compute_relevance_score(

--- a/chapter3/structured-index/hybrid_retriever.py
+++ b/chapter3/structured-index/hybrid_retriever.py
@@ -226,15 +226,19 @@ class HybridStructuredRetriever:
         if entities:
             for item in entities:
                 if isinstance(item, dict):
-                    e_id = item.get("id", item.get("entity_id"))
-                    name = item.get("name", e_id)
+                    e_id = item.get("id") if item.get("id") is not None else item.get("entity_id")
+                    name = item.get("name") if item.get("name") is not None else e_id
                     e_type = item.get("type", "GENERIC")
                     desc = item.get("description", "")
                     emb = item.get("embedding")
                     attrs = item.get("attributes", {})
                 else:
-                    e_id = getattr(item, "id", getattr(item, "entity_id", None))
-                    name = getattr(item, "name", str(e_id))
+                    e_id = getattr(item, "id", None)
+                    if e_id is None:
+                        e_id = getattr(item, "entity_id", None)
+                    name = getattr(item, "name", None)
+                    if name is None:
+                        name = str(e_id)
                     e_type = getattr(item, "type", "GENERIC")
                     desc = getattr(item, "description", "")
                     emb = getattr(item, "embedding", None)
@@ -245,14 +249,16 @@ class HybridStructuredRetriever:
         if relationships:
             for item in relationships:
                 if isinstance(item, dict):
-                    r_id = item.get("id", item.get("relation_id"))
+                    r_id = item.get("id") if item.get("id") is not None else item.get("relation_id")
                     src = item.get("source", "")
                     tgt = item.get("target", "")
                     r_type = item.get("type", "RELATED_TO")
                     desc = item.get("description", "")
                     wt = item.get("weight", 1.0)
                 else:
-                    r_id = getattr(item, "id", getattr(item, "relation_id", None))
+                    r_id = getattr(item, "id", None)
+                    if r_id is None:
+                        r_id = getattr(item, "relation_id", None)
                     src = getattr(item, "source", "")
                     tgt = getattr(item, "target", "")
                     r_type = getattr(item, "type", "RELATED_TO")
@@ -264,13 +270,15 @@ class HybridStructuredRetriever:
         if communities:
             for item in communities:
                 if isinstance(item, dict):
-                    c_id = item.get("id", item.get("community_id"))
+                    c_id = item.get("id") if item.get("id") is not None else item.get("community_id")
                     e_ids = item.get("entity_ids", [])
                     summ = item.get("summary", "")
                     lvl = item.get("level", 0)
                     emb = item.get("embedding")
                 else:
-                    c_id = getattr(item, "id", getattr(item, "community_id", None))
+                    c_id = getattr(item, "id", None)
+                    if c_id is None:
+                        c_id = getattr(item, "community_id", None)
                     e_ids = getattr(item, "entity_ids", [])
                     summ = getattr(item, "summary", "")
                     lvl = getattr(item, "level", 0)
@@ -425,7 +433,9 @@ class HybridStructuredRetriever:
             List of SearchResult items ordered descending by fused RRF score.
         """
         k_val = max(1, int(rrf_k)) if rrf_k is not None else self.rrf_k
-        top_k = max(1, int(top_k))
+        top_k = max(0, int(top_k))
+        if top_k == 0:
+            return []
 
         if not query or not query.strip():
             return []

--- a/chapter3/structured-index/test_hybrid_retriever.py
+++ b/chapter3/structured-index/test_hybrid_retriever.py
@@ -122,3 +122,21 @@ def test_clamp_rrf_k():
     results = retriever.retrieve("Sample", rrf_k=-5)
     assert len(results) == 1
     assert results[0].score > 0
+
+
+def test_parent_id_zero_in_citation_lineage():
+    """Verify that parent ID 0 is preserved in citation lineage, not dropped by truthiness (Finding 12)."""
+    retriever = HybridStructuredRetriever()
+    retriever.add_raptor_node(
+        node_id="child_node",
+        level=1,
+        text="Child content for retrieval",
+        summary="Child summary for retrieval",
+        parent=0,
+    )
+
+    results = retriever.retrieve("Child content", top_k=1)
+    assert len(results) == 1
+    parent_entries = [lin for lin in results[0].citation.lineage if lin.startswith("Parent:")]
+    assert len(parent_entries) == 1
+    assert "0" in parent_entries[0]

--- a/chapter3/structured-index/test_hybrid_retriever.py
+++ b/chapter3/structured-index/test_hybrid_retriever.py
@@ -1,0 +1,124 @@
+"""Unit tests for HybridStructuredRetriever covering core requirements and edge cases."""
+
+import numpy as np
+import pytest
+
+from hybrid_retriever import HybridStructuredRetriever, SearchResult
+
+
+def test_relation_target_included_in_text_content():
+    """Verify that relation matching includes target entity name."""
+    retriever = HybridStructuredRetriever()
+    retriever.add_graphrag_relationship(
+        relation_id="rel_1",
+        source="Attention",
+        target="Transformer",
+        type="USED_IN",
+        description="Core mechanism for neural architecture",
+    )
+
+    results = retriever.retrieve("Transformer", top_k=5)
+    assert len(results) == 1
+    assert results[0].node_id == "rel_1"
+    assert "Transformer" in results[0].citation.citation_label or "Transformer" in results[0].text or "Transformer" in results[0].citation.lineage[1]
+
+
+def test_precision_calculation_unique_matched_words():
+    """Verify precision calculation counts unique matched query terms rather than token frequencies."""
+    retriever = HybridStructuredRetriever()
+    # Node content repeats "python" 5 times
+    retriever.add_raptor_node(
+        node_id="n1",
+        level=0,
+        text="python python python python python tutorial",
+    )
+
+    # Query has 2 terms: python, fast
+    query_terms = {"python", "fast"}
+    node = retriever.unified_nodes["raptor_n1"]
+    final_sc, lex_sc, sem_sc = retriever._compute_scores("python fast", query_terms, None, node)
+
+    # Lexical score should be 1 matched query term / 2 total query terms = 0.5
+    assert lex_sc == 0.5
+
+
+def test_stringify_numeric_ids_in_citation():
+    """Verify that numeric node IDs, children, parents, and entity_ids do not cause TypeError during citation building."""
+    retriever = HybridStructuredRetriever()
+
+    # Numeric IDs in RAPTOR node
+    retriever.add_raptor_node(
+        node_id=101,
+        level=1,
+        text="Hierarchical summary text",
+        children=[201, 202],
+        parent=50,
+    )
+
+    # Numeric IDs in GraphRAG community
+    retriever.add_graphrag_community(
+        community_id=99,
+        entity_ids=[1, 2, 3],
+        summary="Community summary text",
+    )
+
+    results = retriever.retrieve("summary text", top_k=5)
+    assert len(results) == 2
+    for res in results:
+        assert isinstance(res.node_id, str)
+        assert isinstance(res.citation.node_id, str)
+        assert all(isinstance(lin, str) for lin in res.citation.lineage)
+
+
+def test_cache_node_embeddings():
+    """Verify that node embeddings computed via embedding_fn are cached in node['embedding']."""
+    embed_count = 0
+
+    def mock_embed(text: str) -> np.ndarray:
+        nonlocal embed_count
+        embed_count += 1
+        return np.array([0.1, 0.2, 0.3])
+
+    retriever = HybridStructuredRetriever(embedding_fn=mock_embed)
+    retriever.add_raptor_node(
+        node_id="n1",
+        level=0,
+        text="Machine learning models",
+    )
+
+    node = retriever.unified_nodes["raptor_n1"]
+    assert node["embedding"] is None
+
+    # First retrieval computes and caches embedding
+    retriever.retrieve("Machine learning", top_k=5)
+    assert node["embedding"] is not None
+    assert isinstance(node["embedding"], np.ndarray)
+    initial_count = embed_count
+
+    # Second retrieval reuses cached embedding
+    retriever.retrieve("Machine learning", top_k=5)
+    # embed_count should increase by 1 for query vector only, not for node embedding
+    assert embed_count == initial_count + 1
+
+
+def test_top_k_zero_returns_empty_list():
+    """Verify that top_k == 0 returns an empty list immediately."""
+    retriever = HybridStructuredRetriever()
+    retriever.add_raptor_node(node_id="n1", level=0, text="Sample text")
+
+    assert retriever.retrieve("Sample", top_k=0) == []
+    assert retriever.retrieve("Sample", top_k=-1) == []
+
+
+def test_clamp_rrf_k():
+    """Verify that rrf_k is clamped with max(1, int(rrf_k))."""
+    retriever = HybridStructuredRetriever(rrf_k=0)
+    assert retriever.rrf_k == 1
+
+    retriever_neg = HybridStructuredRetriever(rrf_k=-10)
+    assert retriever_neg.rrf_k == 1
+
+    retriever.add_raptor_node(node_id="n1", level=0, text="Sample text")
+    results = retriever.retrieve("Sample", rrf_k=-5)
+    assert len(results) == 1
+    assert results[0].score > 0

--- a/tests/test_ch3_hybrid_structured_retriever.py
+++ b/tests/test_ch3_hybrid_structured_retriever.py
@@ -237,3 +237,19 @@ def test_deterministic_rrf_ranking():
     res1 = [r.node_id for r in retriever.retrieve("Common topic text", top_k=5)]
     res2 = [r.node_id for r in retriever.retrieve("Common topic text", top_k=5)]
     assert res1 == res2
+def test_index_raptor_nodes_id_zero():
+    """Verify node ID 0 is not dropped during index_raptor_nodes."""
+    retriever = HybridStructuredRetriever()
+    retriever.index_raptor_nodes([{"id": 0, "text": "Zero ID text", "summary": "Zero ID summary"}])
+    results = retriever.retrieve("Zero ID", top_k=1)
+    assert len(results) == 1
+    assert results[0].node_id == "0"
+
+
+def test_negative_rrf_k_parameter():
+    """Verify negative rrf_k override is safely clamped without division by zero."""
+    retriever = HybridStructuredRetriever()
+    retriever.add_raptor_node("node1", 0, "Quantum physics content", "Quantum physics summary")
+    results = retriever.retrieve("Quantum physics", top_k=1, rrf_k=-1)
+    assert len(results) == 1
+    assert results[0].score > 0

--- a/tests/test_ch3_hybrid_structured_retriever.py
+++ b/tests/test_ch3_hybrid_structured_retriever.py
@@ -273,3 +273,14 @@ def test_top_k_zero():
     retriever.add_raptor_node("node1", 0, "Quantum physics content", "Quantum physics summary")
     results = retriever.retrieve("Quantum physics", top_k=0)
     assert results == []
+
+def test_orthogonal_vector_scoring():
+    """Verify semantic_score is 0.0 (not replaced by coverage) when orthogonal vector embedding is evaluated."""
+    embedding_fn = lambda text: np.array([0.0, 1.0]) if text == "query" else np.array([1.0, 0.0])
+    retriever = HybridStructuredRetriever(embedding_fn=embedding_fn)
+    retriever.add_raptor_node("node1", 0, "query term content", "query term summary")
+    results = retriever.retrieve("query", top_k=1)
+    assert len(results) == 1
+    # Semantic score should be 0.0 for orthogonal vector
+    raw_score, lex_sc, sem_sc = retriever._compute_scores("query", {"query"}, np.array([0.0, 1.0]), retriever.unified_nodes["raptor_node1"])
+    assert sem_sc == 0.0

--- a/tests/test_ch3_hybrid_structured_retriever.py
+++ b/tests/test_ch3_hybrid_structured_retriever.py
@@ -284,3 +284,15 @@ def test_orthogonal_vector_scoring():
     # Semantic score should be 0.0 for orthogonal vector
     raw_score, lex_sc, sem_sc = retriever._compute_scores("query", {"query"}, np.array([0.0, 1.0]), retriever.unified_nodes["raptor_node1"])
     assert sem_sc == 0.0
+
+
+def test_vector_dimension_mismatch_fallback():
+    """Verify dimension mismatch during vector comparison safely falls back to coverage score."""
+    embedding_fn = lambda text: np.array([1.0, 0.0, 0.0])  # 3D query vector
+    retriever = HybridStructuredRetriever(embedding_fn=embedding_fn)
+    # Node contains 2D embedding vector
+    retriever.add_raptor_node("node1", 0, "query term content", "query term summary", embedding=np.array([1.0, 0.0]))
+    results = retriever.retrieve("query", top_k=1)
+    assert len(results) == 1
+    # Should fall back to lexical / coverage scoring without crashing
+    assert results[0].score > 0

--- a/tests/test_ch3_hybrid_structured_retriever.py
+++ b/tests/test_ch3_hybrid_structured_retriever.py
@@ -1,0 +1,163 @@
+"""Unit tests for chapter3/structured-index/hybrid_retriever.py (HybridStructuredRetriever)."""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+import pytest
+
+# Dynamic import for hyphenated module path
+_module_path = (
+    Path(__file__).resolve().parent.parent
+    / "chapter3"
+    / "structured-index"
+    / "hybrid_retriever.py"
+)
+_spec = importlib.util.spec_from_file_location("hybrid_retriever", _module_path)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["hybrid_retriever"] = _mod
+_spec.loader.exec_module(_mod)
+
+HybridStructuredRetriever = _mod.HybridStructuredRetriever
+SearchResult = _mod.SearchResult
+EvidenceCitation = _mod.EvidenceCitation
+
+
+def test_add_nodes_and_basic_retrieval():
+    """Verify RAPTOR nodes and GraphRAG entities can be added and retrieved."""
+    retriever = HybridStructuredRetriever(rrf_k=60)
+
+    # Add RAPTOR tree summary node
+    retriever.add_raptor_node(
+        node_id="r1",
+        level=2,
+        text="Deep learning architectures utilize multi-layer neural networks.",
+        summary="Overview of deep learning and multi-layer neural networks.",
+        children=["r1_1", "r1_2"],
+    )
+
+    # Add GraphRAG entity
+    retriever.add_graphrag_entity(
+        entity_id="e1",
+        name="Neural Network",
+        type="ARCHITECTURE",
+        description="A machine learning model inspired by biological neural circuits.",
+    )
+
+    # Add GraphRAG relationship
+    retriever.add_graphrag_relationship(
+        relation_id="rel1",
+        source="Neural Network",
+        target="Deep Learning",
+        type="USED_IN",
+        description="Neural networks serve as foundational models in deep learning.",
+    )
+
+    results = retriever.retrieve("deep learning neural network", top_k=5)
+
+    assert len(results) > 0
+    assert isinstance(results[0], SearchResult)
+    assert results[0].score > 0.0
+
+    # Verify citation details exist on all results
+    for res in results:
+        assert isinstance(res.citation, EvidenceCitation)
+        assert res.citation.source_type in (
+            "raptor_tree",
+            "graphrag_entity",
+            "graphrag_relation",
+            "graphrag_community",
+        )
+        assert len(res.citation.citation_label) > 0
+
+
+def test_rrf_scoring_order_and_fusion():
+    """Verify Reciprocal Rank Fusion combines RAPTOR and GraphRAG rankings."""
+    retriever = HybridStructuredRetriever(rrf_k=60)
+
+    # RAPTOR node relevant to quantum computing
+    retriever.add_raptor_node(
+        node_id="rap_quantum",
+        level=1,
+        text="Quantum algorithms exploit superposition and entanglement.",
+        summary="Quantum computing algorithms and superposition.",
+    )
+
+    # GraphRAG community summary relevant to quantum computing
+    retriever.add_graphrag_community(
+        community_id="comm_quantum",
+        entity_ids=["Qubit", "QuantumGate"],
+        summary="Community of quantum hardware components and quantum algorithms.",
+        level=0,
+    )
+
+    # Irrelevant node
+    retriever.add_raptor_node(
+        node_id="rap_gardening",
+        level=0,
+        text="Gardening tips for growing organic tomatoes in summer.",
+        summary="Organic tomato gardening guidance.",
+    )
+
+    results = retriever.retrieve("quantum algorithms superposition", top_k=2)
+
+    assert len(results) == 2
+    retrieved_ids = [r.node_id for r in results]
+
+    assert "rap_quantum" in retrieved_ids or "comm_quantum" in retrieved_ids
+    assert "rap_gardening" not in retrieved_ids
+
+    # Check top score calculation aligns with 1 / (60 + rank)
+    top_result = results[0]
+    assert top_result.score >= 1.0 / 61.0
+
+
+def test_bulk_ingest_objects_and_dicts():
+    """Verify index_raptor_nodes and index_graphrag_data accept lists of dicts or objects."""
+    retriever = HybridStructuredRetriever()
+
+    raptor_nodes = [
+        {
+            "id": "r_node_10",
+            "level": 3,
+            "text": "Tree root summary of agent memory systems.",
+            "summary": "Agent memory hierarchy overview.",
+        }
+    ]
+
+    graph_entities = [
+        {
+            "id": "entity_agent",
+            "name": "Autonomous Agent",
+            "type": "CONCEPT",
+            "description": "An entity that perceives its environment and takes actions.",
+        }
+    ]
+
+    graph_relations = [
+        {
+            "id": "rel_mem",
+            "source": "Autonomous Agent",
+            "target": "Memory Store",
+            "type": "HAS_COMPONENT",
+            "description": "Agents rely on structured memory stores.",
+        }
+    ]
+
+    retriever.index_raptor_nodes(raptor_nodes)
+    retriever.index_graphrag_data(entities=graph_entities, relationships=graph_relations)
+
+    results = retriever.retrieve("agent memory", top_k=3)
+    assert len(results) == 3
+
+
+def test_empty_query_and_edge_cases():
+    """Verify empty queries return empty results and custom top_k bounds are respected."""
+    retriever = HybridStructuredRetriever()
+    retriever.add_raptor_node("1", 0, "Test content", "Test summary")
+
+    assert retriever.retrieve("") == []
+    assert retriever.retrieve("   ") == []
+
+    res = retriever.retrieve("Test", top_k=1)
+    assert len(res) <= 1

--- a/tests/test_ch3_hybrid_structured_retriever.py
+++ b/tests/test_ch3_hybrid_structured_retriever.py
@@ -5,6 +5,7 @@ import os
 import sys
 from pathlib import Path
 import pytest
+import numpy as np
 
 # Dynamic import for hyphenated module path
 _module_path = (
@@ -161,3 +162,78 @@ def test_empty_query_and_edge_cases():
 
     res = retriever.retrieve("Test", top_k=1)
     assert len(res) <= 1
+def test_relationship_target_matching():
+    """Verify GraphRAG relationships match queries matching the target entity name."""
+    retriever = HybridStructuredRetriever()
+    retriever.add_graphrag_relationship(
+        relation_id="rel_target",
+        source="TransformerModel",
+        target="AttentionMechanism",
+        type="USES",
+        description="Transformer models rely heavily on self-attention.",
+    )
+
+    results = retriever.retrieve("AttentionMechanism", top_k=1)
+    assert len(results) == 1
+    assert results[0].node_id == "rel_target"
+
+
+def test_integer_ids_and_children_type_safety():
+    """Verify integer children and entity_ids do not raise TypeError during citation building."""
+    retriever = HybridStructuredRetriever()
+    retriever.add_raptor_node(node_id="100", level=1, text="Text", children=[101, 102])
+    retriever.add_graphrag_community(community_id="200", entity_ids=[201, 202], summary="Summary")
+
+    results = retriever.retrieve("Text Summary", top_k=2)
+    assert len(results) == 2
+    for res in results:
+        assert isinstance(res.citation.lineage[0], str)
+
+
+def test_embedding_caching():
+    """Verify embedding_fn output is cached on the node dictionary."""
+    call_count = 0
+
+    def mock_embed(text: str):
+        nonlocal call_count
+        call_count += 1
+        return np.ones(8, dtype=np.float32)
+
+    retriever = HybridStructuredRetriever(embedding_fn=mock_embed)
+    retriever.add_raptor_node(node_id="embed_node", level=0, text="Embedding test text")
+
+    # First retrieval computes embedding
+    res1 = retriever.retrieve("Embedding test", top_k=1)
+    first_calls = call_count
+    assert first_calls > 0
+
+    # Second retrieval reuses cached embedding without re-invoking embedding_fn for the node
+    res2 = retriever.retrieve("Embedding test", top_k=1)
+    assert call_count == first_calls + 1  # Only +1 for the query embedding
+
+
+def test_precision_bounds_with_repeated_words():
+    """Verify precision score is bounded <= 1.0 even when text contains repeated query terms."""
+    retriever = HybridStructuredRetriever()
+    retriever.add_raptor_node(
+        node_id="rep_node",
+        level=0,
+        text="apple apple apple apple apple apple apple apple",
+        summary="apple apple apple",
+    )
+
+    results = retriever.retrieve("apple", top_k=1)
+    assert len(results) == 1
+    assert results[0].score <= 1.0
+
+
+def test_deterministic_rrf_ranking():
+    """Verify RRF results order is 100% deterministic across multiple invocations."""
+    retriever = HybridStructuredRetriever()
+    for i in range(10):
+        retriever.add_raptor_node(f"r_{i}", 0, f"Common topic text item {i}", f"Summary {i}")
+        retriever.add_graphrag_entity(f"e_{i}", f"Entity {i}", "CONCEPT", f"Common topic text item {i}")
+
+    res1 = [r.node_id for r in retriever.retrieve("Common topic text", top_k=5)]
+    res2 = [r.node_id for r in retriever.retrieve("Common topic text", top_k=5)]
+    assert res1 == res2

--- a/tests/test_ch3_hybrid_structured_retriever.py
+++ b/tests/test_ch3_hybrid_structured_retriever.py
@@ -253,3 +253,23 @@ def test_negative_rrf_k_parameter():
     results = retriever.retrieve("Quantum physics", top_k=1, rrf_k=-1)
     assert len(results) == 1
     assert results[0].score > 0
+
+
+def test_index_graphrag_data_none_id_fallback():
+    """Verify items with explicit id=None fall back to entity_id/relation_id/community_id."""
+    retriever = HybridStructuredRetriever()
+    retriever.index_graphrag_data(
+        entities=[{"id": None, "entity_id": "ent_1", "name": "Entity 1", "description": "GraphRAG entity test"}],
+        relationships=[{"id": None, "relation_id": "rel_1", "source": "A", "target": "B", "description": "GraphRAG relation test"}],
+        communities=[{"id": None, "community_id": "comm_1", "entity_ids": ["ent_1"], "summary": "GraphRAG community test"}],
+    )
+    res = retriever.retrieve("GraphRAG test", top_k=5)
+    assert len(res) == 3
+
+
+def test_top_k_zero():
+    """Verify top_k=0 returns empty results list."""
+    retriever = HybridStructuredRetriever()
+    retriever.add_raptor_node("node1", 0, "Quantum physics content", "Quantum physics summary")
+    results = retriever.retrieve("Quantum physics", top_k=0)
+    assert results == []

--- a/tests/test_ch3_hybrid_structured_retriever.py
+++ b/tests/test_ch3_hybrid_structured_retriever.py
@@ -5,6 +5,8 @@ import os
 import sys
 from pathlib import Path
 import pytest
+
+pytest.importorskip("numpy")
 import numpy as np
 
 # Dynamic import for hyphenated module path

--- a/tests/test_ch3_hybrid_structured_retriever.py
+++ b/tests/test_ch3_hybrid_structured_retriever.py
@@ -296,3 +296,87 @@ def test_vector_dimension_mismatch_fallback():
     assert len(results) == 1
     # Should fall back to lexical / coverage scoring without crashing
     assert results[0].score > 0
+
+
+def test_results_merged_by_score_not_source():
+    """Verify results are ranked by score, not interleaved by source type (Finding 1)."""
+    retriever = HybridStructuredRetriever()
+    # Two RAPTOR nodes with strong lexical match
+    retriever.add_raptor_node("rap_a", 0, "alpha beta gamma", "alpha beta gamma summary")
+    retriever.add_raptor_node("rap_b", 0, "alpha beta delta", "alpha beta delta summary")
+    # One GraphRAG entity with weaker match
+    retriever.add_graphrag_entity("ent_weak", "alpha", "CONCEPT", "alpha description")
+
+    results = retriever.retrieve("alpha beta gamma", top_k=3)
+    # Top two results should both be RAPTOR nodes (higher lexical match), not interleaved
+    assert results[0].source_type == "raptor_tree"
+    assert results[1].source_type == "raptor_tree"
+    # Scores must be in descending order
+    assert results[0].score >= results[1].score >= results[2].score
+
+
+def test_negative_vector_similarity_clamped_to_zero():
+    """Verify negative cosine similarity is clamped to 0, not ranked above positive text relevance (Finding 10)."""
+    # Embedding that produces negative cosine similarity for node text (no "query" in it)
+    def mock_embed(text: str) -> np.ndarray:
+        if "query" in text.lower():
+            return np.array([1.0, 0.0])
+        return np.array([-1.0, 0.0])  # Opposite direction → cos_sim = -1.0
+
+    retriever = HybridStructuredRetriever(embedding_fn=mock_embed)
+    # Node text must NOT contain "query" so mock_embed returns the opposite vector
+    retriever.add_raptor_node("neg_node", 0, "term content", "term summary")
+
+    _, _, sem_sc = retriever._compute_scores(
+        "query term", {"query", "term"}, np.array([1.0, 0.0]), retriever.unified_nodes["raptor_neg_node"]
+    )
+    # Semantic score must be clamped to 0.0, not negative
+    assert sem_sc == 0.0
+    assert sem_sc >= 0.0
+
+
+def test_mixed_vector_presence_consistent_scoring():
+    """Verify nodes with and without vectors are scored on a consistent scale (Finding 11)."""
+    def mock_embed(text: str) -> np.ndarray:
+        if "fail" in text.lower():
+            raise ValueError("cannot embed")
+        return np.array([1.0, 0.0])
+
+    retriever = HybridStructuredRetriever(embedding_fn=mock_embed)
+    # Node A: has a pre-computed embedding aligned with query vector
+    retriever.add_raptor_node(
+        "node_a", 0, "common topic text", "common topic text",
+        embedding=np.array([1.0, 0.0]),
+    )
+    # Node B: no pre-computed embedding; embedding_fn raises → falls back to lexical-only
+    retriever.add_raptor_node(
+        "node_b", 0, "fail common topic text", "fail common topic text",
+    )
+
+    results = retriever.retrieve("common topic", top_k=2)
+    assert len(results) == 2
+    # Both nodes should have positive scores (lexical match exists for both)
+    for res in results:
+        assert res.score > 0
+    # Node A (has vector, aligned) should rank higher than Node B (no vector, lexical-only fallback)
+    assert results[0].node_id == "node_a"
+
+
+def test_parent_id_zero_preserved_in_citation():
+    """Verify parent ID 0 is not dropped from citation lineage (Finding 12)."""
+    retriever = HybridStructuredRetriever()
+    retriever.add_raptor_node(
+        node_id="child_1",
+        level=1,
+        text="Child node content",
+        summary="Child node summary",
+        parent=0,
+    )
+
+    results = retriever.retrieve("Child node", top_k=1)
+    assert len(results) == 1
+    citation = results[0].citation
+    # Parent ID 0 must appear in lineage, not be dropped by truthiness check
+    parent_entries = [lin for lin in citation.lineage if lin.startswith("Parent:")]
+    assert len(parent_entries) == 1
+    assert "0" in parent_entries[0]


### PR DESCRIPTION
## Summary

Adds a hybrid structured retriever that merges RAPTOR hierarchical tree nodes and GraphRAG knowledge graph summaries into a unified retrieval index.

## Changes

- **`chapter3/structured-index/hybrid_retriever.py`** — `HybridStructuredRetriever` performs Reciprocal Rank Fusion (RRF) scoring across RAPTOR tree summary nodes and GraphRAG entity-relation-community summaries. Evidence citation tracking records source type, hierarchical level, entity/relation type, and lineage. No-vector fallback uses 0.8 lexical weight when embeddings are unavailable.
- **`chapter3/structured-index/test_hybrid_retriever.py`** — Co-located test module.
- **`tests/test_ch3_hybrid_structured_retriever.py`** — 19 tests covering RRF fusion, citation tracking, no-vector fallback, and edge cases.