### PR TITLE
fix(site): report machine-translation progress instead of crying wolf

### DIFF
--- a/extras/auto-translate.css
+++ b/extras/auto-translate.css
@@ -50,8 +50,50 @@
   border-left-color: var(--md-typeset-del-color, #f5504e);
 }
 
+.auto-translate-notice--pending {
+  border-left-color: var(--fenix-ink-muted, var(--md-default-fg-color--light));
+}
+
+/* All three states' wording lives in the DOM at once so a single translation
+   pass covers them (see auto-translate.js); only the current one is shown. */
 .auto-translate-notice__text {
+  display: none;
   flex: 1 1 16rem;
+}
+
+.auto-translate-notice[data-state="pending"] .auto-translate-notice__text--pending,
+.auto-translate-notice[data-state="ok"] .auto-translate-notice__text--ok,
+.auto-translate-notice[data-state="failed"] .auto-translate-notice__text--failed {
+  display: block;
+}
+
+/* Progress: a spinner rather than a bar, because translate.js reports batches
+   finishing, not a fraction done. */
+.auto-translate-notice__text--pending::before {
+  content: "";
+  display: inline-block;
+  width: 0.72em;
+  height: 0.72em;
+  margin-inline-end: 0.45em;
+  vertical-align: -0.06em;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: auto-translate-spin 0.8s linear infinite;
+}
+
+@keyframes auto-translate-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .auto-translate-notice__text--pending::before {
+    border-top-color: currentColor;
+    opacity: 0.5;
+    animation: none;
+  }
 }
 
 .auto-translate-notice__off {

--- a/extras/auto-translate.js
+++ b/extras/auto-translate.js
@@ -12,8 +12,10 @@
 //   * Opt-in and lazy. The third-party script is fetched only after the reader
 //     chooses one of these languages — a page view in a real edition makes no
 //     request to it. It is pinned to a version and loaded with an SRI hash.
-//   * Always labelled. An "auto-translated" notice sits above the content for
-//     as long as the tier is active, and says what it cannot translate.
+//   * Always labelled, and honest about what is on screen. A notice sits above
+//     the content for as long as the tier is active, tracking the translation
+//     through three states — translating / translated / unavailable — off
+//     translate.js' own lifecycle hooks, and says what it cannot translate.
 //   * Translated from the English edition, not the Chinese one: MT quality out
 //     of English is better for most targets, and that edition is reviewed. So
 //     selecting a tier-3 language first routes to the English page.
@@ -107,6 +109,14 @@
       "highlight", // code block wrapper (line-number table sits outside <pre>)
       "md-source", // repository name + stars/forks in the header
     ]);
+    // The language switcher lists every edition under its own endonym — 中文,
+    // 日本語, العربية, עברית … Translating those is wrong twice over: a reader
+    // looking for their language wants to see its own name, and translate.js
+    // batches by detected source language, so those labels alone cost one API
+    // request per script. That burst (a dozen requests at once) is what the
+    // free channel's "more than 2 requests in 2 seconds" guard rejects, taking
+    // the page's own batch down with it.
+    push(translate.ignore.id, ["lang-menu", "lang-selector"]);
 
     // translate.listener.start() installs a MutationObserver that re-translates
     // injected content. It is off by default: against Material's
@@ -123,72 +133,158 @@
     var conf = config();
     if (!language || !conf) return;
 
+    // The page on screen is still English until a pass lands, so say that.
+    setState("pending");
+
     loadLibrary(conf)
       .then(function (translate) {
         configure(translate, conf);
+        if (hookLifecycle(translate, conf)) armStallTimer(conf);
+        else watchNoticeText(conf);
         if (translate.to !== language.name) translate.changeLanguage(language.name);
         else translate.execute();
-        watchForFailure(language, conf);
       })
       .catch(function (error) {
         // Leave the English page readable rather than failing loudly.
         console.warn("[auto-translate]", error.message);
-        showNotice(language, true);
+        setState("failed");
       });
   }
 
+  // ── translation progress ──────────────────────────────────
+  //
   // translate.js reports a failed translation service only to the console, so
