### PR TITLE
fix(ch2): Explicitly set reasoning_effort to none in agent-skills-ppt…

### DIFF
--- a/chapter2/agent-skills-ppt/demo.py
+++ b/chapter2/agent-skills-ppt/demo.py
@@ -279,11 +279,15 @@ def run_agent(paper_path: Path, model: str, out_path: Path,
 
     final_result = None
     for turn in range(1, max_turns + 1):
+        # GPT-5.6 的 Chat Completions 端点在带 function tools 时只支持
+        # reasoning_effort="none"。这个示例保留 Chat Completions 的教学用
+        # message/tool_call 格式；若需要推理 + 工具调用，应迁移到 Responses API。
         resp = client.chat.completions.create(
             model=model,
             messages=messages,
             tools=TOOLS,
             temperature=0.2,
+            reasoning_effort="none",
         )
         msg = resp.choices[0].message
         messages.append(msg.model_dump(exclude_none=True))


### PR DESCRIPTION
总结：修复agent-skills-ppt实验里demo.py运行报错问题，将reasoning_effort 显式设置为none。
错误复现方式：运行demo.py
错误： GPT 5.6模型在chat completions api中不允许同时使用 function tools 与 reasoning efforts。
```Python
raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'error': {'message': "Function tools with reasoning_effort are not supported for gpt-5.6-luna in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.", 'type': 'invalid_request_error', 'param': 'reasoning_effort', 'code': None}}
```