### PR TITLE
fix(site): switch the MT tier off the dead client.edge channel

### DIFF
--- a/extras/auto-translate.js
+++ b/extras/auto-translate.js
@@ -108,8 +108,14 @@
       "md-source", // repository name + stars/forks in the header
     ]);
 
-    // Re-translate content injected after load (search results, annotations).
-    translate.listener.start();
+    // translate.listener.start() installs a MutationObserver that re-translates
+    // injected content. It is off by default: against Material's
+    // navigation.instant swaps it throws "Cannot read properties of null
+    // (reading 'nodeValue')" from its own callback, and queues a duplicate
+    // translation pass per mutation. Material's `document$` already tells us
+    // when a page swap finished, which is the only dynamic content that
+    // matters here, so we drive re-translation from that instead.
+    if (conf.listener) translate.listener.start();
   }
 
   function translatePage() {
@@ -122,6 +128,7 @@
         configure(translate, conf);
         if (translate.to !== language.name) translate.changeLanguage(language.name);
         else translate.execute();
+        watchForFailure(language, conf);
       })
       .catch(function (error) {
         // Leave the English page readable rather than failing loudly.
@@ -130,14 +137,47 @@
       });
   }
 
+  // translate.js reports a failed translation service only to the console, so
+  // a dead channel would silently leave the reader on English with a notice
+  // claiming the page was translated. The notice sits inside the translated
+  // region, so a working service always rewrites it; if it is still unchanged
+  // after the timeout, say the service is unavailable instead.
+  var failureTimer = null;
+
+  function watchForFailure(language, conf) {
+    var probe = document.querySelector(".auto-translate-notice__text");
+    if (!probe) return;
+    var before = probe.textContent;
+    clearTimeout(failureTimer);
+    failureTimer = setTimeout(function () {
+      var node = document.querySelector(".auto-translate-notice__text");
+      if (node && node.textContent === before) showNotice(language, true);
+    }, conf.failureTimeoutMs || 12000);
+  }
+
   // ── notice ────────────────────────────────────────────────
