### PR TITLE
fix(en): restore chapter 3 knowledge map

### DIFF
--- a/book-en/images/fig3-1.svg
+++ b/book-en/images/fig3-1.svg
@@ -1,52 +1,26 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 860 540" width="860" height="540" style="background:#ffffff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 920 400" width="920" height="400" style="background:#ffffff">
 <defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="30" y="70" width="800" height="130" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="80" y="90" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">RAG Basics</text>
-<rect x="50" y="108" width="160" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="130.0" y="133.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Dense Embedding</text>
-<text x="130" y="176" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Word2Vec → BGE-M3</text>
-<rect x="230" y="108" width="160" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="310.0" y="122.6" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Sparse</text>
-<text x="310.0" y="143.4" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Embedding</text>
-<text x="310" y="176" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">TF-IDF / BM25</text>
-<rect x="410" y="108" width="160" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="490.0" y="122.6" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Hybrid Retrieval +</text>
-<text x="490.0" y="143.4" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Reranking</text>
-<text x="490" y="176" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Two-tower Retrieval + Cross-Encoder</text>
-<rect x="650" y="108" width="160" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="730.0" y="122.6" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Multimodal</text>
-<text x="730.0" y="143.4" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Extraction</text>
-<text x="730" y="176" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Native / Text / Tool</text>
-<line x1="430.0" y1="200" x2="430.0" y2="230" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="30" y="230" width="800" height="100" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="80" y="250" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">Learning from Existing Knowledge</text>
-<rect x="50" y="265" width="160" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="130.0" y="283.725" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">RAPTOR</text>
-<text x="130.0" y="301.27500000000003" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Tree Hierarchical Index</text>
-<rect x="230" y="265" width="160" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="310.0" y="283.075" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">GraphRAG</text>
-<text x="310.0" y="301.925" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Entity Relation Graph</text>
-<rect x="410" y="265" width="160" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="490.0" y="282.1" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Agentic RAG</text>
-<text x="490.0" y="302.90000000000003" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal"> Retrieval as Tool</text>
-<rect x="590" y="265" width="160" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="670.0" y="276.25" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Context-Aware Retrieval</text>
-<text x="670.0" y="292.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Prefix Summary</text>
-<text x="670.0" y="308.75" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Enhancement</text>
-<line x1="430.0" y1="330" x2="430.0" y2="360" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="30" y="360" width="800" height="100" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="80" y="380" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">Learning from Autonomous Exploration</text>
-<rect x="100" y="395" width="200" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="200.0" y="412.1" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Post-training</text>
-<text x="200.0" y="432.90000000000003" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal"> RL → Muscle Memory</text>
-<rect x="330" y="395" width="200" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="430.0" y="413.4" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">In-Context Learning</text>
-<text x="430.0" y="431.59999999999997" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Inference-time Soft Retrieval</text>
-<rect x="560" y="395" width="200" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="660.0" y="406.25" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Externalized Learning</text>
-<text x="660.0" y="422.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Knowledge Base + Tool</text>
-<text x="660.0" y="438.75" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Generation</text>
-<rect x="180" y="490" width="500" height="44" rx="6" fill="#999999" stroke="#333333" stroke-width="2"/>
-<text x="430.0" y="512" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#ffffff" text-anchor="middle" dominant-baseline="central" font-weight="bold">Bitter Lesson: Search + Learning = General Method</text>
-<line x1="430.0" y1="460" x2="430.0" y2="488" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="40" y="70" width="400" height="46" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="240" y="93" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">User Memory (Individual Scale)</text>
+<rect x="480" y="70" width="400" height="46" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="680" y="93" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Knowledge Base (Group Scale)</text>
+<rect x="40" y="128" width="400" height="158" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="60" y="156" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">· Memory Hierarchy · Three-Level Evaluation</text>
+<text x="60" y="184" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">· Four Storage Formats</text>
+<text x="60" y="212" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">· Cognitive Types: Episodic · Semantic · Procedural</text>
+<text x="60" y="240" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">· Memory Frameworks: Mem0 · Memobase</text>
+<text x="60" y="268" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">· Compression &amp; Consolidation · Privacy Grading</text>
+<rect x="480" y="128" width="400" height="158" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="500" y="156" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">· Document Chunking · Multimodal Extraction</text>
+<text x="500" y="184" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">· Dense/Sparse Embeddings · Hybrid Retrieval</text>
+<text x="500" y="212" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">· Structured Indexing: RAPTOR · GraphRAG</text>
+<text x="500" y="240" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">· File System Paradigm · Agentic RAG</text>
+<text x="500" y="268" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">· Contextual Retrieval · Deep Knowledge Extraction</text>
+<line x1="240" y1="320" x2="240" y2="288" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
+<line x1="680" y1="320" x2="680" y2="288" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
+<rect x="40" y="322" width="840" height="50" rx="6" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="460" y="340" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Shared Foundation: Retrieval Techniques</text>
+<text x="460" y="360" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Document Chunking · Vector/Keyword Embeddings · Hybrid Retrieval · Re-ranking</text>
+<text x="460" y="397" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">The two threads ultimately converge in a "Dual-Layer Memory Architecture":</text>
+<text x="460" y="414" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Advanced JSON Cards keep the overview resident; contextual retrieval fetches details on demand.</text>
 </svg>


### PR DESCRIPTION
## Summary

- replace the incorrect RAG-focused Figure 3-1 with the English chapter knowledge map matching the Chinese source
- adjust the SVG labels and wrap the concluding text to prevent clipping in rendered output

## Root cause

A previous figure-layout update accidentally replaced `book-en/images/fig3-1.svg` with an unrelated RAG and learning diagram, while Chapter 3 still identifies Figure 3-1 as the chapter knowledge map.

## Impact

The next English PDF build will display the correct chapter overview for Figure 3-1.

## Validation

- `xmllint --noout book-en/images/fig3-1.svg`
- `git diff --check`
- rendered the SVG with `rsvg-convert` and visually checked the 920×400 output

Fixes #815