### PR TITLE
docs(ch9): 从章节 README 移除证据审计强度的细节表述

### DIFF
--- a/chapter9/README.md
+++ b/chapter9/README.md
@@ -26,13 +26,7 @@
 | 9-8 | [hermes-self-evolution](hermes-self-evolution/) | 📖 | 实验 9-8：把整本书和源码交给 Hermes；它读完后选择一项改进，亲手修改自己，并把每次 Reviewer 的退回变成下一轮学习，直到通过 |
 | 9-9 | [self-evolution-eval](self-evolution-eval/) | ✅ | 实验 9-9：static、append-only、evolving 三臂 × 3 seeds × 14 任务共 126 次真实调用；[证据](self-evolution-eval/validation/latest.json)保留迁移、规则替换、保持与配对统计 |
 
-除仍处于设计阶段的实验 9-4 外，其余带项目链接的实验都保留无需 API Key 的离线入口和单元测试用于预检；表中 ✅ 来自各目录保存的真实模型、真实轨迹或真实浏览器规范证据，不由离线机制演示代替。历史数值或定性主张未复现时，证据按负结果如实记录。
-
-证据完整性边界：9-6、9-9 的 canonical evidence 与 `latest.json` 都有独立
-SHA-256 sidecar，当前复算一致；9-5 对三个关键浏览器产物保存并核对了 hash。
-9-1、9-2、9-3 的 `latest.json` 虽与各自真实 run 的 `evidence.json` 字节一致，
-但没有顶层 evidence/source hash manifest，因此可审计强度低于 9-6、9-9，
-不能把提交时存在的 JSON 等同于运行时源码已被固定。
+带项目链接的实验都保留无需 API Key 的离线入口和单元测试用于预检。
 
 ## 补充案例
 


### PR DESCRIPTION
解决 #959 里记的那条遗留。第 9 章 README 主表之后有两段中文独有、12 个译本均无的内容，属于实验证据的审计强度细节。按作者判断，章节索引层面的 README 不是记录这类细节的地方，因此**删除**而不是翻译到 12 个语言。

## 删除「证据完整性边界」整段

原文（`chapter9/README.md` 第 31–35 行）：

> 证据完整性边界：9-6、9-9 的 canonical evidence 与 `latest.json` 都有独立 SHA-256 sidecar，当前复算一致；9-5 对三个关键浏览器产物保存并核对了 hash。9-1、9-2、9-3 的 `latest.json` 虽与各自真实 run 的 `evidence.json` 字节一致，但没有顶层 evidence/source hash manifest，因此可审计强度低于 9-6、9-9，不能把提交时存在的 JSON 等同于运行时源码已被固定。

## 第一段精简

```diff
- 除仍处于设计阶段的实验 9-4 外，其余带项目链接的实验都保留无需 API Key 的离线入口和单元测试用于预检；表中 ✅ 来自各目录保存的真实模型、真实轨迹或真实浏览器规范证据，不由离线机制演示代替。历史数值或定性主张未复现时，证据按负结果如实记录。
+ 带项目链接的实验都保留无需 API Key 的离线入口和单元测试用于预检。
```

去掉的两处也是审计表述：「表中 ✅ 来自……不由离线机制演示代替」与「历史数值或定性主张未复现时，证据按负结果如实记录」。原句开头「除仍处于设计阶段的实验 9-4 外」一并去掉——9-4 本就没有项目链接，新表述已自然排除它。

## 这些内容没有从仓库消失

审计细节本来就在**各项目自己的 README** 里，那才是它们该在的位置：

| 项目 README | 保留的内容 |
| --- | --- |
| `self-modifying-agent/README.md` | 生成前后对稳定代码、失败轨迹、沙箱验证器做 SHA-256 比对，证明未越权修改可信根 |
| `harness-safety-gate/README.md` | `release_manifest.json` 记录来源轨迹哈希、提案哈希、回滚版本 |
| `browser-use-rpa/README.md` | 证据文件路径与 SHA-256 |
| `prompt-auto-optimization/README.md` | 机器可读证据路径、SHA-256、可审计性判据 |

逐行的负结果也仍写在主表内——例如 9-2 的说明保留着「证据记录知识文档组仅 25%、两控制组均 50% 的负结果」，9-1 保留着「同时记录关键违规稳定性主张未复现」。所以「如实记录负结果」这条实践在表里仍然看得见，只是不再单独声明一次。

## 校验

- 改动后中文母版与 11 个译本在该位置都只有一段说明
- chapter9 无失效相对链接
- `pytest tests/test_chapter_numbering_consistency.py tests/test_site_i18n.py tests/test_docs_experiment_status_links.py tests/test_build_site_assets.py` — 13 passed

## 两点说明

1. `es` 版原本就没有这段离线入口说明（0 段），属既有缺口，未在此处补。
2. `chapter10/README.md` 有一段性质相近但主题不同的内容（外部仓库不 vendoring、实验 10-3/10-5 固定到不可变提交、caller 偏差记录），译本同样没有。它更偏复现操作信息而非证据强度声明，**本 PR 未动**——要一并处理请说。

## 合并顺序

链路：**#956 → #958 → #959 → 本 PR**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012a9XZi352t2qxfPHQN8f7n
