### PR TITLE
fix(epub): 修復 Kindle 深色模式的白底段落

### DIFF
--- a/epub.css
+++ b/epub.css
@@ -90,6 +90,7 @@ html[lang="ar"] .math {
 
 p {
   margin: 0 0 0.8em 0;
+  background-color: transparent !important;
 }
 
 /* ── 标题 ──────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## 問題

繁中 EPUB 直接使用 Apple Books 閱讀時，深色模式顯示正常；但經過 Send to Kindle 轉檔後，一般
`<p>` 段落會在 Kindle 深色模式中出現白色背景區塊，列表和標題則不受影響。

<img width="1518" height="963" alt="image" src="https://github.com/user-attachments/assets/9d752188-e195-4a61-a8e1-8a9712e8850d" />

## 修復

為一般段落明確指定透明背景：

```css
p {
  background-color: transparent !important;
}
```

這會覆蓋 Kindle 轉檔後套用的段落背景，讓 Kindle 閱讀器主題控制頁面底色。

原本的 color-scheme 和 prefers-color-scheme 暗色配色均保留，因此不會改變 Apple Books 等其他閱
讀器既有的 code block、blockquote 暗色樣式，也不影響 PDF build。

## 驗證

- Send to Kindle 轉檔後，在 Kindle 深色模式確認白底段落已消失
- EPUBCheck 5.3.0：0 errors、0 warnings