-  // a dead channel would silently leave the reader on English with a notice
-  // claiming the page was translated. The notice sits inside the translated
-  // region, so a working service always rewrites it; if it is still unchanged
-  // after the timeout, say the service is unavailable instead.
-  var failureTimer = null;
+  // the notice has to work out for itself whether the page in front of the
+  // reader is actually translated. translate.lifecycle is that signal:
+  //
+  //   execute.start                 a pass began       → "translating"
+  //   execute.translateNetworkAfter one batch came back (result 1 ok / 0 failed)
+  //   execute.renderFinish          every batch of the pass is rendered
+  //
+  // Watching them beats timing out on whether our own text changed. A pass can
+  // legitimately run for tens of seconds — the free channel retries against two
+  // backup hosts — and a fixed deadline declared those dead, then never looked
+  // again, so a translation that landed late left the reader staring at
+  // "unavailable" on a fully translated page. Here the deadline only fires when
+  // nothing has moved for a whole window, and a later renderFinish still
+  // corrects the notice.
+  var passes = {};
+  var stallTimer = null;
+  var hooked = false;
 
-  function watchForFailure(language, conf) {
-    var probe = document.querySelector(".auto-translate-notice__text");
+  function armStallTimer(conf) {
+    clearTimeout(stallTimer);
+    stallTimer = setTimeout(function () {
+      // Nothing moved for a whole window. Say so, but stay subscribed: if the
+      // pass does come back, renderFinish flips the notice to "translated".
+      if (noticeState === "pending") setState("failed");
+    }, conf.failureTimeoutMs || 12000);
+  }
+
+  function hookLifecycle(translate, conf) {
+    var cycle = translate.lifecycle && translate.lifecycle.execute;
+    if (!cycle || !cycle.start || !cycle.renderFinish) return false;
+    if (hooked) return true;
+    hooked = true;
+
+    // translate.js passes the legacy positional arguments to any handler
+    // declared with exactly two parameters, and the object form to every other
+    // arity — so `start` and `translateNetworkAfter` take one parameter here on
+    // purpose, and `renderFinish` is positional-only in the library.
+    cycle.start.push(function (data) {
+      passes[data.uuid] = { requests: 0, done: 0, sourceSeen: false, sourceDone: false };
+      setState("pending");
+      armStallTimer(conf);
+    });
+
+    cycle.translateNetworkAfter.push(function (data) {
+      var pass = passes[data.uuid];
+      if (!pass) return;
+      pass.requests++;
+      if (data.result === 1) pass.done++;
+      if (data.from === (conf.sourceLanguage || "english")) {
+        pass.sourceSeen = true;
+        if (data.result === 1) pass.sourceDone = true;
+      }
+      armStallTimer(conf); // a batch came back: the pass is alive
+    });
+
+    cycle.renderFinish.push(function (uuid) {
+      var pass = passes[uuid];
+      delete passes[uuid];
+      clearTimeout(stallTimer);
+      // No request at all means every string came out of the local cache.
+      // Where there were requests, the one that decides this is the batch out
+      // of the source language: that is the book's own prose. Other batches
+      // are stray strings in other scripts, and one of those failing says
+      // nothing about the page the reader is looking at.
+      var failed =
+        !!pass && pass.requests > 0 && (pass.sourceSeen ? !pass.sourceDone : pass.done === 0);
+      setState(failed ? "failed" : "ok");
+    });
+
+    cycle.finally.push(function (data) {
+      // 5: the page is already in the target language, so the pass returns
+      // before renderFinish. Nothing to translate is not a failure.
+      if (data.state === 5) {
+        clearTimeout(stallTimer);
+        setState("ok");
+      }
+    });
+
+    return true;
+  }
+
+  // Fallback for a translate.js without lifecycle hooks (pre-3.18). The notice
+  // sits inside the translated region, so a working service rewrites it.
+  function watchNoticeText(conf) {
+    var probe = document.querySelector(".auto-translate-notice__text--ok");
     if (!probe) return;
     var before = probe.textContent;
-    clearTimeout(failureTimer);
-    failureTimer = setTimeout(function () {
-      var node = document.querySelector(".auto-translate-notice__text");
-      if (node && node.textContent === before) showNotice(language, true);
+    clearTimeout(stallTimer);
+    stallTimer = setTimeout(function () {
+      var node = document.querySelector(".auto-translate-notice__text--ok");
+      if (node) setState(node.textContent === before ? "failed" : "ok");
     }, conf.failureTimeoutMs || 12000);
   }
 
   // ── notice ────────────────────────────────────────────────
 
+  var STATES = ["pending", "ok", "failed"];
+
   var NOTICE_TEXT = {
+    pending: "Machine-translating this page in your browser — one moment.",
     ok:
       "Machine-translated from the English edition — not reviewed. " +
       "Figures and code stay in English.",
     failed: "Machine translation is unavailable right now. Showing the English edition.",
   };
 
-  function showNotice(language, failed) {
+  var noticeState = null;
+
+  // Every state's wording is in the DOM from the start, with CSS showing one at
+  // a time. That is what lets the notice speak the reader's language: a pass
+  // translates all three at once, so switching states afterwards is a class
+  // change rather than fresh English text that nothing will ever come back for.
+  function buildNotice() {
     var host = document.querySelector(".md-content__inner");
-    if (!host) return;
+    if (!host) return null;
 
     var existing = host.querySelector(".auto-translate-notice");
-    if (existing) {
-      // Update in place: replacing the node would detach the text node that an
-      // in-flight translation pass is holding a reference to.
-      existing.className =
-        "auto-translate-notice" + (failed ? " auto-translate-notice--failed" : "");
-      var current = existing.querySelector(".auto-translate-notice__text");
-      if (current) current.textContent = failed ? NOTICE_TEXT.failed : NOTICE_TEXT.ok;
-      return;
-    }
+    if (existing) return existing;
 
     var notice = document.createElement("div");
     notice.className = "auto-translate-notice";
-    if (failed) notice.className += " auto-translate-notice--failed";
-    // Written in the source language on purpose: translate.js picks it up with
-    // the rest of the page, so the reader sees it in their own language.
     notice.setAttribute("role", "note");
 
-    var text = document.createElement("span");
-    text.className = "auto-translate-notice__text";
-    text.textContent = failed ? NOTICE_TEXT.failed : NOTICE_TEXT.ok;
+    for (var i = 0; i < STATES.length; i++) {
+      var text = document.createElement("span");
+      text.className = "auto-translate-notice__text auto-translate-notice__text--" + STATES[i];
+      // Written in the source language on purpose: translate.js picks it up
+      // with the rest of the page, so the reader sees it in their own language.
+      text.textContent = NOTICE_TEXT[STATES[i]];
+      notice.appendChild(text);
+    }
 
     var off = document.createElement("button");
     off.type = "button";
@@ -199,15 +295,38 @@
       location.reload();
     });
 
-    notice.appendChild(text);
     notice.appendChild(off);
     host.insertBefore(notice, host.firstChild);
+    return notice;
   }
 
+  function setState(state) {
+    noticeState = state;
+    // Update in place: replacing the node would detach the text nodes that an
+    // in-flight translation pass is holding references to.
+    var notice = buildNotice();
+    if (!notice) return;
+    notice.className = "auto-translate-notice auto-translate-notice--" + state;
+    notice.setAttribute("data-state", state);
+    // Only claim the reader's locale once the page is actually in it. While a
+    // pass is running, and after one failed, the text on screen is still
+    // English — and an <html lang> that disagrees with it (or an RTL flip over
+    // English prose) misleads screen readers and hyphenation both.
+    applyDocumentLocale(state === "ok" ? selected() : null);
+  }
+
+  var SOURCE_LOCALE = document.documentElement.lang || "en";
+  var SOURCE_DIR = document.documentElement.dir === "rtl" ? "rtl" : "ltr";
+
   function applyDocumentLocale(language) {
-    if (!language) return;
-    if (language.locale) document.documentElement.lang = language.locale;
-    document.documentElement.dir = language.dir === "rtl" ? "rtl" : "ltr";
+    var root = document.documentElement;
+    if (!language) {
+      root.lang = SOURCE_LOCALE;
+      root.dir = SOURCE_DIR;
+      return;
+    }
+    if (language.locale) root.lang = language.locale;
+    root.dir = language.dir === "rtl" ? "rtl" : "ltr";
   }
 
   // ── language menu ─────────────────────────────────────────
@@ -292,8 +411,6 @@
       return;
     }
 
-    applyDocumentLocale(language);
-    showNotice(language, false);
     syncMenuState(conf);
     translatePage();
   }
