### PR TITLE
fix(en): realign and proofread Chapter 3 figures

### DIFF
--- a/book-en/images/fig3-10.svg
+++ b/book-en/images/fig3-10.svg
@@ -1,44 +1,47 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 460" width="880" height="460" style="background:#ffffff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 800 400" width="800" height="400" style="background:#ffffff">
 <defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="220" y="55" width="440" height="200" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2"/>
-<text x="440" y="78" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Agent (ReAct Loop)</text>
-<rect x="240" y="100" width="180" height="45" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="330.0" y="122.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">① Thought</text>
-<rect x="460" y="100" width="180" height="45" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="550.0" y="122.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">② Action</text>
-<rect x="350" y="180" width="180" height="45" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="440.0" y="202.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">③ Observation</text>
-<line x1="420" y1="122" x2="458" y2="122" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="640" y1="130" x2="530" y2="178" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="350" y1="202" x2="280" y2="145" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<text x="360" y="165" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Loop until information is sufficient</text>
-<rect x="20" y="95" width="160" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="100.0" y="122.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">User query</text>
-<line x1="180" y1="122" x2="218" y2="122" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="700" y="95" width="160" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="780.0" y="122.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Final answer</text>
-<line x1="660" y1="122" x2="698" y2="122" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="100" y="290" width="680" height="85" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="440" y="312" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Tool layer</text>
-<rect x="120" y="330" width="220" height="35" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="230.0" y="347" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="middle" dominant-baseline="central">knowledge_base_search</text>
-<rect x="370" y="330" width="140" height="35" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="440.0" y="347" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="middle" dominant-baseline="central">web_search</text>
-<rect x="540" y="330" width="160" height="35" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="620.0" y="347" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="middle" dominant-baseline="central">code_interpreter</text>
-<line x1="440" y1="255" x2="440" y2="288" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="440" y1="288" x2="440" y2="255" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="100" y="400" width="680" height="85" rx="6" fill="#ffffff" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="440" y="420" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Knowledge base backend (switchable)</text>
-<rect x="120" y="435" width="180" height="45" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="210.0" y="447.75" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">retrieval-pipeline</text>
-<text x="210.0" y="467.25" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Hybrid retrieval</text>
-<rect x="340" y="435" width="180" height="45" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="430.0" y="447.75" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">structured-index</text>
-<text x="430.0" y="467.25" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">RAPTOR/GraphRAG</text>
-<rect x="560" y="435" width="180" height="45" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="650.0" y="447.75" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">contextual-retrieval</text>
-<text x="650.0" y="467.25" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Context-aware</text>
-<line x1="230" y1="365" x2="230" y2="398" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="440" y1="375" x2="440" y2="398" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="300" y="55" width="200" height="50" rx="6" fill="#999999" stroke="#333333" stroke-width="2"/>
+<text x="400.0" y="80.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Global Summary</text>
+<text x="515" y="80" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">← Root Node</text>
+<rect x="80" y="150" width="160" height="48" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="160.0" y="174.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="17" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Cluster Summary A</text>
+<rect x="320" y="150" width="160" height="48" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="400.0" y="174.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="17" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Cluster Summary B</text>
+<rect x="560" y="150" width="160" height="48" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="640.0" y="174.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="17" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Cluster Summary C</text>
+<line x1="400" y1="105" x2="160" y2="150" stroke="#333333" stroke-width="2"/>
+<line x1="400" y1="105" x2="400" y2="150" stroke="#333333" stroke-width="2"/>
+<line x1="400" y1="105" x2="640" y2="150" stroke="#333333" stroke-width="2"/>
+<text x="35" y="230" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">Middle Layer ↑</text>
+<rect x="40" y="250" width="88" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="84.0" y="270.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Text Chunk 1</text>
+<line x1="84.0" y1="250" x2="160" y2="198" stroke="#999999" stroke-width="2"/>
+<rect x="140" y="250" width="88" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="184.0" y="270.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Text Chunk 2</text>
+<line x1="184.0" y1="250" x2="160" y2="198" stroke="#999999" stroke-width="2"/>
+<rect x="240" y="250" width="88" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="284.0" y="270.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Text Chunk 3</text>
+<line x1="284.0" y1="250" x2="160" y2="198" stroke="#999999" stroke-width="2"/>
+<rect x="360" y="250" width="88" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="404.0" y="270.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Text Chunk 4</text>
+<line x1="404.0" y1="250" x2="400" y2="198" stroke="#999999" stroke-width="2"/>
+<rect x="460" y="250" width="88" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="504.0" y="270.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Text Chunk 5</text>
+<line x1="504.0" y1="250" x2="400" y2="198" stroke="#999999" stroke-width="2"/>
+<rect x="560" y="250" width="88" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="604.0" y="270.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Text Chunk 6</text>
+<line x1="604.0" y1="250" x2="640" y2="198" stroke="#999999" stroke-width="2"/>
+<rect x="660" y="250" width="88" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="704.0" y="270.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Text Chunk 7</text>
+<line x1="704.0" y1="250" x2="640" y2="198" stroke="#999999" stroke-width="2"/>
+<text x="35" y="295" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">Leaf Layer ↑</text>
+<rect x="40" y="320" width="720" height="55" rx="6" fill="#ffffff" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
+<text x="400" y="340" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Original Document</text>
+<rect x="60" y="350" width="90" height="16" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<rect x="170" y="350" width="90" height="16" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<rect x="280" y="350" width="90" height="16" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<rect x="390" y="350" width="90" height="16" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<rect x="500" y="350" width="90" height="16" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<rect x="610" y="350" width="90" height="16" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="400.0" y="420" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Bottom-up Recursive Abstraction: Details → Topics → Global Overview</text>
 </svg>

--- a/book-en/images/fig3-11.svg
+++ b/book-en/images/fig3-11.svg
@@ -1,35 +1,33 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 390" width="880" height="390" style="background:#ffffff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 860 390" width="860" height="390" style="background:#ffffff">
 <defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="20" y="55" width="400" height="170" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2"/>
-<text x="220" y="78" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Traditional chunking (no context)</text>
-<rect x="40" y="95" width="360" height="50" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
-<text x="50" y="112" font-family="'Courier New', Courier, monospace" font-size="11.5" fill="#333333" text-anchor="start" dominant-baseline="central">The company's second-quarter revenue grew by 3%,</text>
-<text x="50" y="132" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">mainly driven by new product lines.</text>
-<text x="220" y="170" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Question: &quot;Who is &quot;the company&quot;? Which year?</text>
-<text x="220" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ Retrieval matches revenue data of many irrelevant companies</text>
-<rect x="460" y="55" width="400" height="170" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2"/>
-<text x="660" y="78" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Context-aware chunking</text>
-<rect x="480" y="95" width="360" height="35" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="490" y="113" font-family="'Courier New', Courier, monospace" font-size="8.5" fill="#333333" text-anchor="start" dominant-baseline="central">[ACME Company 2025 Q2 Earnings Report · Key Performance Indicators]</text>
-<rect x="480" y="130" width="360" height="50" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
-<text x="490" y="148" font-family="'Courier New', Courier, monospace" font-size="11.5" fill="#333333" text-anchor="start" dominant-baseline="central">The company's second-quarter revenue grew by 3%,</text>
-<text x="490" y="168" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">mainly driven by new product lines.</text>
-<text x="660" y="200" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ Exact match ACME + Q2 + revenue growth</text>
-<text x="440" y="140" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="24" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">→</text>
-<line x1="20" y1="250" x2="860" y2="250" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="440.0" y="275" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Indexing stage: LLM generates context prefix</text>
-<rect x="30" y="300" width="180" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="120.0" y="327.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Original document</text>
-<line x1="210" y1="327" x2="248" y2="327" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="250" y="300" width="180" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="340.0" y="327.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Chunking</text>
-<line x1="430" y1="327" x2="468" y2="327" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="470" y="300" width="180" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="560.0" y="317.1" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">LLM generates prefix</text>
-<text x="560.0" y="337.90000000000003" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">(prompt caching)</text>
-<line x1="650" y1="327" x2="688" y2="327" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="690" y="300" width="170" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="775.0" y="317.1" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Prefix + original text</text>
-<text x="775.0" y="337.90000000000003" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">→ Index</text>
-<text x="440.0" y="410" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Effect: Retrieval failure rate ↓49% (+BM25), ↓67% (+reranking) — Anthropic data</text>
+<rect x="30" y="185" width="110" height="56" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="85.0" y="213.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">User</text>
+<rect x="250" y="95" width="168" height="56" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="334.0" y="114.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Dr. Zhang-A</text>
+<text x="334.0" y="135.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Department: Dentistry</text>
+<rect x="470" y="95" width="150" height="56" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="545.0" y="123.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="10.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Renai Stomatology Hospital</text>
+<rect x="680" y="95" width="150" height="56" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="755.0" y="114.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Address</text>
+<text x="755.0" y="135.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">XX Road, Xuhui District</text>
+<rect x="250" y="280" width="168" height="56" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="334.0" y="299.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Dr. Zhang-B</text>
+<text x="334.0" y="320.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Department: Cardiology</text>
+<rect x="470" y="280" width="180" height="56" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="560.0" y="299.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Huashan Hospital</text>
+<text x="560.0" y="320.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Cardiovascular Center</text>
+<line x1="140" y1="205" x2="250" y2="128" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<text x="195.0" y="156.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle">My Dentist</text>
+<line x1="140" y1="222" x2="250" y2="300" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<text x="195.0" y="251.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle">My Cardiologist</text>
+<line x1="418" y1="123" x2="470" y2="123" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<text x="444.0" y="110.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12" fill="#666666" text-anchor="middle">Works at</text>
+<line x1="620" y1="123" x2="680" y2="123" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<text x="650.0" y="110.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12" fill="#666666" text-anchor="middle">Address</text>
+<line x1="418" y1="308" x2="470" y2="308" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<text x="444.0" y="295.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12" fill="#666666" text-anchor="middle">Works at</text>
+<text x="40" y="365" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">· Multi-hop reasoning: “Address of the hospital where my dentist works” follows</text>
+<text x="55" y="381" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">User → Dr. Zhang-A → Renai Stomatology Hospital → Address.</text>
+<text x="40" y="402" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">· Entity disambiguation: relation edges distinguish the two “Dr. Zhang” nodes.</text>
+<text x="55" y="418" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">Each edge is a subject–relation–object triple.</text>
 </svg>

