### PR TITLE
docs(ch2): Revise wording in local_llm_serving experiment README.md

### DIFF
--- a/chapter2/local_llm_serving/README.md
+++ b/chapter2/local_llm_serving/README.md
@@ -213,8 +213,9 @@ python server.py                            # vLLM (Linux/WSL2 + NVIDIA GPU)
 ollama serve && ollama pull qwen3:0.6b      # Ollama (Mac / no GPU)
 
 # 2. Run benchmark
+# If you use Ollama, add --backend ollama to every command below.
 python benchmark.py --scenario all --output results.json
-python benchmark.py --scenario kv-cache --backend ollama
+python benchmark.py --scenario kv-cache
 python benchmark.py --scenario batching --concurrency 1,2,4,8
 
 python benchmark.py --dry-run
@@ -517,8 +518,9 @@ python server.py                            # vLLM（Linux/WSL2 + NVIDIA GPU）
 ollama serve && ollama pull qwen3:0.6b      # Ollama（Mac / 无 GPU）
 
 # 2. 运行基准
+# 如果使用 Ollama 后端，请在以下每条命令中添加 --backend ollama参数
 python benchmark.py --scenario all --output results.json
-python benchmark.py --scenario kv-cache --backend ollama
+python benchmark.py --scenario kv-cache
 python benchmark.py --scenario batching --concurrency 1,2,4,8
 
 python benchmark.py --dry-run


### PR DESCRIPTION
在 local_llm_serving 实验的 benchmark 部分，明确说明使用 ollama 时，所有 benchmark 命令都需要添加 `--backend ollama`。
此前仅 kv-cache 场景的示例包含该参数，可能使读者误以为其他 benchmark 场景不需要指定 ollama后端。