### PR TITLE
fix(readme): repair stale cross-chapter links

### DIFF
--- a/chapter3/user-memory-evaluation/README.md
+++ b/chapter3/user-memory-evaluation/README.md
@@ -162,8 +162,8 @@ python validate_rubric.py \
   --output results/live_6_3_layer1.json
 ```
 
-Experiments 6-4 and 6-9 use this judge in the end-to-end runner at
-[`chapter6/user-memory-system-evaluation`](../../chapter6/user-memory-system-evaluation/).
+Experiments 7-4 and 7-11 use this judge in the end-to-end runner at
+[`chapter7/user-memory-system-evaluation`](../../chapter7/user-memory-system-evaluation/).
 
 ### Configuration
 

--- a/chapter6/agent-with-event-trigger/README.md
+++ b/chapter6/agent-with-event-trigger/README.md
@@ -1124,5 +1124,5 @@ MIT License - 详见 LICENSE 文件
 
 - Start with `python event_loop_demo.py --mock` (no API key).  
 - 建议先跑 `python event_loop_demo.py --mock`（无需 API Key）。  
-- MCP servers expected: [collaboration-tools](../collaboration-tools/), [execution-tools](../execution-tools/), [perception-tools](../perception-tools/).  
-- MCP 服务器见同章三个工具项目。
+- Chapter 4 MCP servers expected: [collaboration-tools](../../chapter4/collaboration-tools/), [execution-tools](../../chapter4/execution-tools/), [perception-tools](../../chapter4/perception-tools/).
+- MCP 服务器见第 4 章的三个工具项目。


### PR DESCRIPTION
## Summary
- update user-memory evaluation references after the v2 chapter reorganization
- point the event-trigger experiment to the Chapter 4 MCP tool projects

## Validation
- `git diff --check`
- ran the relevant chapter-reorganization regression tests
- rendered both modified README files and verified all relative-link targets against the current repository tree