--- a/book-en/images/fig3-12.svg
+++ b/book-en/images/fig3-12.svg
@@ -1,41 +1,32 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 470" width="880" height="470" style="background:#ffffff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 900 340" width="900" height="340" style="background:#ffffff">
 <defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="20" y="55" width="840" height="200" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2"/>
-<text x="440" y="78" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Phase 1: Knowledge extraction and structuring</text>
-<rect x="40" y="95" width="180" height="65" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
-<text x="130" y="113" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Original judgment documents</text>
-<text x="50" y="138" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">CAIL2018 dataset</text>
-<line x1="220" y1="127" x2="258" y2="127" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="260" y="95" width="180" height="65" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="350" y="113" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">LLM factor discovery</text>
-<text x="350" y="138" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Bottom-up Schema</text>
-<line x1="440" y1="127" x2="478" y2="127" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="480" y="95" width="200" height="65" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
-<text x="580" y="113" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Structured JSON</text>
-<text x="490" y="138" font-family="'Courier New', Courier, monospace" font-size="6.5" fill="#333333" text-anchor="start" dominant-baseline="central">{voluntary_surrender:true, compensation:500000,</text>
-<text x="490" y="155" font-family="'Courier New', Courier, monospace" font-size="8.5" fill="#333333" text-anchor="start" dominant-baseline="central"> injury_level:severe_second_degree}</text>
-<rect x="40" y="170" width="400" height="70" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="240" y="188" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Modular data schema</text>
-<text x="240" y="212" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="9" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Core schema (voluntary surrender/compensation/criminal record) + charge extension schema</text>
-<text x="240" y="232" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">(theft→amount involved, injury→injury level)</text>
-<rect x="20" y="270" width="840" height="200" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2"/>
-<text x="440" y="293" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Phase 2: Factor analysis and knowledge modeling</text>
-<rect x="40" y="310" width="200" height="65" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="140" y="328" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Feature vectorization</text>
-<text x="140" y="350" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">One-hot encoding + multi-hot encoding</text>
-<text x="140" y="370" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">+ log transformation + standardization</text>
-<line x1="240" y1="342" x2="278" y2="342" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="280" y="310" width="200" height="65" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="380" y="328" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">HDBSCAN clustering</text>
-<text x="380" y="350" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">discover &quot;case prototype&quot;</text>
-<text x="380" y="370" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">e.g., minor quarrel → minor injury</text>
-<line x1="480" y1="342" x2="518" y2="342" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="520" y="310" width="200" height="65" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="620" y="328" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">factor importance model</text>
-<text x="620" y="350" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">quantify the weight of each factor</text>
-<text x="620" y="370" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">build sentencing decision logic</text>
-<line x1="620" y1="375" x2="620" y2="400" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="40" y="400" width="720" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="400" y="420" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Application: conversational legal advice Agent</text>
-<text x="400" y="445" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">guide questions by factor importance → retrieve similar case prototypes → data-driven sentencing analysis</text>
+<rect x="30" y="44" width="370" height="46" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="215.0" y="55.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Non-agentic RAG</text>
+<text x="215.0" y="81.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="bold">Fixed pre-step, one-shot retrieval</text>
+<rect x="80" y="110" width="270" height="44" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="215.0" y="132" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">User query</text>
+<line x1="215.0" y1="156" x2="215.0" y2="174" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="80" y="174" width="270" height="44" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="215.0" y="196" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Retrieval (one-shot)</text>
+<line x1="215.0" y1="220" x2="215.0" y2="238" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="80" y="238" width="270" height="44" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="215.0" y="260" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Direct answer generation</text>
+<rect x="500" y="44" width="370" height="46" rx="6" fill="#eef3f6" stroke="#333333" stroke-width="2"/>
+<text x="685.0" y="55.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Agentic RAG</text>
+<text x="685.0" y="81.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="bold">ReAct-driven, iterative retrieval</text>
+<rect x="530" y="110" width="310" height="44" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="685.0" y="132" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Think: analyze needs, determine keywords</text>
+<line x1="685.0" y1="156" x2="685.0" y2="174" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="530" y="174" width="310" height="44" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="685.0" y="196" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Act: call retrieval tool</text>
+<line x1="685.0" y1="220" x2="685.0" y2="238" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="530" y="238" width="310" height="44" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="685.0" y="260" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Observe: is information sufficient?</text>
+<line x1="840" y1="260" x2="858" y2="260" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
+<line x1="858" y1="260" x2="858" y2="196" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
+<line x1="858" y1="196" x2="840" y2="196" stroke="#333333" stroke-width="2" stroke-dasharray="8,4" marker-end="url(#ah)"/>
+<text x="862" y="228.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">No</text>
+<line x1="685.0" y1="302" x2="685.0" y2="320" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="550" y="322" width="270" height="44" rx="6" fill="#dfeef0" stroke="#333333" stroke-width="2"/>
+<text x="685.0" y="344" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Yes → Synthesize Answer</text>
 </svg>

--- a/book-en/images/fig3-13.svg
+++ b/book-en/images/fig3-13.svg
@@ -1,37 +1,44 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 450" width="880" height="450" style="background:#ffffff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 460" width="880" height="460" style="background:#ffffff">
 <defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<circle cx="440" cy="210" r="55" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="440" y="210" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central">Agent</text>
