### PR TITLE
fix(ch2): 让 gpt-5.x 改走 OpenRouter，而不是关掉推理（supersedes #967）

### DIFF
--- a/agentbook/providers/resolution.py
+++ b/agentbook/providers/resolution.py
@@ -75,22 +75,36 @@ def build_openrouter_backend(
     )
 
 
-def _needs_openrouter_for_gpt5(spec: Provider, model: str) -> bool:
+def _needs_openrouter_for_gpt5(
+    spec: Provider, model: str, chosen_by_reader: bool
+) -> bool:
     """Report whether a gpt-5 request must be rerouted through OpenRouter.
 
-    The direct OpenAI API requires organisation verification for gpt-5.x, which
-    most readers will not have. Routing via OpenRouter avoids that -- except
-    when the reader explicitly selected the ``openai`` provider, in which case
-    honouring their choice matters more.
+    Two independent things make the direct OpenAI API a poor default for
+    gpt-5.x. It requires organisation verification, which most readers will not
+    have. And its ``/v1/chat/completions`` endpoint refuses function tools
+    unless reasoning is switched off entirely -- it accepts the two together
+    only with ``reasoning_effort="none"``, which is the one thing an agent
+    experiment cannot give up. OpenRouter has neither restriction.
+
+    The exception is a reader who named ``openai`` themselves: sending their
+    prompts and their spend to a third party against an explicit instruction is
+    worse than the failure it avoids. A caller whose provider name is its own
+    built-in default rather than the reader's choice passes
+    ``chosen_by_reader=False`` and is rerouted like any other provider.
 
     Args:
         spec: The provider that was requested.
         model: The resolved model id.
+        chosen_by_reader: Whether the provider name came from the reader rather
+            than from the calling experiment's default.
 
     Returns:
         ``True`` if the request should be rerouted.
     """
-    return model.lower().startswith("gpt-5") and spec.name != "openai"
+    if not model.lower().startswith("gpt-5"):
+        return False
+    return not (spec.name == "openai" and chosen_by_reader)
 
 
 def _missing_key_error(spec: Provider) -> ValueError:
@@ -114,13 +128,17 @@ def resolve_backend(
     provider: str,
     model: str | None = None,
     api_key: str | None = None,
+    *,
+    chosen_by_reader: bool = True,
 ) -> Backend:
     """Resolve a provider name into a usable backend.
 
     Resolution order:
 
     1. ``gpt-5*`` ids route through OpenRouter when a key is available, because
-       the direct OpenAI API requires org verification for them.
+       the direct OpenAI API requires org verification for them and refuses
+       function tools alongside reasoning. A reader who named ``openai``
+       themselves is honoured instead; see :func:`_needs_openrouter_for_gpt5`.
     2. If the provider's own key is set (or the provider needs none, e.g.
        Ollama), use the provider directly.
     3. Otherwise fall back to OpenRouter, mapping the model id.
@@ -133,6 +151,10 @@ def resolve_backend(
             provider this is treated as an OpenRouter key; for any other
             provider it belongs to that provider and is never forwarded to
             OpenRouter.
+        chosen_by_reader: Whether ``provider`` is the reader's own selection --
+            a ``--provider`` flag or an equivalent setting. Pass ``False`` when
+            it is a caller's hardcoded default, which lets step 1 reroute a
+            gpt-5 request that would otherwise fail on the direct API.
 
     Returns:
         A ready-to-use :class:`~agentbook.providers.models.Backend`.
@@ -162,8 +184,11 @@ def resolve_backend(
     explicit_openrouter_key = key if spec.name == _OPENROUTER else ""
     available_openrouter_key = explicit_openrouter_key or openrouter_key()
 
-    # 1. gpt-5.x needs OpenAI org verification on the direct API.
-    if available_openrouter_key and _needs_openrouter_for_gpt5(spec, resolved_model):
+    # 1. gpt-5.x needs OpenAI org verification on the direct API, which also
+    #    refuses function tools unless reasoning is off.
+    if available_openrouter_key and _needs_openrouter_for_gpt5(
+        spec, resolved_model, chosen_by_reader
+    ):
         return build_openrouter_backend(resolved_model, available_openrouter_key, spec.name)
 
     # 2. The provider's own credential, or a provider that needs none.

--- a/chapter2/agent-skills-ppt/README.md
+++ b/chapter2/agent-skills-ppt/README.md
@@ -118,7 +118,7 @@ The original book experiment ran on **Claude Code + Anthropic’s official PPTX 
 
 The mechanism maps one-to-one; the built-in Skill loader is replaced by explicit read/execute tools so progressive disclosure still works without Anthropic access.
 
-> **OpenRouter fallback:** Primary path is OpenAI (default model `gpt-5.6-luna`). If `OPENAI_API_KEY` is unset but `OPENROUTER_API_KEY` is set, requests go through OpenRouter (`gpt-*` → `openai/…`). With `OPENAI_API_KEY` set, behavior is unchanged.
+> **Routing:** Default model is `gpt-5.6-luna`. When `OPENROUTER_API_KEY` is set, `gpt-5*` requests go through OpenRouter (`gpt-*` → `openai/…`) even if `OPENAI_API_KEY` is also set: OpenAI's direct `/v1/chat/completions` needs org verification for these ids and refuses function tools unless reasoning is switched off, which would defeat the point of this experiment. With only `OPENAI_API_KEY`, the run stays on the direct endpoint and drops to `reasoning_effort="none"` the first time it is refused, printing a note when it does.
 
 ### Three-layer progressive disclosure
 
@@ -271,7 +271,7 @@ Replace `papers/sample_paper.md` or pass `python demo.py --paper your_paper.md`.
 
 机制一一对应，只是把「Claude 内置的 Skill 加载器」换成了几个显式的读取/执行工具，从而在没有 Anthropic 访问权限时，依然能真实演示渐进式披露的三层加载过程。
 
-> 说明：本项目主用 OpenAI（默认模型 gpt-5.6-luna）。**通用回退**：未设置 `OPENAI_API_KEY` 时，只要配置了 `OPENROUTER_API_KEY`，会自动改走 OpenRouter（`gpt-*` 映射为 `openai/…`）。设置了 `OPENAI_API_KEY` 时行为完全不变。
+> 说明：默认模型 gpt-5.6-luna。**路由**：只要配置了 `OPENROUTER_API_KEY`，`gpt-5*` 一律改走 OpenRouter（`gpt-*` 映射为 `openai/…`），即使同时设置了 `OPENAI_API_KEY` —— OpenAI 直连的 `/v1/chat/completions` 对这些模型既要组织实名认证，又不允许 function tools 与推理并存，而后者正是本实验要展示的能力。只有 `OPENAI_API_KEY` 时仍走直连，首次被拒后自动降级为 `reasoning_effort="none"` 并打印提示。
 
 ### 渐进式披露的三层结构
 

--- a/chapter2/agent-skills-ppt/demo.py
+++ b/chapter2/agent-skills-ppt/demo.py
@@ -25,7 +25,7 @@ import os
 import sys
 from pathlib import Path
 
-from openai import OpenAI
+from openai import BadRequestError, OpenAI
 from pptx import Presentation
 
 # 从同目录 .env 读取 OPENAI_API_KEY（若安装了 python-dotenv）
@@ -229,12 +229,47 @@ def dispatch(catalog: dict, name: str, args: dict, out_path: Path) -> str:
 
 
 # ---------------------------------------------------------------------------
+# 一轮带工具的模型调用。参数不写死，撞上端点限制再降级，并如实告诉读者。
+# ---------------------------------------------------------------------------
+def chat_with_tools(client, model: str, messages: list, no_reasoning: bool):
+    """发起一轮带 function tools 的 chat completions，必要时降级重试一次。
+
+    只配了 OPENAI_API_KEY 的读者会直连 OpenAI，而直连的 chat completions 端点
+    对 gpt-5.x 只允许 reasoning_effort="none" 与 function tools 并存。OpenRouter
+    没有这个限制，所以这里不无条件写死该参数——那会连带关掉本实验最关键的多步
+    推理能力——而是撞上了再降级，并说明如何恢复推理。
+
+    Args:
+        client: 已配置好 base_url 与 key 的 OpenAI 客户端。
+        model: 在该端点上有效的模型 id。
+        messages: 当前对话历史。
+        no_reasoning: 之前是否已降级过；为 True 时直接带上 reasoning_effort。
+
+    Returns:
+        ``(response, no_reasoning)``，后者供调用方记住降级状态，避免每轮都白撞一次。
+    """
+    kwargs = {"model": model, "messages": messages, "tools": TOOLS, "temperature": 0.2}
+    if no_reasoning:
+        kwargs["reasoning_effort"] = "none"
+    try:
+        return client.chat.completions.create(**kwargs), no_reasoning
+    except BadRequestError as exc:
+        if no_reasoning or "reasoning_effort" not in str(exc):
+            raise
+        log('\n[提示] 当前端点不支持「推理 + function tools」并存，本轮起降级为 '
+            'reasoning_effort="none"。')
+        log("       配置 OPENROUTER_API_KEY 可改走 OpenRouter，保留模型的推理能力。")
+        kwargs["reasoning_effort"] = "none"
+        return client.chat.completions.create(**kwargs), True
+
+
+# ---------------------------------------------------------------------------
 # 主流程：agentic loop
 # ---------------------------------------------------------------------------
 def run_agent(paper_path: Path, model: str, out_path: Path,
               max_turns: int = 8) -> Path | None:
-    # OPENAI_API_KEY 存在则官方直连；否则回退 OPENROUTER_API_KEY
-    # （gpt-* 模型名会被映射为 openai/…）。两者皆无则给出清晰错误。
+    # 有 OPENROUTER_API_KEY 时 gpt-5.x 优先走 OpenRouter，否则 OPENAI_API_KEY
+    # 官方直连（gpt-* 模型名会被映射为 openai/…）。两者皆无则给出清晰错误。
     from agentbook.providers import resolve_backend
 
     if not os.environ.get("OPENAI_API_KEY") and not os.environ.get("OPENROUTER_API_KEY"):
@@ -244,8 +279,10 @@ def run_agent(paper_path: Path, model: str, out_path: Path,
         sys.exit(1)
 
     # 端点与 key 的对应关系由 agentbook 的 provider 注册表统一维护，
-    # OPENAI_BASE_URL 覆盖也在其中处理。
-    backend = resolve_backend("openai", model=model)
+    # OPENAI_BASE_URL 覆盖也在其中处理。chosen_by_reader=False 表示 "openai"
+    # 是本实验的默认值而非读者的显式选择：gpt-5.x 直连 chat completions 不允许
+    # function tools 与推理并存，注册表因此会在有 OpenRouter key 时改道。
+    backend = resolve_backend("openai", model=model, chosen_by_reader=False)
     model = backend.model
     # timeout + 自动重试：单次网络/SSL 抖动不至于让整个 agentic loop 崩溃
     client = OpenAI(
@@ -278,13 +315,9 @@ def run_agent(paper_path: Path, model: str, out_path: Path,
     log("\n【任务下发】要求 Agent 从论文生成演示文稿。观察它如何按需渐进式披露：\n")
 
     final_result = None
+    no_reasoning = False
     for turn in range(1, max_turns + 1):
-        resp = client.chat.completions.create(
-            model=model,
-            messages=messages,
-            tools=TOOLS,
-            temperature=0.2,
-        )
+        resp, no_reasoning = chat_with_tools(client, model, messages, no_reasoning)
         msg = resp.choices[0].message
         messages.append(msg.model_dump(exclude_none=True))
 

--- a/chapter2/agent-skills-ppt/tests/conftest.py
+++ b/chapter2/agent-skills-ppt/tests/conftest.py
@@ -18,6 +18,8 @@ try:
 except ImportError:
     openai_stub = ModuleType("openai")
     openai_stub.OpenAI = object
+    # demo.py imports this by name for its reasoning-vs-tools degrade path.
+    openai_stub.BadRequestError = type("BadRequestError", (Exception,), {})
     sys.modules["openai"] = openai_stub
 
 try:

--- a/chapter2/agent-skills-ppt/tests/test_reasoning_degrade.py
+++ b/chapter2/agent-skills-ppt/tests/test_reasoning_degrade.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Regression tests for chat_with_tools() in demo.py.
+
+Bug: gpt-5.x on OpenAI's direct /v1/chat/completions rejects function tools
+unless reasoning_effort="none", so the agentic loop died with a 400 for readers
+who have only OPENAI_API_KEY. Hardcoding reasoning_effort="none" would fix the
+crash by removing the multi-step reasoning this experiment exists to show, and
+would send the parameter to OpenRouter too, where the restriction never
+applied. So the call keeps reasoning on and degrades only when the endpoint
+actually refuses -- once, then remembers.
+"""
+
+import pytest
+
+import demo
+
+
+class _FakeBadRequest(Exception):
+    pass
+
+
+class _FakeCompletions:
+    """Records each call's kwargs; can fail the first call with a given error."""
+
+    def __init__(self, fail_first_with=None):
+        self.calls = []
+        self._fail_first_with = fail_first_with
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._fail_first_with and len(self.calls) == 1:
+            raise self._fail_first_with
+        return "response"
+
+
+class _FakeClient:
+    def __init__(self, completions):
+        self.chat = type("_Chat", (), {"completions": completions})()
+
+
+@pytest.fixture(autouse=True)
+def _patch_exception(monkeypatch):
+    monkeypatch.setattr(demo, "BadRequestError", _FakeBadRequest)
+
+
+def test_reasoning_is_left_on_when_the_endpoint_accepts_tools():
+    completions = _FakeCompletions()
+    resp, no_reasoning = demo.chat_with_tools(
+        _FakeClient(completions), "openai/gpt-5.6-luna", [], False
+    )
+    assert resp == "response"
+    assert no_reasoning is False
+    assert "reasoning_effort" not in completions.calls[0]
+
+
+def test_degrades_once_when_the_endpoint_refuses_reasoning_with_tools():
+    error = _FakeBadRequest(
+        "Function tools with reasoning_effort are not supported for gpt-5.6-luna "
+        "in /v1/chat/completions. To use function tools, use /v1/responses or "
+        "set reasoning_effort to 'none'."
+    )
+    completions = _FakeCompletions(fail_first_with=error)
+    resp, no_reasoning = demo.chat_with_tools(
+        _FakeClient(completions), "gpt-5.6-luna", [], False
+    )
+    assert resp == "response"
+    # The caller remembers, so later turns do not pay for the same 400 again.
+    assert no_reasoning is True
+    assert "reasoning_effort" not in completions.calls[0]
+    assert completions.calls[1]["reasoning_effort"] == "none"
+
+
+def test_remembered_degrade_skips_the_failing_attempt():
+    completions = _FakeCompletions()
+    demo.chat_with_tools(_FakeClient(completions), "gpt-5.6-luna", [], True)
+    assert len(completions.calls) == 1
+    assert completions.calls[0]["reasoning_effort"] == "none"
+
+
+def test_unrelated_bad_requests_are_not_swallowed():
+    completions = _FakeCompletions(fail_first_with=_FakeBadRequest("context_length_exceeded"))
+    with pytest.raises(_FakeBadRequest):
+        demo.chat_with_tools(_FakeClient(completions), "gpt-5.6-luna", [], False)
+    assert len(completions.calls) == 1

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -177,6 +177,33 @@ def test_explicit_openai_provider_is_not_hijacked_for_gpt5(monkeypatch):
     assert backend.base_url == "https://api.openai.com/v1"
 
 