@@ -306,10 +423,8 @@
     buildMenuGroup(conf);
     syncMenuState(conf);
 
-    var active = selected();
-    if (!active) return;
-    applyDocumentLocale(active);
-    showNotice(active, false);
+    if (!selected()) return;
+    // translatePage() puts up the notice; it owns which state it shows.
     translatePage();
   }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -213,7 +213,11 @@ extra:
     # mutation. We re-translate on Material's own `document$` instead, so it
     # stays off unless you explicitly want it.
     listener: false
-    # How long to wait before telling the reader the service is not answering.
+    # How long a translation pass may go without any sign of life before the
+    # notice tells the reader the service is not answering. It is a stall
+    # window, not a deadline: every batch that comes back restarts it, and a
+    # pass that lands after it expired still clears the warning. The states in
+    # between ("translating", "translated") come from translate.lifecycle.
     failureTimeoutMs: 12000
     # Pinned version + SRI hash: this is third-party code from a public CDN,
     # so the exact bytes are fixed. Both must be updated together.

--- a/tests/js/auto-translate.test.js
+++ b/tests/js/auto-translate.test.js
@@ -32,9 +32,11 @@ const CONF = {
   ],
 };
 
-// A stand-in for translate.js with the same API surface the script touches.
-function fakeTranslate() {
-  return {
+// A stand-in for translate.js with the same API surface the script touches,
+// including the lifecycle hooks the notice's state machine subscribes to.
+// Nothing fires on its own: each test drives the pass it wants to describe.
+function fakeTranslate({ lifecycle = true } = {}) {
+  const t = {
     to: "",
     selectLanguageTag: { show: true },
     service: { used: null, use(n) { this.used = n; } },
@@ -42,12 +44,40 @@ function fakeTranslate() {
     ignore: { tag: ["style", "script", "link", "pre", "code"], class: ["ignore"], id: [] },
     listener: { started: false, start() { this.started = true; } },
     calls: [],
-    changeLanguage(n) { this.to = n; this.calls.push(["changeLanguage", n]); },
-    execute() { this.calls.push(["execute"]); },
+    changeLanguage(n) { this.to = n; this.calls.push(["changeLanguage", n]); this.pass && this.pass.start(); },
+    execute() { this.calls.push(["execute"]); this.pass && this.pass.start(); },
   };
+  if (!lifecycle) return t;
+
+  t.lifecycle = {
+    execute: { start: [], translateNetworkAfter: [], renderFinish: [], finally: [] },
+  };
+  const fire = (name, ...args) => t.lifecycle.execute[name].forEach((f) => f(...args));
+  let uuid = 0;
+  // Mirrors what translate.js emits for one translate.execute() call.
+  t.pass = {
+    uuid: null,
+    start() { this.uuid = "uuid-" + ++uuid; fire("start", { uuid: this.uuid, to: t.to }); },
+    batch(from, result) {
+      fire("translateNetworkAfter", { uuid: this.uuid, from, to: t.to, result });
+    },
+    renderFinish() { fire("renderFinish", this.uuid, t.to); },
+    finally(state) { fire("finally", { uuid: this.uuid, to: t.to, state }); },
+  };
+  return t;
 }
 
-async function setup({ path = "/ai-agent-book/book-en/chapter1/", stored = null, urlFor = () => null } = {}) {
+const stateOf = (w) => {
+  const n = w.document.querySelector(".auto-translate-notice");
+  return n && n.getAttribute("data-state");
+};
+
+async function setup({
+  path = "/ai-agent-book/book-en/chapter1/",
+  stored = null,
+  urlFor = () => null,
+  lifecycle = true,
+} = {}) {
   const navErrors = [];
   const vc = new VirtualConsole();
   vc.on("jsdomError", (e) => navErrors.push(e.message));
@@ -78,7 +108,7 @@ async function setup({ path = "/ai-agent-book/book-en/chapter1/", stored = null,
     }
     return realAppend(node);
   };
-  w.__fakeTranslate = fakeTranslate();
+  w.__fakeTranslate = fakeTranslate({ lifecycle });
 
   const replaced = [];
   try { w.location.replace = (u) => replaced.push(u); } catch (_) {}
@@ -157,20 +187,74 @@ test("on the English edition it loads, configures and translates", async () => {
   for (const c of ["mermaid", "arithmatex", "highlight", "md-source"]) {
     assert.ok(t.ignore.class.includes(c), `${c} must be ignored`);
   }
+  // The language menu lists every edition under its own endonym; translating
+  // those is both wrong and one API request per script.
+  for (const id of ["lang-menu", "lang-selector"]) {
+    assert.ok(t.ignore.id.includes(id), `#${id} must be ignored`);
+  }
   assert.deepStrictEqual(t.calls, [["changeLanguage", "french"]]);
 });
 
-test("shows a labelled notice and marks the document locale", async () => {
+test("shows a labelled notice carrying every state's wording", async () => {
   const { w } = await setup();
   w.document.querySelector('[data-auto-lang="hebrew"]').click();
   await tick();
   const notice = w.document.querySelector(".auto-translate-notice");
   assert.ok(notice, "notice missing");
+  // All three are in the DOM so one translation pass covers them; CSS shows one.
+  assert.match(notice.textContent, /Machine-translating this page/);
   assert.match(notice.textContent, /Machine-translated from the English edition/);
   assert.match(notice.textContent, /not reviewed/);
   assert.match(notice.textContent, /Figures and code stay in English/);
+  assert.match(notice.textContent, /unavailable/);
+  assert.strictEqual(w.document.querySelectorAll(".auto-translate-notice__text").length, 3);
+});
+
+test("reports progress while the pass runs, then that it is translated", async () => {
+  const { w } = await setup();
+  w.document.querySelector('[data-auto-lang="hebrew"]').click();
+  await tick();
+
+  // Mid-flight: the text on screen is still English, so neither the "done"
+  // wording nor the Hebrew locale may be claimed yet.
+  assert.strictEqual(stateOf(w), "pending");
+  assert.strictEqual(w.document.documentElement.lang, "en");
+  assert.strictEqual(w.document.documentElement.dir, "ltr");
+
+  w.translate.pass.batch("english", 1);
+  w.translate.pass.renderFinish();
+  assert.strictEqual(stateOf(w), "ok");
   assert.strictEqual(w.document.documentElement.lang, "he");
   assert.strictEqual(w.document.documentElement.dir, "rtl");
+});
+
+test("a pass that renders without any request counts as translated", async () => {
+  // Everything came out of translate.js' local cache — no network, no failure.
+  const { w } = await setup();
+  w.document.querySelector('[data-auto-lang="french"]').click();
+  await tick();
+  w.translate.pass.renderFinish();
+  assert.strictEqual(stateOf(w), "ok");
+});
+
+test("a failed batch in another source language does not mask a translated page", async () => {
+  const { w } = await setup();
+  w.document.querySelector('[data-auto-lang="french"]').click();
+  await tick();
+  w.translate.pass.batch("english", 1); // the book's prose
+  w.translate.pass.batch("chinese_simplified", 0); // a stray string elsewhere
+  w.translate.pass.renderFinish();
+  assert.strictEqual(stateOf(w), "ok");
+});
+
+test("a failed source-language batch is reported as unavailable", async () => {
+  const { w } = await setup();
+  w.document.querySelector('[data-auto-lang="french"]').click();
+  await tick();
+  w.translate.pass.batch("english", 0);
+  w.translate.pass.renderFinish();
+  assert.strictEqual(stateOf(w), "failed");
+  assert.strictEqual(w.document.documentElement.lang, "en", "must not claim the target locale");
 });
 
 test("a stored selection is re-applied on the next page load", async () => {
@@ -219,9 +303,8 @@ test("a failed library load degrades to a visible warning", async () => {
   w.console.warn = () => {};
   w.document.querySelector('[data-auto-lang="french"]').click();
   await tick();
-  const notice = w.document.querySelector(".auto-translate-notice--failed");
-  assert.ok(notice, "failure notice missing");
-  assert.match(notice.textContent, /unavailable/);
+  assert.strictEqual(stateOf(w), "failed");
+  assert.ok(w.document.querySelector(".auto-translate-notice--failed"), "failure class missing");
 });
 
 test("corrupt storage is ignored rather than throwing", async () => {
@@ -240,32 +323,74 @@ test("starts translate.js' listener only when explicitly enabled", async () => {
   assert.strictEqual(w.translate.listener.started, true);
 });
 
-test("warns in place when the translation service never answers", async () => {
+test("warns when a pass stalls with nothing coming back", async () => {
   const { w } = await setup();
   w.document.querySelector('[data-auto-lang="french"]').click();
   await tick();
-  // Service is dead: the notice text is never rewritten.
   const notice = w.document.querySelector(".auto-translate-notice");
-  const before = notice.querySelector(".auto-translate-notice__text").textContent;
-  await new Promise((r) => setTimeout(r, 120));
-  const after = w.document.querySelector(".auto-translate-notice");
-  assert.ok(after.className.includes("auto-translate-notice--failed"), "should flag failure");
-  assert.match(after.textContent, /unavailable/);
+  await new Promise((r) => setTimeout(r, 120)); // past failureTimeoutMs
+  assert.strictEqual(stateOf(w), "failed");
   // Same node, not a replacement — an in-flight pass may hold a reference.
-  assert.strictEqual(after, notice);
-  assert.notStrictEqual(after.querySelector(".auto-translate-notice__text").textContent, before);
+  assert.strictEqual(w.document.querySelector(".auto-translate-notice"), notice);
 });
 
-test("stays silent when the service does answer", async () => {
+test("a batch coming back keeps a slow pass from being called dead", async () => {
   const { w } = await setup();
   w.document.querySelector('[data-auto-lang="french"]').click();
   await tick();
+  // The free channel retries against backup hosts, so batches can trickle in
+  // for well past one timeout window. Progress restarts the clock, not trips it.
+  for (let i = 0; i < 4; i++) {
+    await new Promise((r) => setTimeout(r, 40));
+    w.translate.pass.batch("english", 1);
+  }
+  assert.strictEqual(stateOf(w), "pending", "must not cry wolf while batches land");
+  w.translate.pass.renderFinish();
+  assert.strictEqual(stateOf(w), "ok");
+});
+
+test("a late pass corrects a notice that already gave up", async () => {
+  // The reported bug: the page ends up translated, yet the notice still says
+  // the service is unavailable because nothing ever looked again.
+  const { w } = await setup();
+  w.document.querySelector('[data-auto-lang="french"]').click();
+  await tick();
+  await new Promise((r) => setTimeout(r, 120));
+  assert.strictEqual(stateOf(w), "failed");
+
+  w.translate.pass.batch("english", 1);
+  w.translate.pass.renderFinish();
+  assert.strictEqual(stateOf(w), "ok", "a translation that lands late must clear the warning");
+  assert.strictEqual(w.document.documentElement.lang, "fr");
+});
+
+test("a page already in the target language is not a failure", async () => {
+  const { w } = await setup();
+  w.document.querySelector('[data-auto-lang="french"]').click();
+  await tick();
+  w.translate.pass.finally(5); // local language == target: no render pass follows
+  await new Promise((r) => setTimeout(r, 120));
+  assert.strictEqual(stateOf(w), "ok");
+});
+
+test("without lifecycle hooks an untouched notice still warns", async () => {
+  const { w } = await setup({ lifecycle: false });
+  w.document.querySelector('[data-auto-lang="french"]').click();
+  await tick();
+  await new Promise((r) => setTimeout(r, 120));
+  assert.strictEqual(stateOf(w), "failed");
+});
+
+test("without lifecycle hooks it falls back to watching its own text", async () => {
+  const { w } = await setup({ lifecycle: false });
+  w.document.querySelector('[data-auto-lang="french"]').click();
+  await tick();
+  assert.strictEqual(stateOf(w), "pending");
   // Simulate translate.js rewriting the page (including our notice).
-  w.document.querySelector(".auto-translate-notice__text").textContent =
+  w.document.querySelector(".auto-translate-notice__text--ok").textContent =
     "Traduit automatiquement de l'\u00e9dition anglaise";
   await new Promise((r) => setTimeout(r, 120));
-  const notice = w.document.querySelector(".auto-translate-notice");
-  assert.ok(!notice.className.includes("auto-translate-notice--failed"), "must not cry wolf");
+  assert.strictEqual(stateOf(w), "ok");
 });
 
 (async () => {


### PR DESCRIPTION
## The bug

> "Machine translation is unavailable right now. Showing the English edition." — shown even when translate.js has already finished translating the page.

The notice decided whether the service was alive by checking, **once and 12s in**, whether translate.js had rewritten the notice's own text. The free giteeAI channel retries against two backup hosts, so a pass routinely lands after that deadline — and nothing ever looked again. Readers ended up on a fully translated page still being told the service was down.

Reproduced against the live site and the pinned library in a headless browser.

## The fix

Drive the notice off translate.js' own lifecycle hooks rather than a stopwatch:

| hook | meaning |
| --- | --- |
| `execute.start` | a pass began → **translating** |
| `execute.translateNetworkAfter` | one source-language batch came back (`result` 1 ok / 0 failed) |
| `execute.renderFinish` | every batch of the pass is rendered → **translated** / **unavailable** |

Three honest states, and a pass that lands late now *clears* the warning instead of being ignored. All three wordings sit in the DOM at once so a single pass translates them all — switching state is a class change, not fresh untranslated English that nothing will ever come back for.

Only the batch out of English decides the verdict: a stray string in another script failing no longer condemns a page whose prose translated fine.

Two related fixes fall out of it:

- `failureTimeoutMs` becomes a **stall window**, restarted by every batch that comes back, rather than a deadline for the whole pass.
- `<html lang>` / `dir` is only switched once the page really is translated. It used to flip to the target locale — and to RTL — over English prose.

## Also: stop translating the language menu

translate.js batches **per detected source language**, and the switcher lists every edition under its own endonym (中文, 日本語, العربية, עברית …). Those labels alone cost one API request per script — ten in a burst on a live page, which the channel rejects with `您当前2秒内的请求次数已超过2次`, taking the page's own batch down with it. `#lang-menu` / `#lang-selector` now go in `translate.ignore.id`; language names should stay in their own script anyway.

Harness page went from 3 requests to 1; the live site was firing 10.

## Verification

Against the pinned translate.js 3.18.66 in a headless browser with a stubbed service:

| service behaviour | result |
| --- | --- |
| answers | translating → **translated** in 4s, notice rendered in the target language |
| fails | translating → **unavailable** in 4s (not 12) |
| answers at 16s | translating → unavailable → **translated** ← the reported bug |

`node tests/js/auto-translate.test.js` — 23/23 pass (7 new cases covering the state machine, including the late-landing pass).

## Not fixed here

The giteeAI channel is currently over its daily cap (`您当日翻译字数为515312,已超过每日上限400000字符`), so on the live site every language will honestly report "unavailable" until it resets. A couple of long chapter loads exhausts 400k characters. If this tier matters, `siliconflow` or a self-hosted `translate.service` is the real answer — separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