-<rect x="120" y="100" width="200" height="80" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="119.2" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">① Execute task</text>
-<text x="220.0" y="140.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">process refund request</text>
-<text x="220.0" y="160.8" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">call customer service API</text>
-<rect x="680" y="100" width="200" height="80" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="780.0" y="112.7" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">② Get feedback</text>
-<text x="780.0" y="130.9" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">successfully refunded $45</text>
-<text x="780.0" y="149.1" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">found need to verify last four</text>
-<text x="780.0" y="167.3" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">digits</text>
-<rect x="680" y="310" width="200" height="80" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="780.0" y="323.675" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">③ Reflect and distill</text>
-<text x="780.0" y="341.225" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">LLM summarizes experience:</text>
-<text x="780.0" y="358.77500000000003" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">&quot;Company A refund requires</text>
-<text x="780.0" y="376.32500000000005" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">verification&quot;</text>
-<rect x="340" y="380" width="200" height="80" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="440.0" y="403.1" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">④ Store in knowledge base</text>
-<text x="440.0" y="420.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">experience → vectorized index</text>
-<text x="440.0" y="436.90000000000003" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">process → generate tool code</text>
-<rect x="120" y="310" width="200" height="80" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="326.6" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">⑤ Future retrieval and reuse</text>
-<text x="220.0" y="342.20000000000005" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">similar task → retrieve</text>
-<text x="220.0" y="357.8" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">experience</text>
-<text x="220.0" y="373.40000000000003" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">directly reuse successful strategy</text>
-<line x1="325.0" y1="140.0" x2="675.0" y2="140.0" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
-<line x1="780.0" y1="185.0" x2="780.0" y2="305.0" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
-<line x1="677.1570104580516" y1="359.0743814301719" x2="542.8429895419484" y2="410.9256185698281" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
-<line x1="339.94279309860747" y1="406.3558354225374" x2="320.05720690139253" y2="363.6441645774626" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
-<line x1="220.0" y1="305.0" x2="220.0" y2="185.0" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
-<rect x="30" y="395" width="180" height="28" rx="6" fill="#999999" stroke="#333333" stroke-width="2"/>
-<text x="120" y="409" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="10.5" fill="#ffffff" text-anchor="middle" dominant-baseline="central" font-weight="normal">Knowledge: summary/tree summary</text>
-<rect x="670" y="395" width="180" height="28" rx="6" fill="#999999" stroke="#333333" stroke-width="2"/>
-<text x="760" y="409" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#ffffff" text-anchor="middle" dominant-baseline="central" font-weight="normal">Tool: process → code</text>
+<rect x="220" y="55" width="440" height="200" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2"/>
+<text x="440" y="78" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Agent (ReAct Loop)</text>
+<rect x="240" y="100" width="180" height="45" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="330.0" y="122.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">① Thought</text>
+<rect x="460" y="100" width="180" height="45" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="550.0" y="122.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">② Action</text>
+<rect x="350" y="180" width="180" height="45" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="440.0" y="202.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">③ Observation</text>
+<line x1="420" y1="122" x2="458" y2="122" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="640" y1="130" x2="530" y2="178" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="350" y1="202" x2="280" y2="145" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<text x="440" y="242" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Repeat until the information is sufficient</text>
+<rect x="20" y="95" width="160" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="100.0" y="122.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">User Query</text>
+<line x1="180" y1="122" x2="218" y2="122" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="700" y="95" width="160" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="780.0" y="122.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Final Answer</text>
+<line x1="660" y1="122" x2="698" y2="122" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="100" y="290" width="680" height="85" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
+<text x="440" y="312" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Tool Layer</text>
+<rect x="120" y="330" width="220" height="35" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="230.0" y="347" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="middle" dominant-baseline="central">knowledge_base_search</text>
+<rect x="370" y="330" width="140" height="35" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="440.0" y="347" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="middle" dominant-baseline="central">web_search</text>
+<rect x="540" y="330" width="160" height="35" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="620.0" y="347" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="middle" dominant-baseline="central">code_interpreter</text>
+<line x1="440" y1="255" x2="440" y2="288" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="440" y1="288" x2="440" y2="255" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="100" y="400" width="680" height="85" rx="6" fill="#ffffff" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
+<text x="440" y="420" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Knowledge Base Backend (Switchable)</text>
+<rect x="120" y="435" width="180" height="45" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="210.0" y="449" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">retrieval-pipeline</text>
+<text x="210.0" y="466" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Hybrid Retrieval</text>
+<rect x="340" y="435" width="180" height="45" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="430.0" y="449" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">structured-index</text>
+<text x="430.0" y="466" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">RAPTOR/GraphRAG</text>
+<rect x="560" y="435" width="180" height="45" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="650.0" y="449" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">contextual-retrieval</text>
+<text x="650.0" y="466" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Contextual Retrieval</text>
+<line x1="230" y1="365" x2="230" y2="398" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="440" y1="375" x2="440" y2="398" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
 </svg>

--- a/book-en/images/fig3-14.svg
+++ b/book-en/images/fig3-14.svg
@@ -1,51 +1,35 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 470" width="880" height="470" style="background:#ffffff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 390" width="880" height="390" style="background:#ffffff">
 <defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="20" y="55" width="400" height="420" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2"/>
-<text x="220" y="80" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Learning Mode</text>
-<rect x="70" y="100" width="300" height="60" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="117.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">GAIA task</text>
-<text x="220.0" y="143.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">complex multi-step problem</text>
-<rect x="70" y="175" width="300" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="192.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Agent execution</text>
-<text x="220.0" y="218.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">browser + file + code interpreter</text>
-<line x1="220" y1="162" x2="220" y2="173" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="70" y="250" width="300" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="267.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Task successful?</text>
-<text x="220.0" y="293.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Auto Evaluation (AWorld)</text>
-<line x1="220" y1="237" x2="220" y2="248" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="70" y="325" width="300" height="60" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="342.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">LLM Reflection &amp; Summary</text>
-<text x="220.0" y="368.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Extract Strategy Summary</text>
-<line x1="220" y1="312" x2="220" y2="323" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="70" y="400" width="300" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="417.975" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Experience → Vectorization</text>
-<text x="220.0" y="442.02500000000003" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Store in Experience Knowledge Base</text>
-<line x1="220" y1="387" x2="220" y2="398" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="460" y="55" width="400" height="420" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2"/>
-<text x="660" y="80" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Apply Mode</text>
-<rect x="510" y="100" width="300" height="60" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="660.0" y="117.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">New GAIA Task</text>
-<text x="660.0" y="143.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Receive New Question</text>
-<rect x="510" y="175" width="300" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="660.0" y="194.6" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Semantic Retrieval of Experience</text>
-<text x="660.0" y="215.4" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.0" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Search for Similar Tasks in Experience Base</text>
-<line x1="660" y1="162" x2="660" y2="173" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="510" y="250" width="300" height="60" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="660.0" y="269.925" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Inject into System Prompt</text>
-<text x="660.0" y="290.075" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Historical Successful Strategies as Examples</text>
-<line x1="660" y1="237" x2="660" y2="248" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="510" y="325" width="300" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="660.0" y="337.45" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Agent execution</text>
-<text x="660.0" y="355.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Leverage Experience for More Efficient Problem</text>
-<text x="660.0" y="372.55" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Solving</text>
-<line x1="660" y1="312" x2="660" y2="323" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="510" y="400" width="300" height="60" rx="6" fill="#999999" stroke="#333333" stroke-width="2"/>
-<text x="660.0" y="419.275" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Success Rate ↑ Efficiency ↑</text>
-<text x="660.0" y="440.72499999999997" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Self-Evolution: Getting Stronger Over Time</text>
-<line x1="660" y1="387" x2="660" y2="398" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="375" y="255.0" width="130" height="50" rx="6" fill="#999999" stroke="#333333" stroke-width="2"/>
-<text x="440.0" y="272.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="8.5" fill="#ffffff" text-anchor="middle" dominant-baseline="central" font-weight="bold">Experience Knowledge Base</text>
-<text x="440.0" y="292.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#ffffff" text-anchor="middle" dominant-baseline="central" font-weight="normal">(Vector Index)</text>
-<line x1="370" y1="430.0" x2="373" y2="290.0" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="507" y1="270.0" x2="510" y2="205.0" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="20" y="55" width="400" height="170" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2"/>
+<text x="220" y="78" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Traditional chunking (no context)</text>
+<rect x="40" y="95" width="360" height="50" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="50" y="112" font-family="'Courier New', Courier, monospace" font-size="11.5" fill="#333333" text-anchor="start" dominant-baseline="central">The company's second-quarter revenue grew by 3%,</text>
+<text x="50" y="132" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">mainly driven by new product lines.</text>
+<text x="220" y="170" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Question: Who is "the company"? Which year?</text>
+<text x="220" y="195" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ Retrieval matches revenue data of many irrelevant companies</text>
+<rect x="460" y="55" width="400" height="170" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2"/>
+<text x="660" y="78" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Context-aware chunking</text>
+<rect x="480" y="95" width="360" height="35" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="490" y="113" font-family="'Courier New', Courier, monospace" font-size="8" fill="#333333" text-anchor="start" dominant-baseline="central">[ACME Company 2025 Q2 Financial Report · Key Performance Indicators]</text>
+<rect x="480" y="130" width="360" height="50" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="490" y="148" font-family="'Courier New', Courier, monospace" font-size="11.5" fill="#333333" text-anchor="start" dominant-baseline="central">The company's second-quarter revenue grew by 3%,</text>
+<text x="490" y="168" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">mainly driven by new product lines.</text>
+<text x="660" y="200" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ Exact match: ACME + Q2 + revenue growth</text>
+<text x="440" y="140" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="24" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">→</text>
+<line x1="20" y1="250" x2="860" y2="250" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
+<text x="440.0" y="275" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Indexing phase: LLM generates context prefix</text>
+<rect x="30" y="300" width="180" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="120.0" y="327.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Original document</text>
+<line x1="210" y1="327" x2="248" y2="327" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="250" y="300" width="180" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="340.0" y="327.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Chunk</text>
+<line x1="430" y1="327" x2="468" y2="327" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="470" y="300" width="180" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="560.0" y="317.9" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">LLM generates prefix</text>
+<text x="560.0" y="338.7" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">(prompt caching)</text>
+<line x1="650" y1="327" x2="688" y2="327" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="690" y="300" width="170" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="775.0" y="317.9" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Prefix + original text</text>
+<text x="775.0" y="338.7" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">→ Index</text>
+<text x="440.0" y="410" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Effect: Retrieval failure rate ↓49% (+BM25), ↓67% (+reranking) — Anthropic data</text>
 </svg>

