### PR TITLE
fix(ch3): handle empty choices in streaming responses

### DIFF
--- a/chapter3/user-memory/agent.py
+++ b/chapter3/user-memory/agent.py
@@ -932,7 +932,7 @@ Current Memory Context will be provided with each message."""
             print("\nAssistant: ", end='', flush=True)
             
             for chunk in stream:
-                if chunk.choices[0].delta.content:
+                if chunk.choices and chunk.choices[0].delta.content:
                     delta = chunk.choices[0].delta.content
                     assistant_message += delta
                     # Stream output in real-time

--- a/chapter3/user-memory/conversational_agent.py
+++ b/chapter3/user-memory/conversational_agent.py
@@ -261,7 +261,7 @@ You MUST analyze the context, user's questions and memories in detail, and provi
                 logger.info("Streaming response...")
                 
             for chunk in stream:
-                if chunk.choices[0].delta.content:
+                if chunk.choices and chunk.choices[0].delta.content:
                     delta = chunk.choices[0].delta.content
                     assistant_message += delta
                     # Always stream output to show real-time response

--- a/chapter3/user-memory/test_stream_empty_choices.py
+++ b/chapter3/user-memory/test_stream_empty_choices.py
@@ -1,0 +1,64 @@
+"""Regression tests for providers that end streams with ``choices=[]``."""
+
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from agent import UserMemoryAgent
+from conversational_agent import ConversationConfig, ConversationalAgent
+
+
+class StubCompletions:
+    def create(self, **kwargs):
+        return [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(delta=SimpleNamespace(content="Hello"))
+                ]
+            ),
+            SimpleNamespace(choices=[]),
+        ]
+
+
+def stub_client():
+    return SimpleNamespace(
+        chat=SimpleNamespace(completions=StubCompletions())
+    )
+
+
+def test_conversational_agent_ignores_empty_choices_chunk():
+    agent = ConversationalAgent.__new__(ConversationalAgent)
+    agent.config = ConversationConfig(
+        enable_memory_context=False,
+        enable_conversation_history=False,
+    )
+    agent.verbose = False
+    agent.model = "test-model"
+    agent.client = stub_client()
+    agent.conversation = []
+    agent.conversation_history = None
+    agent.session_id = "session-test"
+
+    assert agent.chat("Hi") == "Hello"
+    assert agent.conversation[-1] == {
+        "role": "assistant",
+        "content": "Hello",
+    }
+
+
+def test_user_memory_agent_ignores_empty_choices_chunk():
+    agent = UserMemoryAgent.__new__(UserMemoryAgent)
+    agent._get_memory_context = lambda: ""
+    agent.model = "test-model"
+    agent.client = stub_client()
+    agent.conversation = []
+    agent.conversation_history = None
+    agent.session_id = "session-test"
+
+    assert agent._chat_stream("Hi") == "Hello"
+    assert agent.conversation[-1] == {
+        "role": "assistant",
+        "content": "Hello",
+    }


### PR DESCRIPTION
## Summary

- skip provider terminal chunks whose `choices` list is empty
- guard both Chapter 3 user-memory streaming implementations
- add regression coverage for valid content followed by `choices=[]`

## Testing

- `python -m pytest chapter3/user-memory -q` (17 passed)

Fixes #915