### PR TITLE
docs: update the remaining Memobase cloud URL to memobase.ai

### DIFF
--- a/chapter3/memobase/profile_demo.py
+++ b/chapter3/memobase/profile_demo.py
@@ -17,7 +17,7 @@ flush 时才统一触发一次 LLM 记忆提取，查询侧（profile/event/cont
 运行前提：Memobase 需要一个正在运行的服务端 + 用于提取记忆的 LLM。
   * 自托管：见 https://github.com/memodb-io/memobase （docker compose 启动，
     默认服务地址 http://localhost:8019，默认 token 为 secret）；
-  * 云服务：在 https://www.memobase.io 申请 project_url 与 api_key。
+  * 云服务：在 https://www.memobase.ai 申请 project_url 与 api_key。
 无服务端时可用 --dry-run 查看示例对话与将要执行的操作（不联网、不伪造结果）。
 """
 


### PR DESCRIPTION
Follow-up to #852. That PR fixed the two `https://www.memobase.io` occurrences in `chapter3/memobase/README.md`, but the module docstring of `chapter3/memobase/profile_demo.py` still pointed readers at the same dead domain for cloud credentials.

Verified again just now: `https://www.memobase.io` → 404, `https://www.memobase.ai` → 200.

After this change, `grep -rn "memobase\.io"` over the repo (excluding the vendored `chapter3/memobase/memobase/` upstream checkout) returns nothing.

**On syncing to the other language editions:** there is nothing to sync. The URL never appeared outside these two files — no `book-*/chapter3.*` edition, and no translated chapter index (`chapter3/README.{en,ja,ko,es,ru,tr,ta,hu,id,vi,ar,zh-TW}.md`), mentions the domain; they reference Memobase only by name. Experiment sub-directory READMEs such as `chapter3/memobase/README.md` have no per-language variants either — that file is a single bilingual (EN + 中文) document that `scripts/build_site.sh` copies unchanged into every language build, so #852 already covered every edition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)