--- a/book-en/images/fig3-2.svg
+++ b/book-en/images/fig3-2.svg
@@ -1,35 +1,43 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 400" width="880" height="400" style="background:#ffffff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 920 412" width="920" height="412" style="background:#ffffff">
 <defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="20" y="65" width="180" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="110.0" y="92.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">① User Query</text>
-<text x="110" y="145" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">&quot;How many years for intentional homicide?&quot;</text>
-<line x1="200" y1="92" x2="238" y2="92" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="240" y="65" width="180" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="330.0" y="92.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">② Retrieval</text>
-<text x="330" y="140" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Dense Retrieval + BM25</text>
-<text x="330" y="160" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ Top-K Text Chunks</text>
-<line x1="420" y1="92" x2="458" y2="92" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="460" y="65" width="180" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="550.0" y="92.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">③ Augment</text>
-<text x="550" y="140" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Query + Retrieved Results</text>
-<text x="550" y="160" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ Construct Full Prompt</text>
-<line x1="640" y1="92" x2="678" y2="92" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="680" y="65" width="180" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="770.0" y="92.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">④ Generate</text>
-<text x="770" y="140" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">LLM synthesizes context</text>
-<text x="770" y="160" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ Generate response</text>
-<line x1="20" y1="195" x2="860" y2="195" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="440.0" y="215" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Example data flow</text>
-<rect x="20" y="235" width="400" height="90" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
-<text x="220" y="253" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Retrieved text chunks</text>
-<text x="30" y="278" font-family="'Courier New', Courier, monospace" font-size="6.5" fill="#333333" text-anchor="start" dominant-baseline="central">Article 232 of the Criminal Law: Whoever intentionally kills another shall be sentenced to death,</text>
-<text x="30" y="298" font-family="'Courier New', Courier, monospace" font-size="8.5" fill="#333333" text-anchor="start" dominant-baseline="central">life imprisonment or fixed-term imprisonment of not less than ten years...</text>
-<rect x="440" y="235" width="420" height="90" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
-<text x="650" y="253" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Augmented Prompt</text>
-<text x="450" y="278" font-family="'Courier New', Courier, monospace" font-size="11" fill="#333333" text-anchor="start" dominant-baseline="central">Answer the question based on the following legal provisions:</text>
-<text x="450" y="298" font-family="'Courier New', Courier, monospace" font-size="7.5" fill="#333333" text-anchor="start" dominant-baseline="central">[Article 232 of the Criminal Law...] Q: What is the sentence for intentional homicide?</text>
-<rect x="20" y="345" width="840" height="80" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="440.0" y="363" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Generated response</text>
-<text x="30" y="390" font-family="'Courier New', Courier, monospace" font-size="7.5" fill="#333333" text-anchor="start" dominant-baseline="central">According to Article 232 of the Criminal Law, the crime of intentional homicide is punishable by death, life imprisonment, or fixed-term imprisonment of not less than ten years;</text>
-<text x="30" y="412" font-family="'Courier New', Courier, monospace" font-size="10.5" fill="#333333" text-anchor="start" dominant-baseline="central">if the circumstances are minor, the sentence is fixed-term imprisonment of not less than three years but not more than ten years.</text>
+<rect x="24" y="70" width="200" height="42" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="124.0" y="91" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Simple Notes</text>
+<rect x="38" y="126" width="172" height="84" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="48" y="150" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">&quot;User email:</text>
+<text x="48" y="172" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central"> john@x.com&quot;</text>
+<text x="124.0" y="236" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">✓ Atomic fact · O(1)</text>
+<text x="124.0" y="262" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">✓ Extremely low overhead</text>
+<text x="124.0" y="292" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">✗ Relevance lost</text>
+<rect x="248" y="70" width="200" height="42" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="348.0" y="91" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Enhanced Notes</text>
+<rect x="262" y="126" width="172" height="84" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="272" y="150" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">&quot;At TechCorp,</text>
+<text x="272" y="172" font-family="'Courier New', Courier, monospace" font-size="11" fill="#333333" text-anchor="start" dominant-baseline="central">a senior engineer leads</text>
+<text x="272" y="194" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">a team of five.&quot;</text>
+<text x="348.0" y="236" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">✓ Full narrative</text>
+<text x="348.0" y="262" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">✓ Semantically complete</text>
+<text x="348.0" y="292" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">✗ Redundant · Hard to update</text>
+<text x="348.0" y="318" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">✗ Long text is difficult to retrieve</text>
+<rect x="472" y="70" width="200" height="42" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="572.0" y="91" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">JSON Cards</text>
+<rect x="486" y="126" width="172" height="84" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="496" y="150" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">work.position</text>
+<text x="496" y="172" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central"> .title = …</text>
+<text x="496" y="194" font-family="'Courier New', Courier, monospace" font-size="11.5" fill="#333333" text-anchor="start" dominant-baseline="central">(category → key-value)</text>
+<text x="572.0" y="236" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">✓ Three-level structure</text>
+<text x="572.0" y="262" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">✓ Supports partial updates</text>
+<text x="572.0" y="292" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">✗ Rigid classification</text>
+<rect x="696" y="70" width="200" height="42" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="796.0" y="91" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Advanced JSON Cards</text>
+<rect x="710" y="126" width="172" height="84" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="720" y="150" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">+ backstory</text>
+<text x="720" y="172" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">+ person</text>
+<text x="720" y="194" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">+ relationship</text>
+<text x="796.0" y="236" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">✓ Disambiguation · knowledge management</text>
+<text x="796.0" y="262" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">✓ With sources and relations</text>
+<text x="796.0" y="292" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">✗ Costly to generate and maintain</text>
+<line x1="70" y1="400" x2="850" y2="400" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<text x="70" y="383" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">Simplicity</text>
+<text x="850" y="383" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="end" dominant-baseline="central" font-weight="normal">Expressiveness</text>
+<text x="460" y="424" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Decreasing simplicity, increasing expressiveness</text>
 </svg>

--- a/book-en/images/fig3-4.svg
+++ b/book-en/images/fig3-4.svg
@@ -1,51 +1,31 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 750 400" width="750" height="400" style="background:#ffffff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 920 380" width="920" height="380" style="background:#ffffff">
 <defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="30" y="40" width="690" height="90" rx="6" fill="#ffffff" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="100" y="56" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">Layer 2 (sparse · long-range connections)</text>
