### PR TITLE
fix(ch4-async): add explicit protocol-to-gate coverage mapping

### DIFF
--- a/chapter4/async-agent/run_real_experiment.py
+++ b/chapter4/async-agent/run_real_experiment.py
@@ -267,6 +267,28 @@ def real_task(receipt: dict[str, Any]) -> bool:
 
 
 def derive_acceptance(scenarios: list[dict[str, Any]], protocol: dict[str, Any]) -> dict[str, Any]:
+    # Explicit mapping from protocol acceptance keys to the gate keys that
+    # enforce them. This prevents silent drift: adding a key to the protocol's
+    # acceptance block without a corresponding gate entry raises an assertion
+    # at run time, and removing a gate key leaves a dangling reference that
+    # the coverage check also catches.
+    PROTOCOL_TO_GATE: dict[str, str | tuple[str, ...]] = {
+        "long_job_at_least_three_seconds": "scenario_1_nonblocking_and_immediate_response",
+        "placeholder_return_is_nonblocking": "scenario_1_nonblocking_and_immediate_response",
+        "all_terminal_jobs_are_real_subprocesses": "real_subprocess_receipts_only",
+        "cancelled_jobs_have_os_return_codes": "scenario_3_os_process_cancelled_then_recovered",
+        "completed_jobs_have_stdout_and_input_hashes": "real_subprocess_receipts_only",
+        "all_artifacts_are_hash_manifested": (
+            "scenario_2_japanese_html_artifact",
+            "scenario_4_integrated_report_hashed",
+        ),
+        "no_simulated_terminal_result_can_pass": "real_subprocess_receipts_only",
+    }
+    protocol_acceptance = protocol.get("acceptance", {})
+    missing = set(protocol_acceptance) - set(PROTOCOL_TO_GATE)
+    assert not missing, (
+        f"protocol acceptance keys not covered by PROTOCOL_TO_GATE: {missing}"
+    )
     by_id = {row["id"]: row for row in scenarios}
     one = by_id.get("async_command_and_immediate_question", {})
     two = by_id.get("queued_batch_to_japanese_html", {})
@@ -328,7 +350,28 @@ def derive_acceptance(scenarios: list[dict[str, Any]], protocol: dict[str, Any])
             and len(four.get("artifact", {}).get("sha256", "")) == 64
         ),
     }
+    # Verify that every referenced gate key actually exists.
+    referenced_gate_keys = set()
+    for gate_spec in PROTOCOL_TO_GATE.values():
+        if isinstance(gate_spec, str):
+            referenced_gate_keys.add(gate_spec)
+        else:
+            referenced_gate_keys.update(gate_spec)
+    dangling = referenced_gate_keys - set(gates)
+    assert not dangling, (
+        f"PROTOCOL_TO_GATE references gate keys that do not exist: {dangling}"
+    )
+    # Compute per-protocol-key coverage so an auditor can mechanically verify
+    # that every acceptance declaration is enforced by at least one gate.
+    protocol_coverage: dict[str, Any] = {}
+    for proto_key, gate_spec in PROTOCOL_TO_GATE.items():
+        gate_keys = (gate_spec,) if isinstance(gate_spec, str) else gate_spec
+        protocol_coverage[proto_key] = {
+            "enforced_by": list(gate_keys),
+            "all_gates_passed": all(gates.get(gk, False) for gk in gate_keys),
+        }
     return {"status": "passed" if all(gates.values()) else "failed", "gates": gates,
+            "protocol_coverage": protocol_coverage,
             "protocol_sha256": sha256(canonical_json(protocol))}
 
 

--- a/chapter4/async-agent/test_real_experiment.py
+++ b/chapter4/async-agent/test_real_experiment.py
@@ -50,3 +50,55 @@ def test_empty_evidence_fails_closed():
     acceptance = runner.derive_acceptance([], protocol)
     assert acceptance["status"] == "failed"
     assert not any(acceptance["gates"].values())
+
+
+
+def test_protocol_coverage_mapping_is_complete_and_enforced():
+    """Every protocol acceptance key must map to at least one gate, and the
+    coverage report must reflect gate pass/fail status correctly."""
+    scenarios, protocol = _campaign()
+    acceptance = runner.derive_acceptance(scenarios, protocol)
+    coverage = acceptance["protocol_coverage"]
+    # Every protocol acceptance key must appear in the coverage report.
+    protocol_keys = set(protocol.get("acceptance", {}))
+    assert set(coverage) == protocol_keys, (
+        f"coverage keys {set(coverage)} != protocol keys {protocol_keys}"
+    )
+    # Every coverage entry must reference at least one gate key.
+    for proto_key, entry in coverage.items():
+        assert len(entry["enforced_by"]) >= 1, f"{proto_key} has no enforcing gate"
+    # When all gates pass, every coverage entry must report all_gates_passed=True.
+    if acceptance["status"] == "passed":
+        assert all(entry["all_gates_passed"] for entry in coverage.values())
+
+
+def test_protocol_coverage_detects_unmapped_acceptance_key():
+    """Adding an acceptance key to the protocol without a PROTOCOL_TO_GATE
+    mapping must raise an assertion at run time."""
+    scenarios, protocol = _campaign()
+    tampered_protocol = copy.deepcopy(protocol)
+    tampered_protocol["acceptance"]["bogus_unmapped_key"] = "must be enforced"
+    try:
+        runner.derive_acceptance(scenarios, tampered_protocol)
+    except AssertionError as exc:
+        assert "bogus_unmapped_key" in str(exc)
+    else:
+        raise AssertionError("expected AssertionError for unmapped acceptance key")
+
+
+def test_protocol_coverage_reflects_gate_failure():
+    """When a gate fails, the coverage entries that depend on it must report
+    all_gates_passed=False."""
+    scenarios, protocol = _campaign()
+    tampered = copy.deepcopy(scenarios)
+    tampered[0]["tasks"][0]["executable"]["mode"] = "simulated"
+    acceptance = runner.derive_acceptance(tampered, protocol)
+    coverage = acceptance["protocol_coverage"]
+    # real_subprocess_receipts_only gate should have failed.
+    assert not acceptance["gates"]["real_subprocess_receipts_only"]
+    # Every protocol key enforced by that gate must report failure.
+    for proto_key, entry in coverage.items():
+        if "real_subprocess_receipts_only" in entry["enforced_by"]:
+            assert not entry["all_gates_passed"], (
+                f"{proto_key} should report gate failure"
+            )


### PR DESCRIPTION
## Summary

Fixes #802.

`derive_acceptance()` in `chapter4/async-agent/run_real_experiment.py` produced gate keys that did not mechanically correspond to the protocol's acceptance declarations. Adding a new acceptance key to `experiment_protocol.json` would silently pass without any gate enforcing it.

## Changes

- Added `PROTOCOL_TO_GATE` mapping that explicitly links each protocol acceptance key to the gate key(s) that enforce it
- Two assertions prevent drift:
  - Missing protocol keys (in protocol but not in mapping) raise at run time
  - Dangling gate references (in mapping but not in gates dict) raise at run time
- The acceptance result now includes a `protocol_coverage` dict so an auditor can mechanically verify every acceptance declaration is enforced

## Tests

3 regression tests added:
- `test_protocol_coverage_mapping_is_complete_and_enforced` — verifies every protocol key maps to at least one gate
- `test_protocol_coverage_detects_unmapped_acceptance_key` — adding an unmapped key raises `AssertionError`
- `test_protocol_coverage_reflects_gate_failure` — when a gate fails, dependent coverage entries report `all_gates_passed=False`

All 6 tests in `test_real_experiment.py` pass.