+
+  var NOTICE_TEXT = {
+    ok:
+      "Machine-translated from the English edition — not reviewed. " +
+      "Figures and code stay in English.",
+    failed: "Machine translation is unavailable right now. Showing the English edition.",
+  };
 
   function showNotice(language, failed) {
     var host = document.querySelector(".md-content__inner");
     if (!host) return;
 
     var existing = host.querySelector(".auto-translate-notice");
-    if (existing) existing.parentNode.removeChild(existing);
+    if (existing) {
+      // Update in place: replacing the node would detach the text node that an
+      // in-flight translation pass is holding a reference to.
+      existing.className =
+        "auto-translate-notice" + (failed ? " auto-translate-notice--failed" : "");
+      var current = existing.querySelector(".auto-translate-notice__text");
+      if (current) current.textContent = failed ? NOTICE_TEXT.failed : NOTICE_TEXT.ok;
+      return;
+    }
 
     var notice = document.createElement("div");
     notice.className = "auto-translate-notice";
@@ -148,10 +188,7 @@
 
     var text = document.createElement("span");
     text.className = "auto-translate-notice__text";
-    text.textContent = failed
-      ? "Machine translation is unavailable right now. Showing the English edition."
-      : "Machine-translated from the English edition — not reviewed. " +
-        "Figures and code stay in English.";
+    text.textContent = failed ? NOTICE_TEXT.failed : NOTICE_TEXT.ok;
 
     var off = document.createElement("button");
     off.type = "button";

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -194,9 +194,21 @@ extra:
     # site language code; `sourceLanguage` is translate.js' name for it.
     source: en
     sourceLanguage: english
-    # Free, keyless channel. Alternatives: `giteeAI`, `siliconflow`, or
-    # `translate.service` against a self-hosted API.
-    service: client.edge
+    # Free, keyless channel. NOT `client.edge`: that channel authenticates
+    # against https://edge.microsoft.com/translate/auth, an undocumented Edge
+    # browser endpoint that now returns 404, so it fails for every visitor.
+    # `giteeAI` posts to giteeai.zvo.cn/translate.json (verified working,
+    # keyless) and fails over to two backup hosts on its own.
+    # Alternatives: `siliconflow`, or `translate.service` against a self-host.
+    service: giteeAI
+    # translate.js' MutationObserver (translate.listener.start) throws
+    # "Cannot read properties of null (reading 'nodeValue')" against Material's
+    # navigation.instant DOM swaps, and queues a redundant translation pass per
+    # mutation. We re-translate on Material's own `document$` instead, so it
+    # stays off unless you explicitly want it.
+    listener: false
+    # How long to wait before telling the reader the service is not answering.
+    failureTimeoutMs: 12000
     # Pinned version + SRI hash: this is third-party code from a public CDN,
     # so the exact bytes are fixed. Both must be updated together.
     cdn: https://cdn.staticfile.net/translate.js/3.18.66/translate.js

--- a/tests/js/auto-translate.test.js
+++ b/tests/js/auto-translate.test.js
@@ -21,7 +21,9 @@ const CONF = {
   label: "机器翻译 / Machine translation",
   source: "en",
   sourceLanguage: "english",
-  service: "client.edge",
+  service: "giteeAI",
+  listener: false,
+  failureTimeoutMs: 60,
   cdn: "https://cdn.example.test/translate.js",
   integrity: "sha384-TESTHASH",
   languages: [
@@ -146,10 +148,10 @@ test("on the English edition it loads, configures and translates", async () => {
   assert.strictEqual(injected[0].crossOrigin, "anonymous");
 
   const t = w.translate;
-  assert.strictEqual(t.service.used, "client.edge");
+  assert.strictEqual(t.service.used, "giteeAI");
   assert.strictEqual(t.language.local, "english");
   assert.strictEqual(t.selectLanguageTag.show, false);
-  assert.ok(t.listener.started);
+  assert.strictEqual(t.listener.started, false, "MutationObserver must stay off by default");
   assert.ok(t.ignore.tag.includes("mjx-container"), "MathJax output must be ignored");
   assert.ok(t.ignore.tag.includes("pre") && t.ignore.tag.includes("code"), "defaults kept");
   for (const c of ["mermaid", "arithmatex", "highlight", "md-source"]) {
@@ -228,6 +230,42 @@ test("corrupt storage is ignored rather than throwing", async () => {
   w.document.dispatchEvent(new w.Event("DOMContentLoaded"));
   await tick();
   assert.strictEqual(injected.length, 0);
+});
+
+test("starts translate.js' listener only when explicitly enabled", async () => {
+  const { w } = await setup();
+  w.AUTO_TRANSLATE_CONFIG = { ...CONF, listener: true };
+  w.document.querySelector('[data-auto-lang="french"]').click();
+  await tick();
+  assert.strictEqual(w.translate.listener.started, true);
+});
+
+test("warns in place when the translation service never answers", async () => {
+  const { w } = await setup();
+  w.document.querySelector('[data-auto-lang="french"]').click();
+  await tick();
+  // Service is dead: the notice text is never rewritten.
+  const notice = w.document.querySelector(".auto-translate-notice");
+  const before = notice.querySelector(".auto-translate-notice__text").textContent;
+  await new Promise((r) => setTimeout(r, 120));
+  const after = w.document.querySelector(".auto-translate-notice");
+  assert.ok(after.className.includes("auto-translate-notice--failed"), "should flag failure");
+  assert.match(after.textContent, /unavailable/);
+  // Same node, not a replacement — an in-flight pass may hold a reference.
+  assert.strictEqual(after, notice);
+  assert.notStrictEqual(after.querySelector(".auto-translate-notice__text").textContent, before);
+});
+
+test("stays silent when the service does answer", async () => {
+  const { w } = await setup();
+  w.document.querySelector('[data-auto-lang="french"]').click();
+  await tick();
+  // Simulate translate.js rewriting the page (including our notice).
+  w.document.querySelector(".auto-translate-notice__text").textContent =
+    "Traduit automatiquement de l'\u00e9dition anglaise";
+  await new Promise((r) => setTimeout(r, 120));
+  const notice = w.document.querySelector(".auto-translate-notice");
+  assert.ok(!notice.className.includes("auto-translate-notice--failed"), "must not cry wolf");
 });
 
 (async () => {


### PR DESCRIPTION
Follow-up to #822. The machine-translation tier shipped, but selecting a language leaves the page in English — the menu, routing to the English edition, notice and checkmark all work, and then nothing translates.

## Cause

Not the integration. `client.edge` authenticates against `https://edge.microsoft.com/translate/auth`, an **undocumented endpoint of Edge's built-in translator**, and Microsoft now returns 404 there. From a reader's console:

```
request url : https://edge.microsoft.com/translate/auth
http code   : 404
translate.js  edge translate service error, http code : 404
```

Verified directly, just now:

| endpoint | result |
|---|---|
| `https://edge.microsoft.com/translate/auth` | **HTTP 404** |
| `https://api.translate.zvo.cn/…` | unreachable from my network |
| `https://giteeai.zvo.cn/` | **HTTP 200**, 0.19 s |

So that channel fails for every visitor, everywhere — nothing to do with this site.

## Fix

Switch to **`giteeAI`**, verified end-to-end and keyless before changing anything:

```
POST https://giteeai.zvo.cn/translate.json   from=english&to=french
{"result":1,"info":"SUCCESS","text":["Le cycle d'interaction agent-environnement"]}

POST … to=deutsch
{"result":1,"info":"SUCCESS","text":["Context Engineering ist die Praxis, zu entwerfen, was das Modell sieht."]}
```

It fails over to two backup hosts (`deutsch.enterprise.api.translate.zvo.cn:1000`, `api.translate.zvo.cn:1000`) on its own. This also re-confirms `deutsch` rather than `german`.

## Two related fixes

**The uncaught `TypeError`.** Readers also saw:

```
Uncaught TypeError: Cannot read properties of null (reading 'nodeValue')
    at Object.nodeValueChangeNeedTranslate (translate.js:1356)
    at translate.listener.callback (translate.js:1430)
```

That is a translate.js bug in its own MutationObserver, hit by Material's `navigation.instant` DOM swaps; it was also queueing a duplicate translation pass per mutation (the `当前翻译未完结，新翻译任务已加入等待翻译队列` spam). `translate.listener.start()` is now **off by default** behind a `listener:` config flag — we already re-translate on Material's `document$`, which is the dynamic content that actually matters on this site. Enabling the flag restores the old behaviour if search-result translation is ever wanted more than a clean console.

**Silent failure — the part that made this confusing.** translate.js reports a failed service only to the console, so a dead channel left the reader on English *underneath a notice claiming the page was machine-translated*. The notice sits inside the translated region, so a working service always rewrites it; if it is still unchanged after `failureTimeoutMs` (12 s), it now says translation is unavailable. It updates **in place** rather than being replaced, so an in-flight pass cannot write into a detached node.

## Testing

`tests/js/auto-translate.test.js` is up to **15 cases, all passing**, including three new ones:

- the MutationObserver stays off by default and starts only when `listener: true`
- the failure warning appears, in the same DOM node, when the service never answers
- the failure warning does **not** fire when the service does answer (no crying wolf)

`tests/test_split_search_index.py` (15 cases, from #821) also still passes on this branch.

## Note for later

This is the failure mode flagged when the tier was scoped: the free keyless channels are undocumented third-party endpoints that can disappear without notice. It cost a live breakage on an opt-in fallback, which is survivable — it would not have been if the 13 real editions depended on it. If it breaks again the fix is a one-line `service:` change, or point `translate.service` at a self-hosted API.

Worth a browser check once this is deployed — I can verify the endpoint, not the rendered page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)