-<circle cx="222.5" cy="95" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="375.0" cy="95" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="527.5" cy="95" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<line x1="236.5" y1="95" x2="361.0" y2="95" stroke="#999999" stroke-width="2"/>
-<line x1="389.0" y1="95" x2="513.5" y2="95" stroke="#999999" stroke-width="2"/>
-<rect x="30" y="155" width="690" height="90" rx="6" fill="#ffffff" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="100" y="171" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">Layer 1 (medium density)</text>
-<circle cx="157.14285714285714" cy="210" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="244.28571428571428" cy="210" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="331.42857142857144" cy="210" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="418.57142857142856" cy="210" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="505.71428571428567" cy="210" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="592.8571428571429" cy="210" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<line x1="171.14285714285714" y1="210" x2="230.28571428571428" y2="210" stroke="#999999" stroke-width="2"/>
-<line x1="258.2857142857143" y1="210" x2="317.42857142857144" y2="210" stroke="#999999" stroke-width="2"/>
-<line x1="345.42857142857144" y1="210" x2="404.57142857142856" y2="210" stroke="#999999" stroke-width="2"/>
-<line x1="432.57142857142856" y1="210" x2="491.71428571428567" y2="210" stroke="#999999" stroke-width="2"/>
-<line x1="519.7142857142857" y1="210" x2="578.8571428571429" y2="210" stroke="#999999" stroke-width="2"/>
-<rect x="30" y="270" width="690" height="90" rx="6" fill="#ffffff" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="100" y="286" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">Layer 0 (dense · all nodes)</text>
-<circle cx="125.45454545454545" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="180.9090909090909" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="236.36363636363637" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="291.8181818181818" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="347.27272727272725" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="402.72727272727275" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="458.1818181818182" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="513.6363636363636" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="569.090909090909" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<circle cx="624.5454545454545" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<line x1="139.45454545454544" y1="325" x2="222.36363636363637" y2="325" stroke="#999999" stroke-width="2"/>
-<line x1="194.9090909090909" y1="325" x2="222.36363636363637" y2="325" stroke="#999999" stroke-width="2"/>
-<line x1="250.36363636363637" y1="325" x2="333.27272727272725" y2="325" stroke="#999999" stroke-width="2"/>
-<line x1="305.8181818181818" y1="325" x2="333.27272727272725" y2="325" stroke="#999999" stroke-width="2"/>
-<line x1="361.27272727272725" y1="325" x2="444.1818181818182" y2="325" stroke="#999999" stroke-width="2"/>
-<line x1="416.72727272727275" y1="325" x2="444.1818181818182" y2="325" stroke="#999999" stroke-width="2"/>
-<line x1="472.1818181818182" y1="325" x2="555.090909090909" y2="325" stroke="#999999" stroke-width="2"/>
-<line x1="527.6363636363636" y1="325" x2="555.090909090909" y2="325" stroke="#999999" stroke-width="2"/>
-<line x1="375.0" y1="130" x2="325.0" y2="165" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<text x="455.0" y="148" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Search starts from the top level</text>
-<line x1="325.0" y1="245" x2="295.0" y2="280" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<text x="435.0" y="263" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Refine layer by layer downward</text>
-<rect x="50" y="395" width="300" height="32" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="200" y="411" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Supports incremental updates · High recall</text>
-<rect x="400" y="395" width="300" height="32" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
-<text x="550" y="411" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">O(log N) query complexity</text>
+<rect x="340" y="250" width="240" height="90" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="460" y="278" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Working Memory</text>
+<text x="460" y="302" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Active Workspace</text>
+<text x="460" y="322" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Current Task State</text>
+<rect x="60" y="80" width="200" height="84" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="160" y="104" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Episodic Memory</text>
+<text x="160" y="128" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Episodic</text>
+<text x="160" y="148" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">event sequences with metadata</text>
+<rect x="360" y="80" width="200" height="84" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="460" y="104" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Semantic Memory</text>
+<text x="460" y="128" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Semantic</text>
+<text x="460" y="148" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">abstracted general knowledge</text>
+<rect x="660" y="80" width="200" height="84" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="760" y="104" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Procedural Memory</text>
+<text x="760" y="128" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Procedural</text>
+<text x="760" y="148" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">reusable behavior flows</text>
+<line x1="200" y1="168" x2="410" y2="246" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
+<line x1="430" y1="246" x2="250" y2="168" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
+<line x1="460" y1="164" x2="460" y2="246" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
+<line x1="460" y1="246" x2="470" y2="164" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
+<line x1="720" y1="168" x2="510" y2="246" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
+<line x1="490" y1="246" x2="700" y2="164" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
+<rect x="242" y="194" width="150" height="25" rx="3" fill="#ffffff"/>
+<text x="317" y="207" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Selective Transfer</text>
+<rect x="536" y="194" width="150" height="25" rx="3" fill="#ffffff"/>
+<text x="611" y="207" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Activation and Loading</text>
+<text x="460" y="60" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Long-Term Memory (Cross-Session)</text>
+<text x="460" y="372" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Dynamic interaction between working memory and long-term memory: important information is selectively written, and relevant memories are activated on demand.</text>
 </svg>

--- a/book-en/images/fig3-5.svg
+++ b/book-en/images/fig3-5.svg
@@ -1,31 +1,36 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 800 340" width="800" height="340" style="background:#ffffff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 400" width="880" height="400" style="background:#ffffff">
 <defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="40" y="50" width="720" height="50" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
-<text x="60" y="75" font-family="'Courier New', Courier, monospace" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central">Score(Q,D) = Σ IDF(qi) × TF(qi,D)×(k1+1) / (TF + k1×(1-b+b×|D|/avgdl))</text>
-<rect x="40" y="120" width="220" height="170" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="150" y="148" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Term frequency saturation (TF)</text>
-<line x1="60" y1="163" x2="240" y2="163" stroke="#999999" stroke-width="2"/>
-<text x="150" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">k₁ controls saturation speed</text>
-<text x="150" y="218" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">TF ↑ but contribution diminishes</text>
-<text x="150" y="246" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Example: 5→10 occurrences</text>
-<text x="150" y="274" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Score increases only ~20%</text>
-<rect x="290" y="120" width="220" height="170" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="400" y="148" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Inverse document frequency (IDF)</text>
-<line x1="310" y1="163" x2="490" y2="163" stroke="#999999" stroke-width="2"/>
-<text x="400" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Measures word rarity</text>
-<text x="400" y="218" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">&quot;的&quot; → IDF ≈ 0</text>
-<text x="400" y="246" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">&quot;量刑&quot; → IDF ≈ 5.2</text>
-<text x="400" y="274" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Rare word weight &gt;&gt; common word</text>
-<rect x="540" y="120" width="220" height="170" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="650" y="148" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="18.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Length normalization (b)</text>
-<line x1="560" y1="163" x2="740" y2="163" stroke="#999999" stroke-width="2"/>
-<text x="650" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">b ∈ [0,1] normalization strength</text>
-<text x="650" y="218" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">b=0: ignore length</text>
-<text x="650" y="246" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">b=1: full normalization</text>
-<text x="650" y="274" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Avoid bias towards long documents</text>
-<line x1="150" y1="290" x2="150" y2="315" stroke="#999999" stroke-width="2"/>
-<line x1="400" y1="290" x2="400" y2="315" stroke="#999999" stroke-width="2"/>
-<line x1="650" y1="290" x2="650" y2="315" stroke="#999999" stroke-width="2"/>
-<rect x="40" y="315" width="720" height="48" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="400.0" y="339" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Final score = Σ (TF saturation × IDF weighting × length normalization)</text>
+<rect x="20" y="65" width="180" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="110.0" y="92.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="17" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">① User Query</text>
+<text x="110" y="140" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">&quot;What sentence applies to</text>
+<text x="110" y="156" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">intentional homicide?&quot;</text>
+<line x1="200" y1="92" x2="238" y2="92" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="240" y="65" width="180" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="330.0" y="92.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="17" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">② Retrieval</text>
+<text x="330" y="140" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Dense Retrieval + BM25</text>
+<text x="330" y="160" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ Top-K Text Chunks</text>
+<line x1="420" y1="92" x2="458" y2="92" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="460" y="65" width="180" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="550.0" y="92.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="17" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">③ Augment</text>
+<text x="550" y="140" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Query + Retrieved Results</text>
+<text x="550" y="160" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ Construct Complete Prompt</text>
+<line x1="640" y1="92" x2="678" y2="92" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="680" y="65" width="180" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="770.0" y="92.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="17" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">④ Generate</text>
+<text x="770" y="140" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">LLM Synthesizes Context</text>
+<text x="770" y="160" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ Generate Answer</text>
+<line x1="20" y1="195" x2="860" y2="195" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
+<text x="440.0" y="215" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Specific Data Flow Example</text>
+<rect x="20" y="235" width="400" height="90" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="220" y="253" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Retrieved Text Chunks</text>
+<text x="30" y="278" font-family="'Courier New', Courier, monospace" font-size="6" fill="#333333" text-anchor="start" dominant-baseline="central">Article 232 of the Criminal Law: Whoever intentionally commits homicide shall be sentenced to death,</text>
+<text x="30" y="298" font-family="'Courier New', Courier, monospace" font-size="8.5" fill="#333333" text-anchor="start" dominant-baseline="central">life imprisonment or fixed-term imprisonment of not less than 10 years...</text>
+<rect x="440" y="235" width="420" height="90" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="650" y="253" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Augmented Prompt</text>
+<text x="450" y="278" font-family="'Courier New', Courier, monospace" font-size="11" fill="#333333" text-anchor="start" dominant-baseline="central">Answer the question based on the following legal provisions:</text>
+<text x="450" y="298" font-family="'Courier New', Courier, monospace" font-size="7.5" fill="#333333" text-anchor="start" dominant-baseline="central">[Article 232 of the Criminal Law...] Q: What is the sentence for intentional homicide?</text>
+<rect x="20" y="345" width="840" height="80" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="440.0" y="363" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Generated Answer</text>
+<text x="30" y="390" font-family="'Courier New', Courier, monospace" font-size="8" fill="#333333" text-anchor="start" dominant-baseline="central">According to Article 232 of the Criminal Law, intentional homicide is punishable by death, life imprisonment, or fixed-term imprisonment of not less than 10 years;</text>
+<text x="30" y="412" font-family="'Courier New', Courier, monospace" font-size="11" fill="#333333" text-anchor="start" dominant-baseline="central">if the circumstances are minor, the sentence is fixed-term imprisonment of not less than 3 years but not more than 10 years.</text>
 </svg>