+def test_default_openai_provider_is_rerouted_for_gpt5(monkeypatch):
+    # An experiment that merely defaults to OpenAI is not the reader choosing
+    # it: gpt-5.x on the direct chat completions endpoint refuses function
+    # tools unless reasoning is off, so the reroute has to apply here.
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key-3b")
+    backend = resolve_backend("openai", model="gpt-5.6-luna", chosen_by_reader=False)
+    assert backend.using_openrouter is True
+    assert backend.model == "openai/gpt-5.6-luna"
+
+
+def test_default_openai_provider_stays_direct_without_openrouter_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    backend = resolve_backend("openai", model="gpt-5.6-luna", chosen_by_reader=False)
+    assert backend.using_openrouter is False
+    assert backend.base_url == "https://api.openai.com/v1"
+
+
+def test_default_provider_flag_does_not_reroute_non_gpt5(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key-3c")
+    backend = resolve_backend("openai", model="gpt-4o", chosen_by_reader=False)
+    assert backend.using_openrouter is False
+    assert backend.model == "gpt-4o"
+
+
 def test_ollama_needs_no_key():
     backend = resolve_backend("ollama")
     assert backend.base_url == "http://localhost:11434/v1"


### PR DESCRIPTION
Supersedes #967（那个 PR 的报错复现是对的，感谢 @Lucien2714；这里换一个层面修）。

## 问题

`chapter2/agent-skills-ppt/demo.py` 对配了 `OPENAI_API_KEY` 的读者一直是 400：

```
Function tools with reasoning_effort are not supported for gpt-5.6-luna in
/v1/chat/completions. To use function tools, use /v1/responses or set
reasoning_effort to 'none'.
```

## 根因：路由回归，不是缺参数

`7128335f` 之前，这个实验用的本地 helper 第一个分支就是为此准备的：只要模型是 `gpt-5*` 且有 OpenRouter key，就优先改走 OpenRouter，即使调用方自己有 key。迁移到共享注册表后，`resolve_backend` 里的同一条规则在调用方显式指定 `"openai"` 时**故意不生效**（`_needs_openrouter_for_gpt5`，并有 `test_explicit_openai_provider_is_not_hijacked_for_gpt5` 钉住）——那个例外是为了尊重读者的显式选择，而本实验硬编码的默认值静默踩中了它。`demo.py:248` 是全仓库唯一硬编码 `"openai"` 的调用点，也就是唯一丢掉改道的实验。

## 改法

**共享层**（`agentbook/providers/resolution.py`）：`resolve_backend` 新增 `chosen_by_reader`（keyword-only，默认 `True`），把「读者点名要 openai」和「openai 只是调用方的内置默认值」区分开。只有后者会被改道，显式的 `--provider openai` 仍然永远不会被劫持到第三方（原测试不变、继续通过）。

修在共享层而不是实验里，是因为 gpt-5 的这类知识本就该只有一处定义，而且这个包内部原本已经不一致：`legacy.resolve_llm_backend` 对 gpt-5 是无条件改道的。

**实验层**（`demo.py`）：
- `resolve_backend("openai", model=model, chosen_by_reader=False)` —— 有 OpenRouter key 时保留「推理 + 工具调用」。
- 只有 `OPENAI_API_KEY` 的读者仍走直连，所以新增 `chat_with_tools()`：先保留推理，**只有端点真的拒绝时**才降级重试一次 `reasoning_effort="none"`，并打印丢了什么、怎么恢复；降级状态记住，后续轮次不再白撞一次 400。

无条件写死 `reasoning_effort="none"` 会对所有人关掉推理——包括从来不受此限制的 OpenRouter 读者——而本实验的核心恰恰是 Agent 自己判断该用哪个 Skill、再按其 SKILL.md 跨约 8 轮工具调用逐层披露。

## 测试

- `tests/test_providers.py` +3：默认值被改道 / 无 OpenRouter key 时保持直连 / 非 gpt-5 不受影响。
- `chapter2/agent-skills-ppt/tests/test_reasoning_degrade.py` +4：不拒绝时不带参数、拒绝后降级一次并记住、已降级时不再重试、无关的 400 不被吞掉。
- `python demo.py --offline` 通过；`tests/test_providers.py` 与本实验自带测试全绿（78 passed）。

## 验证说明

**未做线上验证**：两个 key 今天都没额度（OpenAI `429 credit_balance_exhausted`、OpenRouter `402 Insufficient credits`），而配额检查发生在参数校验之前。依据是 #967 里的 traceback，以及当初引入 `prefer_or` 分支时记录的同一条报错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKUAoLDhVDcw4e24yaJJra
