### PR TITLE
refactor(fig1-5): ReAct 改为闭环表示，输入输出移至服务端框外

### DIFF
--- a/book/images/fig1-5.svg
+++ b/book/images/fig1-5.svg
@@ -1,11 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 820 480" width="820" height="480" style="background:#ffffff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 820 530" width="820" height="530" style="background:#ffffff">
 <title>图 1-5 “模型即 Agent” 架构——原生工具调用</title>
-<desc>LLM 通过服务端 Harness 闭环调用 web_search 与 code_interpreter 等原生工具，图中以比特币技术分析任务展示一次 ReAct 执行过程。</desc>
+<desc>LLM 通过服务端 Harness 闭环调用 web_search 与 code_interpreter 等原生工具。用户输入与最终输出位于服务端闭环之外，闭环内部为思考、行动、观察三个节点构成的 ReAct 循环。</desc>
 <defs><marker id="ah" markerUnits="userSpaceOnUse" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerUnits="userSpaceOnUse" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
+
 <rect x="260" y="70" width="300" height="100" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
 <text x="410" y="100" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">LLM（Kimi K3 / GPT-5.6）</text>
 <text x="410" y="130" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">RL 训练后的原生 Agent 能力</text>
-<rect x="620" y="70" width="180" height="230" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
+
+<rect x="620" y="70" width="180" height="230" rx="8" fill="none" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
 <text x="632" y="88" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="bold">原生工具</text>
 <rect x="635" y="105" width="150" height="50" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
 <text x="710.0" y="130.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">$web_search</text>
@@ -15,34 +17,43 @@
 <text x="710.0" y="260.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">更多工具...</text>
 <line x1="560" y1="120" x2="633" y2="130" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
 <line x1="633" y1="195" x2="560" y2="145" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="100" y="210" width="460" height="280" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="112" y="228" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="bold">ReAct 循环（服务端 Harness 闭环执行）</text>
-<rect x="120" y="250" width="200" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="267.9" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">用户：搜索最近一个月</text>
-<text x="220.0" y="288.7" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">的比特币走势</text>
-<rect x="120" y="325" width="200" height="55" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="342.9" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">思考：需要搜索实时</text>
-<text x="220.0" y="363.7" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">数据，再用代码分析</text>
-<line x1="220" y1="307" x2="220" y2="323" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="340" y="250" width="200" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="440.0" y="267.9" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">调用 $web_search</text>
-<text x="440.0" y="288.7" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">&quot;BTC price last month&quot;</text>
-<path d="M 322,352 L 330,352 L 330,277 L 338,277" fill="none" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="340" y="325" width="200" height="55" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="440.0" y="342.9" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">结果：[价格数据]</text>
-<text x="440.0" y="363.7" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">$67,230 → $71,450</text>
-<line x1="440" y1="307" x2="440" y2="323" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="120" y="400" width="200" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="220.0" y="417.9" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">调用 code_interpreter</text>
-<text x="220.0" y="438.7" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">RSI, MACD 计算代码</text>
-<line x1="400" y1="382" x2="240" y2="398" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
-<rect x="340" y="400" width="200" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="440.0" y="417.9" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">最终输出：技术分析</text>
-<text x="440.0" y="438.7" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">报告 + 可视化图表</text>
-<line x1="322" y1="427" x2="338" y2="427" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<path d="M 562,450 Q 640,300 545,172" fill="none" stroke="#999999" stroke-width="2" stroke-dasharray="8,4" marker-end="url(#ah-light)"/>
-<text x="605" y="330" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="bold">RL 训练信号</text>
-<rect x="15" y="70" width="230" height="120" rx="8" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
+
+<path d="M 570,308 Q 600,240 548,172" fill="none" stroke="#999999" stroke-width="2" stroke-dasharray="8,4" marker-end="url(#ah-light)"/>
+<text x="568" y="250" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="end" dominant-baseline="central" font-weight="bold">RL 训练信号</text>
+
+<rect x="25" y="235" width="230" height="55" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="140.0" y="252.9" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">用户：搜索最近一个月</text>
+<text x="140.0" y="273.7" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">的比特币走势</text>
+
+<rect x="15" y="310" width="790" height="170" rx="8" fill="none" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
+<text x="410" y="328" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="bold">ReAct 循环（服务端 Harness 闭环执行）</text>
+
+<line x1="140" y1="292" x2="140" y2="380" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+
+<text x="440" y="350" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">带着观察结果继续下一轮</text>
+<path d="M 680,382 L 680,366 L 200,366 L 200,382" fill="none" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+
+<rect x="40" y="384" width="200" height="76" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
+<text x="140.0" y="412.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">思考：需要搜索实时</text>
+<text x="140.0" y="433.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">数据，再用代码分析</text>
+<line x1="242" y1="422" x2="298" y2="422" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+
+<rect x="300" y="384" width="220" height="76" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="410.0" y="404.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">第 1 轮：调用 $web_search</text>
+<text x="410.0" y="424.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">&quot;BTC price last month&quot;</text>
+<text x="410.0" y="444.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">第 2 轮：code_interpreter</text>
+<line x1="522" y1="422" x2="578" y2="422" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+
+<rect x="580" y="384" width="200" height="76" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
+<text x="680.0" y="412.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">结果：[价格数据]</text>
+<text x="680.0" y="433.0" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">$67,230 → $71,450</text>
+
+<line x1="140" y1="462" x2="140" y2="496" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<rect x="25" y="500" width="230" height="55" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="140.0" y="517.9" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">最终输出：技术分析</text>
+<text x="140.0" y="538.7" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">报告 + 可视化图表</text>
+
+<rect x="15" y="70" width="230" height="120" rx="8" fill="none" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
 <text x="27" y="88" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="bold">与传统框架的区别</text>
 <text x="30" y="110" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">✓ 编排由服务端 Harness 托管</text>
 <text x="30" y="135" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">✓ 客户端无需手写 ReAct 循环</text>


### PR DESCRIPTION
基于#943 。本 PR 暂时也包含了那边的提交，#943 合并后这里的 diff 会自动收缩成只剩重排部分。

## 改动内容

- **ReAct 部分改成了真实的闭环**：思考 → 行动 → 观察，观察上方有一条回边接回思考。原图标题写着「循环」，但画出来是一条单向链，没有回边。
- 原「调用 code_interpreter」框被循环吸收了，这实际上是第 2 轮的行动，也正是画成循环的意义。轮次信息以「第 1 轮」「第 2 轮」的形式保留在「行动」框里。
- **用户输入和最终输出移到了服务端虚线框外面**，两条箭头穿过边界。原图把「用户」画在循环内部，而正文强调的是「编排由服务端 Harness 托管、客户端不写循环」，这条界线之前没体现出来。
- 画布高度 480 → 530，纵向多了输入输出两层。

## 修改前后

<img width="860" height="370" alt="image" src="https://github.com/user-attachments/assets/da2eb443-eb6b-42e0-86de-d33116cc6231" />


## 关于改动范围

这版改动比 #943 稍大，若幅度过大，或有任何不妥及其他调整也可随时沟通。
另外画布变高可能会影响书里的排版，如果 LaTeX 那边给这张图设了固定尺寸，烦请告知。