--- a/book-en/images/fig3-6.svg
+++ b/book-en/images/fig3-6.svg
@@ -1,33 +1,53 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 440" width="880" height="440" style="background:#ffffff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 860 300" width="860" height="300" style="background:#ffffff">
 <defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="30" y="55" width="160" height="50" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="110" y="73" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">User query</text>
-<text x="110" y="93" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="middle" dominant-baseline="central">&quot;kitty behavior&quot;</text>
-<line x1="190" y1="68" x2="238" y2="68" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="240" y="50" width="180" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="330.0" y="75.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Dense retrieval</text>
-<text x="330" y="118" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Semantic matching: kitty ≈ cat</text>
-<text x="250" y="140" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">doc3: &quot;feline habits and cat play...&quot;</text>
-<text x="700" y="140" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">cos=0.87</text>
-<text x="250" y="172" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">doc7: &quot;cat grooming patterns...&quot;</text>
-<text x="700" y="172" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">cos=0.82</text>
-<text x="250" y="204" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">doc1: &quot;pet care basics...&quot;</text>
-<text x="700" y="204" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">cos=0.71</text>
-<line x1="190" y1="90" x2="238" y2="270" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="240" y="250" width="180" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="330.0" y="264.275" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Sparse retrieval</text>
-<text x="330.0" y="285.72499999999997" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">(BM25)</text>
-<text x="330" y="318" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Exact match: &quot;kitty&quot; keyword</text>
-<text x="250" y="340" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">doc5: &quot;kitty litter training...&quot;</text>
-<text x="700" y="340" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">BM25=8.4</text>
-<text x="250" y="372" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">doc9: &quot;kitty adoption guide...&quot;</text>
-<text x="700" y="372" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">BM25=6.1</text>
-<text x="250" y="404" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">doc2: &quot;kitten health tips...&quot;</text>
-<text x="700" y="404" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">BM25=3.2</text>
-<line x1="770" y1="180" x2="808" y2="220" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="770" y1="370" x2="808" y2="330" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="790" y="215" width="70" height="120" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="825" y="250" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Merge</text>
-<text x="825" y="275" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="10.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Deduplicate</text>
-<text x="825" y="300" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">6→5</text>
+<line x1="50" y1="90" x2="810" y2="90" stroke="#999999" stroke-width="2"/>
+<polygon points="810,84 822,90 810,96" fill="#999999"/>
+<circle cx="80.0" cy="90" r="8" fill="#999999" stroke="#333333" stroke-width="2"/>
+<text x="80.0" y="60" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Word2Vec</text>
+<text x="80.0" y="118" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">2013</text>
+<rect x="15.0" y="140" width="130" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="80.0" y="158" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">300-dimensional</text>
+<text x="80.0" y="180" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">static word vectors</text>
+<rect x="15.0" y="205" width="130" height="55" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="80.0" y="223" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">co-occurrence relations</text>
+<text x="80.0" y="245" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">predictive training</text>
+<circle cx="255.0" cy="90" r="8" fill="#999999" stroke="#333333" stroke-width="2"/>
+<text x="255.0" y="60" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">GloVe</text>
+<text x="255.0" y="118" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">2014</text>
+<rect x="190.0" y="140" width="130" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="255.0" y="158" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">300-dimensional</text>
+<text x="255.0" y="180" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">global statistics</text>
+<rect x="190.0" y="205" width="130" height="55" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="255.0" y="223" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">matrix factorization</text>
+<text x="255.0" y="245" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">+ co-occurrence</text>
+<circle cx="430.0" cy="90" r="8" fill="#999999" stroke="#333333" stroke-width="2"/>
+<text x="430.0" y="60" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">BERT</text>
+<text x="430.0" y="118" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">2018</text>
+<rect x="365.0" y="140" width="130" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="430.0" y="158" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">768-dimensional</text>
+<text x="430.0" y="180" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">context-aware</text>
+<rect x="365.0" y="205" width="130" height="55" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="430.0" y="223" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Transformer</text>
+<text x="430.0" y="245" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">MLM pre-training</text>
+<circle cx="605.0" cy="90" r="8" fill="#999999" stroke="#333333" stroke-width="2"/>
+<text x="605.0" y="60" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Sentence-BERT</text>
+<text x="605.0" y="118" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">2019</text>
+<rect x="540.0" y="140" width="130" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="605.0" y="158" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">768-dimensional</text>
+<text x="605.0" y="180" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="9.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">sentence-level embeddings</text>
+<rect x="540.0" y="205" width="130" height="55" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="605.0" y="223" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Siamese network</text>
+<text x="605.0" y="245" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">contrastive learning</text>
+<circle cx="780.0" cy="90" r="8" fill="#999999" stroke="#333333" stroke-width="2"/>
+<text x="780.0" y="60" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">BGE-M3</text>
+<text x="780.0" y="118" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">2024</text>
+<rect x="715.0" y="140" width="130" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="780.0" y="158" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">1024-dimensional</text>
+<text x="780.0" y="180" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">multilingual long text</text>
+<rect x="715.0" y="205" width="130" height="55" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="780.0" y="223" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">multi-stage</text>
+<text x="780.0" y="245" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">mixed training</text>
+<text x="167.5" y="322" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">static word vectors (one vector per word)</text>
+<text x="692.5" y="322" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">context-aware embeddings (multiple vectors per word)</text>
+<line x1="342.5" y1="75" x2="342.5" y2="305" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
 </svg>

--- a/book-en/images/fig3-7.svg
+++ b/book-en/images/fig3-7.svg
@@ -1,54 +1,53 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 800 400" width="800" height="400" style="background:#ffffff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 750 400" width="750" height="400" style="background:#ffffff">
 <defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="300" y="55" width="200" height="50" rx="6" fill="#999999" stroke="#333333" stroke-width="2"/>
-<text x="400.0" y="80.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Global summary</text>
-<text x="515" y="80" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">← Root node</text>
-<rect x="80" y="150" width="160" height="48" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="160.0" y="174.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Cluster summary A</text>
-<rect x="320" y="150" width="160" height="48" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="400.0" y="174.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Cluster summary B</text>
-<rect x="560" y="150" width="160" height="48" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="640.0" y="174.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Cluster summary C</text>
-<line x1="400" y1="105" x2="160" y2="150" stroke="#333333" stroke-width="2"/>
-<line x1="400" y1="105" x2="400" y2="150" stroke="#333333" stroke-width="2"/>
-<line x1="400" y1="105" x2="640" y2="150" stroke="#333333" stroke-width="2"/>
-<text x="35" y="230" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">Middle layer ↑</text>
-<rect x="40" y="250" width="88" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="84.0" y="261.55" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Text chunk</text>
-<text x="84.0" y="278.45" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">1</text>
-<line x1="84.0" y1="250" x2="160" y2="198" stroke="#999999" stroke-width="2"/>
-<rect x="140" y="250" width="88" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="184.0" y="261.55" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Text chunk</text>
-<text x="184.0" y="278.45" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">2</text>
-<line x1="184.0" y1="250" x2="160" y2="198" stroke="#999999" stroke-width="2"/>
-<rect x="240" y="250" width="88" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="284.0" y="261.55" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Text chunk</text>
-<text x="284.0" y="278.45" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">3</text>
-<line x1="284.0" y1="250" x2="160" y2="198" stroke="#999999" stroke-width="2"/>
-<rect x="360" y="250" width="88" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="404.0" y="261.55" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Text chunk</text>
-<text x="404.0" y="278.45" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">4</text>
-<line x1="404.0" y1="250" x2="400" y2="198" stroke="#999999" stroke-width="2"/>
-<rect x="460" y="250" width="88" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="504.0" y="261.55" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Text chunk</text>
-<text x="504.0" y="278.45" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">5</text>
-<line x1="504.0" y1="250" x2="400" y2="198" stroke="#999999" stroke-width="2"/>
-<rect x="560" y="250" width="88" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="604.0" y="261.55" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Text chunk</text>
-<text x="604.0" y="278.45" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">6</text>
-<line x1="604.0" y1="250" x2="640" y2="198" stroke="#999999" stroke-width="2"/>
-<rect x="660" y="250" width="88" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="704.0" y="261.55" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Text chunk</text>
-<text x="704.0" y="278.45" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13.0" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">7</text>
-<line x1="704.0" y1="250" x2="640" y2="198" stroke="#999999" stroke-width="2"/>
-<text x="35" y="295" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">Leaf layer ↑</text>
-<rect x="40" y="320" width="720" height="55" rx="6" fill="#ffffff" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="400" y="340" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Original document</text>
-<rect x="60" y="350" width="90" height="16" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<rect x="170" y="350" width="90" height="16" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<rect x="280" y="350" width="90" height="16" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<rect x="390" y="350" width="90" height="16" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<rect x="500" y="350" width="90" height="16" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<rect x="610" y="350" width="90" height="16" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="400.0" y="420" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Bottom-up recursive abstraction: details → topics → global overview</text>
+<rect x="30" y="40" width="690" height="90" rx="6" fill="#ffffff" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
+<text x="100" y="56" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">Layer 2 (sparse · long-range connections)</text>
+<circle cx="222.5" cy="95" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="375.0" cy="95" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="527.5" cy="95" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<line x1="236.5" y1="95" x2="361.0" y2="95" stroke="#999999" stroke-width="2"/>
+<line x1="389.0" y1="95" x2="513.5" y2="95" stroke="#999999" stroke-width="2"/>
+<rect x="30" y="155" width="690" height="90" rx="6" fill="#ffffff" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
+<text x="100" y="171" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">Layer 1 (medium density)</text>
+<circle cx="157.14285714285714" cy="210" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="244.28571428571428" cy="210" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="331.42857142857144" cy="210" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="418.57142857142856" cy="210" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="505.71428571428567" cy="210" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="592.8571428571429" cy="210" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<line x1="171.14285714285714" y1="210" x2="230.28571428571428" y2="210" stroke="#999999" stroke-width="2"/>
+<line x1="258.2857142857143" y1="210" x2="317.42857142857144" y2="210" stroke="#999999" stroke-width="2"/>
+<line x1="345.42857142857144" y1="210" x2="404.57142857142856" y2="210" stroke="#999999" stroke-width="2"/>
+<line x1="432.57142857142856" y1="210" x2="491.71428571428567" y2="210" stroke="#999999" stroke-width="2"/>
+<line x1="519.7142857142857" y1="210" x2="578.8571428571429" y2="210" stroke="#999999" stroke-width="2"/>
+<rect x="30" y="270" width="690" height="90" rx="6" fill="#ffffff" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
+<text x="100" y="286" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">Layer 0 (dense · full nodes)</text>
+<circle cx="125.45454545454545" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="180.9090909090909" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="236.36363636363637" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="291.8181818181818" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="347.27272727272725" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="402.72727272727275" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="458.1818181818182" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="513.6363636363636" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="569.090909090909" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<circle cx="624.5454545454545" cy="325" r="14" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<line x1="139.45454545454544" y1="325" x2="222.36363636363637" y2="325" stroke="#999999" stroke-width="2"/>
+<line x1="194.9090909090909" y1="325" x2="222.36363636363637" y2="325" stroke="#999999" stroke-width="2"/>
+<line x1="250.36363636363637" y1="325" x2="333.27272727272725" y2="325" stroke="#999999" stroke-width="2"/>
+<line x1="305.8181818181818" y1="325" x2="333.27272727272725" y2="325" stroke="#999999" stroke-width="2"/>
+<line x1="361.27272727272725" y1="325" x2="444.1818181818182" y2="325" stroke="#999999" stroke-width="2"/>
+<line x1="416.72727272727275" y1="325" x2="444.1818181818182" y2="325" stroke="#999999" stroke-width="2"/>
+<line x1="472.1818181818182" y1="325" x2="555.090909090909" y2="325" stroke="#999999" stroke-width="2"/>
+<line x1="527.6363636363636" y1="325" x2="555.090909090909" y2="325" stroke="#999999" stroke-width="2"/>
+<line x1="375.0" y1="130" x2="325.0" y2="165" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="385" y="134" width="260" height="28" rx="3" fill="#ffffff"/>
+<text x="515" y="148" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Search starts from the top layer</text>
+<line x1="325.0" y1="245" x2="295.0" y2="280" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="365" y="249" width="270" height="28" rx="3" fill="#ffffff"/>
+<text x="500" y="263" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Refine layer by layer downward</text>
+<rect x="50" y="395" width="300" height="32" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="200" y="411" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Supports incremental updates · high recall</text>
+<rect x="400" y="395" width="300" height="32" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="550" y="411" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">O(log N) query complexity</text>
 </svg>

--- a/book-en/images/fig3-9.svg
+++ b/book-en/images/fig3-9.svg
@@ -1,52 +1,39 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 880 520" width="880" height="520" style="background:#ffffff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 1130 440" width="1130" height="440" style="background:#ffffff">
 <defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
-<rect x="20" y="50" width="400" height="45" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="73" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Non-Agentic RAG</text>
-<rect x="50" y="110" width="340" height="80" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="129.2" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Query: &quot;How to sentence for causing serious</text>
-<text x="220.0" y="150.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">injury by negligence while drunk</text>
-<text x="220.0" y="170.79999999999998" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">and with a previous theft conviction?&quot;</text>
-<rect x="50" y="218" width="340" height="80" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="237.2" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Single retrieval:</text>
-<text x="220.0" y="258.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">&quot;Sentencing for causing serious injury by</text>
-<text x="220.0" y="278.8" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">negligence&quot;</text>
-<line x1="220" y1="192" x2="220" y2="216" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="50" y="326" width="340" height="80" rx="6" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="345.2" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Retrieval result: Only found basic provisions</text>
-<text x="220.0" y="366.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">for negligent injury</text>
-<text x="220.0" y="386.8" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal"> (incomplete context)</text>
-<line x1="220" y1="300" x2="220" y2="324" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="50" y="434" width="340" height="80" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="463.6" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Direct generation: Missing &quot;drunk&quot;</text>
-<text x="220.0" y="484.40000000000003" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">and &quot;previous conviction&quot; influencing factors</text>
-<line x1="220" y1="408" x2="220" y2="432" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<text x="220.0" y="545" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Single pass · Incomplete information</text>
-<line x1="440" y1="50" x2="440" y2="555" stroke="#999999" stroke-width="2" stroke-dasharray="8,4"/>
-<rect x="460" y="50" width="400" height="45" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="660.0" y="73" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Agentic RAG (ReAct)</text>
-<rect x="490" y="105" width="340" height="68" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="660.0" y="128.6" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Thought: Need to decompose into 3</text>
-<text x="660.0" y="149.4" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">sub-questions</text>
-<rect x="490" y="191" width="340" height="68" rx="6" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="660.0" y="202.575" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Search ①: &quot;Sentencing for causing serious injury by</text>
-<text x="660.0" y="217.52499999999998" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">negligence&quot;</text>
-<text x="660.0" y="232.475" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Search ②: &quot;Criminal liability for drunkenness&quot;</text>
-<text x="660.0" y="247.42499999999998" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="11.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Search ③: &quot;Impact of previous theft conviction&quot;</text>
-<line x1="660" y1="175" x2="660" y2="189" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="490" y="277" width="340" height="68" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="660.0" y="290.85" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Observation: Found basic provisions but</text>
-<text x="660.0" y="311.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">missing link between &quot;previous conviction&quot;</text>
-<text x="660.0" y="331.15000000000003" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15.5" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">and &quot;negligent injury&quot;</text>
-<line x1="660" y1="261" x2="660" y2="275" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="490" y="363" width="340" height="68" rx="6" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="660.0" y="386.6" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Search ④: &quot;Recidivism different crimes</text>
-<text x="660.0" y="407.40000000000003" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">judicial interpretation&quot;</text>
-<line x1="660" y1="347" x2="660" y2="361" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="490" y="449" width="340" height="68" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="660.0" y="472.6" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">Synthesis: Complete answer including all</text>
-<text x="660.0" y="493.40000000000003" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">legal provisions and sentencing analysis</text>
-<line x1="660" y1="433" x2="660" y2="447" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<path d="M 840,311 C 868,311 868,225 840,225" fill="none" stroke="#333333" stroke-width="2" stroke-dasharray="6,3" marker-end="url(#ah)"/>
-<text x="844" y="268.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="9.5" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">Iteration</text>
-<text x="660.0" y="545" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Multi-round iteration · Complete information</text>
+<rect x="30" y="55" width="160" height="50" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="110" y="73" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">User query</text>
+<text x="110" y="93" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="middle" dominant-baseline="central">&quot;kitty behavior&quot;</text>
+<line x1="190" y1="68" x2="238" y2="68" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="240" y="50" width="180" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="330.0" y="75.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Dense retrieval</text>
+<text x="330" y="118" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Semantic matching: kitty ≈ cat</text>
+<text x="250" y="140" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">doc3: &quot;feline habits and cat play...&quot;</text>
+<text x="700" y="140" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">cos=0.87</text>
+<text x="250" y="172" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">doc7: &quot;cat grooming patterns...&quot;</text>
+<text x="700" y="172" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">cos=0.82</text>
+<text x="250" y="204" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">doc1: &quot;pet care basics...&quot;</text>
+<text x="700" y="204" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">cos=0.71</text>
+<line x1="190" y1="90" x2="238" y2="270" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="240" y="250" width="180" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="330.0" y="275.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Sparse retrieval (BM25)</text>
+<text x="330" y="318" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Exact match: &quot;kitty&quot; keyword</text>
+<text x="250" y="340" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">doc5: &quot;kitty litter training...&quot;</text>
+<text x="700" y="340" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">BM25=8.4</text>
+<text x="250" y="372" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">doc9: &quot;kitty adoption guide...&quot;</text>
+<text x="700" y="372" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">BM25=6.1</text>
+<text x="250" y="404" font-family="'Courier New', Courier, monospace" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central">doc2: &quot;kitten health tips...&quot;</text>
+<text x="700" y="404" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">BM25=3.2</text>
+<line x1="770" y1="180" x2="808" y2="220" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="770" y1="370" x2="808" y2="330" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="790" y="215" width="70" height="120" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="825" y="250" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="17" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Results</text>
+<text x="825" y="275" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="19" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Fusion</text>
+<text x="825" y="300" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="12.5" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">RRF: 6→5</text>
+<line x1="860" y1="275" x2="898" y2="275" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="900" y="215" width="120" height="120" rx="6" fill="#c8c8c8" stroke="#333333" stroke-width="2"/>
+<text x="960" y="250" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Neural</text>
+<text x="960" y="275" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Re-ranking</text>
+<text x="960" y="305" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="9" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Cross-encoder fine-ranking</text>
+<line x1="960" y1="335" x2="960" y2="352" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<text x="960" y="370" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Final Top-N Ranking</text>
 </svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,6 +285,9 @@ audio = [
 
 # Test and lint tooling.
 dev = [
+    # Root registry tests collect Chapter 4 perception-tool modules directly;
+    # those modules import httpx before individual tests can exercise helpers.
+    "httpx>=0.27,<1",
     "Markdown>=3.5,<4",
     "pytest>=8.3.0",
     "pytest-asyncio>=0.24.0",

--- a/tests/test_ch3_english_figures.py
+++ b/tests/test_ch3_english_figures.py
@@ -1,0 +1,47 @@
+import re
+from pathlib import Path
+from xml.etree import ElementTree
+
+ROOT = Path(__file__).resolve().parents[1]
+CHAPTER = ROOT / "book-en" / "chapter3.md"
+IMAGE_DIR = ROOT / "book-en" / "images"
+
+EXPECTED_ANCHORS = {
+    1: ("User Memory (Individual Scale)", "Knowledge Base (Group Scale)"),
+    2: ("Simple Notes", "Advanced JSON Cards"),
+    3: ("v2 (2025 paper)", "v3 (April 2026)"),
+    4: ("Working Memory", "Procedural"),
+    5: ("① User Query", "④ Generate"),
+    6: ("Word2Vec", "BGE-M3"),
+    7: ("Layer 2 (sparse · long-range connections)", "O(log N) query complexity"),
+    8: ("Term frequency saturation (TF)", "Length normalization (b)"),
+    9: ("Dense retrieval", "Sparse retrieval (BM25)", "Neural\nRe-ranking"),
+    10: ("Global Summary", "Bottom-up Recursive Abstraction"),
+    11: ("My Dentist", "Multi-hop reasoning"),
+    12: ("Non-agentic RAG", "Agentic RAG"),
+    13: ("Agent (ReAct Loop)", "Knowledge Base Backend (Switchable)"),
+    14: ("Traditional chunking (no context)", "Context-aware chunking"),
+    15: ("Phase 1: Knowledge Extraction and Structuring", "Phase 2: Factor Analysis and Knowledge Modeling"),
+}
+
+
+def svg_text(path: Path) -> str:
+    root = ElementTree.parse(path).getroot()
+    return "\n".join(text.strip() for text in root.itertext() if text.strip())
+
+
+def test_chapter_3_references_each_numbered_figure_once():
+    markdown = CHAPTER.read_text(encoding="utf-8")
+    references = [
+        int(number)
+        for number in re.findall(r"images/fig3-(\d+)\.svg", markdown)
+    ]
+
+    assert references == list(range(1, 16))
+
+
+def test_chapter_3_english_figures_match_their_captions():
+    for number, anchors in EXPECTED_ANCHORS.items():
+        text = svg_text(IMAGE_DIR / f"fig3-{number}.svg")
+        for anchor in anchors:
+            assert anchor in text, f"Figure 3-{number} is missing {anchor!r}"

--- a/uv.lock
+++ b/uv.lock
@@ -545,6 +545,7 @@ ch9 = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 dev = [
+    { name = "httpx" },
     { name = "markdown" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -748,6 +749,7 @@ requires-dist = [
     { name = "hnswlib", marker = "extra == 'rag'", specifier = ">=0.8" },
     { name = "html2text", marker = "extra == 'web'", specifier = ">=2020.1.16" },
     { name = "httpx", marker = "extra == 'ch9'", specifier = ">=0.27" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27,<1" },
     { name = "httpx", marker = "extra == 'web'", specifier = ">=0.27" },
     { name = "huggingface-hub", marker = "extra == 'rag'", specifier = ">=0.34.0" },
     { name = "jieba", marker = "extra == 'rag'", specifier = ">=0.42.1" },


### PR DESCRIPTION
## Summary

- restore the correct English diagrams for Figures 3-2, 3-4–3-7, and 3-9–3-14
- preserve the existing correct versions of Figures 3-1, 3-3, 3-8, and 3-15
- proofread diagram text and fix clipping, overlapping labels, capitalization, and stale translation artifacts
- add regression coverage that verifies every Chapter 3 figure contains content matching its caption

## Root cause

The Chapter 3 SVG updates imported from #13 placed several diagrams under the wrong figure filenames. As a result, the English chapter captions remained correct while the rendered diagrams described different topics.

This PR restores the last semantically correct diagrams, reconciles them with subsequent valid updates, and adds a regression test to prevent figure-number drift.

## Impact

The English web, PDF, and EPUB editions will once again show the correct diagram beneath every Chapter 3 figure caption.

## Proofreading

All fifteen Chapter 3 diagrams were rendered and reviewed. The proofreading pass also corrected:

- double-escaped quotation marks
- an untranslated Chinese label
- awkward or inconsistent English
- undersized text
- relationship labels overlapping nodes and connectors
- arrow annotations crossing connector lines
- dense GraphRAG explanatory text

## Validation

- `xmllint --noout book-en/images/fig3-*.svg`
- `python3 book-en/fit_svg_text.py <affected SVGs>` — second run adjusted 0 files
- `.venv/bin/ruff check tests/test_ch3_english_figures.py`
- `.venv/bin/pytest -q tests/test_ch3_english_figures.py` — 2 passed
- `git diff --check`
- rendered and visually inspected all fifteen SVGs
- compiled a standalone 36-page Chapter 3 PDF with XeLaTeX and inspected every figure page

The complete book build was also attempted, but the local environment does not contain `elegantbook.cls`; the focused Chapter 3 PDF build completed successfully.

Fixes #818
