### PR TITLE
refactor(ch4,ch5): 六个实验改用共享 provider 注册表，删掉手抄的 gpt-5 改道

### DIFF
--- a/.github/workflows/provider-adoption-tests.yml
+++ b/.github/workflows/provider-adoption-tests.yml
@@ -90,6 +90,13 @@ jobs:
       - name: Install log-sanitization extras
         run: python -m pip install "ollama>=0.3.0" "pyyaml>=6.0"
 
+      # Same rule for chapter 5: both are in the experiments' requirements.txt
+      # and both are needed at *collection* time, not at call time --
+      # paper-to-ppt's paper_source.py imports fitz and code-for-math's
+      # build_aime_2024.py imports pyarrow, each from a module a test imports.
+      - name: Install chapter5 extras
+        run: python -m pip install "PyMuPDF>=1.25.0" "pyarrow>=20.0.0"
+
       # Empty rather than unset: a resolver bug that reads a key from the
       # runner environment must fail here, not silently pass.
       - name: Run offline tests

--- a/.github/workflows/provider-adoption-tests.yml
+++ b/.github/workflows/provider-adoption-tests.yml
@@ -1,11 +1,11 @@
 name: provider adoption tests
 
-# Chapters 2 and 3 resolve endpoints, credentials and model ids through
+# Chapters 2 to 5 resolve endpoints, credentials and model ids through
 # agentbook.providers rather than through per-experiment copies of the old
-# openrouter_fallback.py. That makes a change to agentbook/ able to break six
-# experiments at once, in code paths none of their own tests would flag as
-# related -- so the shared package is a trigger here, exactly as it is for
-# chapter 1 in web-search-agent-tests.yml.
+# openrouter_fallback.py and its hand-rolled gpt-5 reroute. That makes a change
+# to agentbook/ able to break a dozen experiments at once, in code paths none of
+# their own tests would flag as related -- so the shared package is a trigger
+# here, exactly as it is for chapter 1 in web-search-agent-tests.yml.
 
 on:
   pull_request:
@@ -15,6 +15,11 @@ on:
       - "chapter2/prompt-injection/**"
       - "chapter2/system-hint/**"
       - "chapter3/log-sanitization/**"
+      - "chapter5/code-for-math/**"
+      - "chapter5/conversational-ui/**"
+      - "chapter5/erp-agent/**"
+      - "chapter5/paper-to-ppt/**"
+      - "chapter5/paper-to-video/**"
       - "pyproject.toml"
       - ".github/workflows/provider-adoption-tests.yml"
   push:
@@ -25,6 +30,11 @@ on:
       - "chapter2/prompt-injection/**"
       - "chapter2/system-hint/**"
       - "chapter3/log-sanitization/**"
+      - "chapter5/code-for-math/**"
+      - "chapter5/conversational-ui/**"
+      - "chapter5/erp-agent/**"
+      - "chapter5/paper-to-ppt/**"
+      - "chapter5/paper-to-video/**"
       - "pyproject.toml"
       - ".github/workflows/provider-adoption-tests.yml"
   workflow_dispatch: {}
@@ -38,17 +48,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Two of the six migrated experiments are deliberately absent.
+        # Three migrated experiments are deliberately absent.
         # chapter2/kv-cache keeps live-API scripts at its root that exit(1)
         # without MOONSHOT_API_KEY, and chapter2/agent-skills-ppt cannot import
         # python-pptx under the shared install. Both fail the same way before
         # this migration; adding them needs the Phase 6A test/manual split
-        # first, not a workaround here.
+        # first, not a workaround here. chapter4/multimodal-agent has one test
+        # (test_extract_image_to_text) that needs a real key to be present at
+        # all -- it fails identically on main with the keys blanked, so it would
+        # report this job red for a reason unrelated to routing.
         experiment:
           - chapter2/context-compression
           - chapter2/prompt-injection
           - chapter2/system-hint
           - chapter3/log-sanitization
+          - chapter5/code-for-math
+          - chapter5/conversational-ui
+          - chapter5/erp-agent
+          - chapter5/paper-to-ppt
+          - chapter5/paper-to-video
 
     steps:
       - uses: actions/checkout@v5
@@ -60,9 +78,11 @@ jobs:
       # The chapter aggregates ch2 and ch3 pull torch, which these offline
       # tests never touch. Installing the capability groups they do use keeps
       # the job to seconds; a chapter that outgrows this set will fail on the
-      # missing import rather than resolving it silently.
+      # missing import rather than resolving it silently. `media` is here for
+      # chapter5: paper-to-ppt's agents.py and paper-to-video's demo.py both
+      # import PIL at module scope, so their tests cannot even collect without it.
       - name: Install the package
-        run: python -m pip install -e ".[dev,web,tokens]"
+        run: python -m pip install -e ".[dev,web,tokens,media]"
 
       # Declared by chapter3/log-sanitization's requirements.txt and not yet in
       # any capability group. Named here rather than widened into pyproject so
@@ -79,4 +99,6 @@ jobs:
           KIMI_API_KEY: ""
           OPENROUTER_API_KEY: ""
           OPENAI_API_KEY: ""
+          ARK_API_KEY: ""
+          GEMINI_API_KEY: ""
         run: python -m pytest -q

--- a/agentbook/providers/openrouter.py
+++ b/agentbook/providers/openrouter.py
@@ -84,8 +84,9 @@ def map_model_to_openrouter(model: str, *, substitute_unknown: bool = False) -> 
     Mapping rules, applied in order:
 
     * ids already containing ``/`` are returned unchanged (already OpenRouter form)
-    * ``gpt-*`` / ``o1-*`` / ``o3-*`` / ``o4-*`` become ``openai/<id>``
+    * ``gpt-*`` / ``o1*`` / ``o3*`` / ``o4*`` / ``chatgpt*`` become ``openai/<id>``
     * ``claude-*`` becomes the matching Anthropic id
+    * ``gemini*`` becomes ``google/<id>``
     * ``kimi-*`` becomes ``moonshotai/kimi-k2.6`` (kimi-k3 is not hosted)
     * ``deepseek-*`` becomes ``deepseek/<id>``
     * ``qwen-*`` / ``qwen2*`` / ``qwen3*`` becomes ``qwen/<id>``
@@ -113,7 +114,9 @@ def map_model_to_openrouter(model: str, *, substitute_unknown: bool = False) -> 
     if "/" in m:
         return m
     ml = m.lower()
-    if ml.startswith(("gpt-", "o1-", "o3-", "o4-")):
+    # The o-series ships bare ids too ("o3", "o4-mini"), so the prefixes are
+    # matched without the dash the other families need.
+    if ml.startswith(("gpt-", "o1", "o3", "o4", "chatgpt")):
         return "openai/" + m
     if ml.startswith("claude-"):
         if "sonnet" in ml:
@@ -121,6 +124,8 @@ def map_model_to_openrouter(model: str, *, substitute_unknown: bool = False) -> 
         if "haiku" in ml:
             return "anthropic/claude-haiku-4.5"
         return "anthropic/claude-opus-4.8"
+    if ml.startswith("gemini"):
+        return "google/" + m
     if ml.startswith("kimi"):
         return "moonshotai/kimi-k2.6"
     if ml.startswith("deepseek"):

--- a/chapter4/multimodal-agent/config.py
+++ b/chapter4/multimodal-agent/config.py
@@ -13,25 +13,17 @@ load_dotenv()
 
 def _openrouter_model_id(model) -> str:
     """Map a provider-native model name to an OpenRouter model id, used by the
-    universal OpenRouter fallback. An explicit OPENROUTER_MODEL env var wins.
-    Vision-capable default (gpt-5.6-luna) so image analysis still works."""
+    universal OpenRouter fallback. An explicit OPENROUTER_MODEL env var wins
+    here even for a mappable id, which env.example documents as the way to force
+    one model. The vendor prefixes themselves come from agentbook's registry, so
+    this chapter cannot drift from the others; an id it cannot map becomes a
+    vision-capable default (gpt-5.6-luna) so image analysis still works."""
+    from agentbook.providers import map_model_to_openrouter
+
     override = os.getenv("OPENROUTER_MODEL")
     if override:
         return override
-    m = (model or "").strip()
-    if not m:
-        return "openai/gpt-5.6-luna"
-    if "/" in m:
-        return m
-    ml = m.lower()
-    if ml.startswith(("gpt-", "o1", "o3", "o4", "chatgpt")):
-        return "openai/" + m
-    if ml.startswith("claude-"):
-        return "anthropic/claude-opus-4.8"
-    if ml.startswith("gemini"):
-        return "google/" + m  # e.g. gemini-3.5-flash -> google/gemini-3.5-flash
-    # Provider-native ids (doubao-*/qwen/...) -> a widely-available vision model.
-    return "openai/gpt-5.6-luna"
+    return map_model_to_openrouter(model, substitute_unknown=True)
 
 
 class ExtractionMode(Enum):
@@ -45,7 +37,15 @@ class Provider(Enum):
     GEMINI = "gemini"
     OPENAI = "openai"
     DOUBAO = "doubao"
-    
+
+
+# This chapter's enum, in the names agentbook's provider registry knows.
+_REGISTRY_PROVIDER = {
+    Provider.GEMINI: "gemini",
+    Provider.OPENAI: "openai",
+    Provider.DOUBAO: "doubao",
+}
+
 
 @dataclass
 class ModelConfig:
@@ -151,17 +151,36 @@ class Config:
         return (not self.has_provider_key(provider)) and bool(self.openrouter_api_key)
 
     def openai_client_args(self, model_config: 'ModelConfig'):
-        """Return (client_kwargs, model_name) for an OpenAI-compatible call,
-        applying the universal OpenRouter fallback when needed."""
-        provider = model_config.provider
-        _m = (model_config.model_name or "").lower()
-        _prefer_or = bool(self.openrouter_api_key) and _m.startswith("gpt-5")  # 直连 gpt-5.6 需组织实名，优先 OpenRouter
-        if _prefer_or or self.use_openrouter(provider):
-            return (
-                {"api_key": self.openrouter_api_key, "base_url": self.openrouter_base_url},
-                _openrouter_model_id(model_config.model_name),
+        """Return (client_kwargs, model_name) for an OpenAI-compatible call.
+
+        Which endpoint and whose key comes from agentbook's provider registry,
+        so the reroute rules are stated once for the whole book. The reader
+        picks a *model* here rather than an endpoint, hence
+        chosen_by_reader=False: gpt-5.x is rerouted through OpenRouter when its
+        key is available, because the direct API needs org verification for
+        those ids and refuses function tools alongside reasoning.
+        """
+        from agentbook.providers import resolve_backend
+
+        try:
+            backend = resolve_backend(
+                _REGISTRY_PROVIDER[model_config.provider],
+                model=model_config.model_name,
+                # "" rather than None: a missing key must leave the OpenRouter
+                # fallback intact instead of being read back from the environment.
+                api_key=model_config.api_key or "",
+                chosen_by_reader=False,
             )
-        if provider == Provider.DOUBAO:
-            return {"api_key": self.doubao_api_key, "base_url": model_config.base_url}, model_config.model_name
-        # OPENAI (and any GEMINI forced through the OpenAI-compatible path)
-        return {"api_key": self.openai_api_key}, model_config.model_name
+        except ValueError:
+            # Nothing configured anywhere. Keep the previous shape and let the
+            # API call report the missing credential, so a caller that handles
+            # request errors gracefully still gets to do so.
+            return (
+                {"api_key": model_config.api_key or "", "base_url": model_config.base_url},
+                model_config.model_name,
+            )
+        client_kwargs = {"api_key": backend.api_key, "base_url": backend.base_url}
+        if backend.using_openrouter:
+            # OPENROUTER_MODEL still wins here; see _openrouter_model_id.
+            return client_kwargs, _openrouter_model_id(model_config.model_name)
+        return client_kwargs, backend.model

--- a/chapter5/code-for-math/README.md
+++ b/chapter5/code-for-math/README.md
@@ -119,7 +119,7 @@ Full flags: `python demo.py --help`. Common switches:
 
 Env vars: `OPENAI_API_KEY` (or `MOONSHOT_API_KEY` / `ARK_API_KEY`), `OPENAI_BASE_URL` (compatible endpoint), `MODEL` (default `gpt-5.6-luna`).
 
-**OpenRouter fallback**: if no direct key is set but `OPENROUTER_API_KEY` is, traffic goes through OpenRouter (model mapping: `gpt-*` → `openai/*`, others → `openai/gpt-5.6-luna`). Default `gpt-5.6-luna` is gpt-5.x and needs org verification on direct OpenAI, so with `OPENROUTER_API_KEY` set, OpenRouter is preferred (`openai/gpt-5.6-luna`).
+**OpenRouter fallback**: if no direct key is set but `OPENROUTER_API_KEY` is, traffic goes through OpenRouter (model mapping: `gpt-*` → `openai/*`, `kimi-*` → `moonshotai/*`, `gemini-*` → `google/*`, …; an id with no mapping is sent as asked and rejected by name rather than silently answered by another vendor's model). Default `gpt-5.6-luna` is gpt-5.x: direct OpenAI needs org verification for it and refuses function tools unless reasoning is off, and this experiment's `code` mode is function calling, so with `OPENROUTER_API_KEY` set OpenRouter is preferred (`openai/gpt-5.6-luna`).
 
 ### Sample results / takeaway
 
@@ -277,9 +277,12 @@ python demo.py --problems mine.json   # 换用自定义题库
 `OPENAI_BASE_URL`（切换兼容端点）、`MODEL`（默认 `gpt-5.6-luna`）。
 
 **通用 OpenRouter 兜底**：未配置任何直连 key 时，只要设置了 `OPENROUTER_API_KEY`
-即可自动改走 OpenRouter（模型名自动映射：`gpt-*` → `openai/*`，其它 → `openai/gpt-5.6-luna`）。
-另外默认模型 `gpt-5.6-luna` 属于 gpt-5.x，直连 OpenAI 调用它需要组织实名认证，
-因此只要设置了 `OPENROUTER_API_KEY` 就会优先走 OpenRouter（route `openai/gpt-5.6-luna`）。
+即可自动改走 OpenRouter（模型名自动映射：`gpt-*` → `openai/*`、`kimi-*` → `moonshotai/*`、
+`gemini-*` → `google/*` 等；映射不到的 id 按读者写的名字原样发出并由 OpenRouter 报错，
+而不是悄悄换成别家的模型作答）。另外默认模型 `gpt-5.6-luna` 属于 gpt-5.x，直连 OpenAI
+调用它既需要组织实名认证，也不允许 function tools 与推理并存（本实验的 code 模式正是
+function calling），因此只要设置了 `OPENROUTER_API_KEY` 就会优先走 OpenRouter
+（route `openai/gpt-5.6-luna`）。
 
 ### 预期输出示例 / 结论
 

--- a/chapter5/code-for-math/demo.py
+++ b/chapter5/code-for-math/demo.py
@@ -35,43 +35,22 @@ from sandbox import run_python
 # 配置：兼容多种可用的 OpenAI 协议 key（含通用 OpenRouter 兜底）
 # ---------------------------------------------------------------------------
 
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+# 每个 provider 的默认模型。端点、key 与模型名映射由 agentbook 的 provider
+# 注册表统一维护，实验这里只保留「默认用哪个模型」这一个自己的决定。
+DEFAULT_MODELS = {
+    "openai": "gpt-5.6-luna",
+    "openrouter": "openai/gpt-5.6-luna",
+    "moonshot": "kimi-k3",
+    "ark": "doubao-seed-1-6-250615",
+}
 
-
-def map_model_to_openrouter(model: str) -> str:
-    """把直连模型名映射为 OpenRouter 上的 id（非可映射 id 统一兜底到当前廉价旗舰）。"""
-    if not model or "/" in model:
-        return model or "openai/gpt-5.6-luna"
-    m = model.lower()
-    if m.startswith(("gpt-", "o1", "o3", "o4")):
-        return "openai/" + model
-    if m.startswith("claude"):
-        if "haiku" in m:
-            return "anthropic/claude-haiku-4.5"
-        if "sonnet" in m:
-            return "anthropic/claude-sonnet-4.6"
-        return "anthropic/claude-opus-4.8"
-    if m.startswith("gemini"):
-        return "google/" + model
-    # kimi / doubao / 其它非 OpenRouter 原生 id -> 统一兜底
-    return "openai/gpt-5.6-luna"
-
-
-def resolve_llm(api_key, base_url, model):
-    """通用 OpenRouter 兜底 + gpt-5.x 优先路由，返回 (api_key, base_url, model)。
-
-    - gpt-5.x / gpt-5.6* 且设置了 OPENROUTER_API_KEY 时优先走 OpenRouter
-      （直连 OpenAI 调用 gpt-5.6 需要组织实名认证）。
-    - 否则有直连 key 就保持直连不变。
-    - 否则有 OPENROUTER_API_KEY 就整体改走 OpenRouter。
-    - 都没有则原样返回，由调用方给出缺 key 的报错。
-    """
-    orkey = os.getenv("OPENROUTER_API_KEY")
-    m = (model or "").lower()
-    prefer_or = bool(orkey) and m.startswith("gpt-5")
-    if prefer_or or (not api_key and orkey):
-        return orkey, OPENROUTER_BASE_URL, map_model_to_openrouter(model)
-    return api_key, base_url, model
+# auto 模式下按此顺序挑第一个配了 key 的 provider。
+AUTO_KEY_VARS = {
+    "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "moonshot": "MOONSHOT_API_KEY",
+    "ark": "ARK_API_KEY",
+}
 
 
 def build_client_and_model(model_override=None, provider="auto"):
@@ -84,47 +63,40 @@ def build_client_and_model(model_override=None, provider="auto"):
     # 延迟导入：离线自检（--selfcheck）不需要 openai，也不需要 API key。
     from openai import OpenAI
 
+    from agentbook.providers import resolve_backend
+
     requested_model = model_override or os.getenv("MODEL")
-    choices = {
-        "openai": (
-            os.getenv("OPENAI_API_KEY"), os.getenv("OPENAI_BASE_URL"),
-            requested_model or "gpt-5.6-luna",
-        ),
-        "openrouter": (
-            os.getenv("OPENROUTER_API_KEY"), OPENROUTER_BASE_URL,
-            map_model_to_openrouter(requested_model or "gpt-5.6-luna"),
-        ),
-        "moonshot": (
-            os.getenv("MOONSHOT_API_KEY"), "https://api.moonshot.cn/v1",
-            requested_model or "kimi-k3",
-        ),
-        "ark": (
-            os.getenv("ARK_API_KEY"), "https://ark.cn-beijing.volces.com/api/v3",
-            requested_model or "doubao-seed-1-6-250615",
-        ),
-    }
+    # --provider 是读者的显式选择；auto 只是本实验的默认策略，所以后者允许注册表
+    # 把 gpt-5.x 改道到 OpenRouter（直连需组织实名认证，且不允许 function tools
+    # 与推理并存——本实验的 code 模式正是靠 function calling 跑沙箱）。
+    chosen_by_reader = provider != "auto"
     if provider == "auto":
         provider = next(
             (name for name in ("openai", "openrouter", "moonshot", "ark")
-             if choices[name][0]),
+             if os.getenv(AUTO_KEY_VARS[name])),
             "openai",
         )
-    if provider not in choices:
+    if provider not in DEFAULT_MODELS:
         raise ValueError(f"unsupported provider: {provider}")
-    api_key, base_url, model = choices[provider]
 
-    if not api_key:
+    try:
+        backend = resolve_backend(
+            provider,
+            model=requested_model or DEFAULT_MODELS[provider],
+            chosen_by_reader=chosen_by_reader,
+        )
+    except ValueError as exc:
         raise SystemExit(
             "未找到 API key，请设置 OPENAI_API_KEY（或 MOONSHOT_API_KEY / ARK_API_KEY / OPENROUTER_API_KEY）。\n"
             "若只想验证沙箱与题库而不调用大模型，可运行：python demo.py --selfcheck"
-        )
+        ) from exc
 
     # 加上超时与重试：避免个别 API 调用长时间挂起导致整个评测卡死。
-    _kw = {"api_key": api_key, "timeout": 180.0, "max_retries": 5}
-    if base_url:
-        _kw["base_url"] = base_url
-    client = OpenAI(**_kw)
-    return client, model, provider
+    client = OpenAI(
+        api_key=backend.api_key, base_url=backend.base_url, timeout=180.0, max_retries=5
+    )
+    # 记录进 evidence 的必须是实际走的通道，而不是最初挑中的那个名字。
+    return client, backend.model, "openrouter" if backend.using_openrouter else provider
 
 
 # ---------------------------------------------------------------------------

--- a/chapter5/conversational-ui/agent.py
+++ b/chapter5/conversational-ui/agent.py
@@ -39,44 +39,29 @@ EDITABLE_FILES = [
 ]
 
 
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-
-
-def map_model_to_openrouter(model: str) -> str:
-    """把直连模型名映射为 OpenRouter 上的 id（非可映射 id 统一兜底到当前廉价旗舰）。"""
-    if not model or "/" in model:
-        return model or "openai/gpt-5.6-luna"
-    m = model.lower()
-    if m.startswith(("gpt-", "o1", "o3", "o4")):
-        return "openai/" + model
-    if m.startswith("claude"):
-        if "haiku" in m:
-            return "anthropic/claude-haiku-4.5"
-        if "sonnet" in m:
-            return "anthropic/claude-sonnet-4.6"
-        return "anthropic/claude-opus-4.8"
-    if m.startswith("gemini"):
-        return "google/" + model
-    return "openai/gpt-5.6-luna"
-
-
 def build_client_and_model():
-    model = os.getenv("MODEL", "gpt-5.6-luna")
-    api_key = os.getenv("OPENAI_API_KEY")
-    base_url = os.getenv("OPENAI_BASE_URL")
-    orkey = os.getenv("OPENROUTER_API_KEY")
-    # 通用 OpenRouter 兜底：无直连 key，或默认 gpt-5.x（直连需组织实名认证）时改走 OpenRouter。
-    prefer_or = bool(orkey) and (model or "").lower().startswith("gpt-5")
-    if prefer_or or (not api_key and orkey):
-        api_key, base_url, model = orkey, OPENROUTER_BASE_URL, map_model_to_openrouter(model)
-    if not api_key:
-        raise SystemExit("未找到 OPENAI_API_KEY（或 OPENROUTER_API_KEY 兜底），请先在环境变量或 .env 中设置。")
+    """构造客户端与模型名。端点、key 与模型名映射统一由 agentbook 的 provider
+    注册表维护。
+
+    chosen_by_reader=False 表示 "openai" 是本实验的默认值而非读者的显式选择：
+    gpt-5.x 在有 OPENROUTER_API_KEY 时改走 OpenRouter（直连需组织实名认证，
+    且不允许 function tools 与推理并存，而本实验正是用 function calling 改前端）。
+    """
+    from agentbook.providers import resolve_backend
+
+    try:
+        backend = resolve_backend(
+            "openai", model=os.getenv("MODEL", "gpt-5.6-luna"), chosen_by_reader=False
+        )
+    except ValueError as exc:
+        raise SystemExit(
+            "未找到 OPENAI_API_KEY（或 OPENROUTER_API_KEY 兜底），请先在环境变量或 .env 中设置。"
+        ) from exc
     # timeout / max_retries：让偶发的网络/SSL 抖动自动重试，不至于整轮崩溃
-    client_kwargs = {"api_key": api_key, "timeout": 60.0, "max_retries": 3}
-    if base_url:
-        client_kwargs["base_url"] = base_url
-    client = OpenAI(**client_kwargs)
-    return client, model
+    client = OpenAI(
+        api_key=backend.api_key, base_url=backend.base_url, timeout=60.0, max_retries=3
+    )
+    return client, backend.model
 
 
 APPLY_EDITS_TOOL = {

--- a/chapter5/conversational-ui/backend/main.py
+++ b/chapter5/conversational-ui/backend/main.py
@@ -63,21 +63,23 @@ def _llm_reply(message: str, model: str) -> str:
     except Exception:
         return "（未安装 openai 依赖，无法启用 LLM 模式；已回退占位回复）"
 
-    api_key = os.getenv("OPENAI_API_KEY")
-    base_url = os.getenv("OPENAI_BASE_URL")
-    orkey = os.getenv("OPENROUTER_API_KEY")
-    # 通用 OpenRouter 兜底：无直连 key，或 gpt-5.x（直连需组织实名认证）时改走 OpenRouter。
-    prefer_or = bool(orkey) and (model or "").lower().startswith("gpt-5")
-    if prefer_or or (not api_key and orkey):
-        api_key, base_url = orkey, "https://openrouter.ai/api/v1"
-        if "/" not in model:
-            model = ("openai/" + model) if model.lower().startswith(("gpt-", "o1", "o3", "o4")) else "openai/gpt-5.6-luna"
-    if not api_key:
-        return "（未配置 OPENAI_API_KEY 或 OPENROUTER_API_KEY，无法启用 LLM 模式；已回退占位回复）"
+    # 端点、key 与模型名映射与 agent.py 一样交给 agentbook 的 provider 注册表：
+    # chosen_by_reader=False 表示 "openai" 是本实验的默认值而非读者的显式选择，
+    # 于是 gpt-5.x 在有 OPENROUTER_API_KEY 时改走 OpenRouter（直连需组织实名认证）。
+    from agentbook.providers import resolve_backend
 
-    client_kwargs = {"api_key": api_key, "timeout": 60.0, "max_retries": 2}
-    if base_url:
-        client_kwargs["base_url"] = base_url
+    try:
+        backend = resolve_backend("openai", model=model, chosen_by_reader=False)
+    except ValueError:
+        return "（未配置 OPENAI_API_KEY 或 OPENROUTER_API_KEY，无法启用 LLM 模式；已回退占位回复）"
+    model = backend.model
+
+    client_kwargs = {
+        "api_key": backend.api_key,
+        "base_url": backend.base_url,
+        "timeout": 60.0,
+        "max_retries": 2,
+    }
 
     try:
         client = OpenAI(**client_kwargs)

--- a/chapter5/erp-agent/README.md
+++ b/chapter5/erp-agent/README.md
@@ -59,7 +59,7 @@ cp env.example .env      # OPENAI_API_KEY
 python demo.py           # same as python demo.py run
 ```
 
-**OpenRouter fallback**: if `OPENAI_API_KEY` unset, set `OPENROUTER_API_KEY` (`gpt-*` → `openai/*`, else `openai/gpt-5.6-luna`). Default `gpt-5.6-luna` is gpt-5.x (org verification on direct OpenAI), so with `OPENROUTER_API_KEY` OpenRouter is preferred.
+**OpenRouter fallback**: if `OPENAI_API_KEY` unset, set `OPENROUTER_API_KEY` (`gpt-*` → `openai/*`, `kimi-*` → `moonshotai/*`, `gemini-*` → `google/*`, …; an unmapped id is sent as asked and rejected by name). Default `gpt-5.6-luna` is gpt-5.x (org verification on direct OpenAI), so with `OPENROUTER_API_KEY` OpenRouter is preferred.
 
 `demo.py` has 4 subcommands (no subcommand = `run`):
 
@@ -162,7 +162,8 @@ python demo.py           # 等价于 python demo.py run
 ```
 
 **通用 OpenRouter 兜底**：未配置 `OPENAI_API_KEY` 时，设置 `OPENROUTER_API_KEY` 即自动
-改走 OpenRouter（`gpt-*` → `openai/*`，其它 → `openai/gpt-5.6-luna`）。默认模型
+改走 OpenRouter（`gpt-*` → `openai/*`、`kimi-*` → `moonshotai/*`、`gemini-*` → `google/*` 等；
+映射不到的 id 按原名发出并由 OpenRouter 报错）。默认模型
 `gpt-5.6-luna` 属 gpt-5.x，直连 OpenAI 需组织实名认证，故设置了 `OPENROUTER_API_KEY`
 时会优先走 OpenRouter。
 

--- a/chapter5/erp-agent/agent.py
+++ b/chapter5/erp-agent/agent.py
@@ -13,47 +13,20 @@ from openai import OpenAI
 
 MODEL = os.environ.get("OPENAI_MODEL", "gpt-5.6-luna")
 
-# --- 通用 OpenRouter 兜底 ---
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-
-
-def _map_to_openrouter_model(model: str) -> str:
-    """把直连模型名映射为 OpenRouter 上的 id（非可映射 id 统一兜底到当前廉价旗舰）。"""
-    if not model or "/" in model:
-        return model or "openai/gpt-5.6-luna"
-    m = model.lower()
-    if m.startswith(("gpt-", "o1", "o3", "o4")):
-        return "openai/" + model
-    if m.startswith("claude"):
-        if "haiku" in m:
-            return "anthropic/claude-haiku-4.5"
-        if "sonnet" in m:
-            return "anthropic/claude-sonnet-4.6"
-        return "anthropic/claude-opus-4.8"
-    if m.startswith("gemini"):
-        return "google/" + model
-    return "openai/gpt-5.6-luna"
-
 
 def _make_client_and_model(model: str):
-    """构造客户端并解析模型名，含通用 OpenRouter 兜底。返回 (client, resolved_model)。
+    """构造客户端并解析模型名。返回 (client, resolved_model)。
 
-    - 有 OPENAI_API_KEY：直连；但 model 为 gpt-5.x 且同时设置了 OPENROUTER_API_KEY
-      时优先走 OpenRouter（直连 gpt-5.6 需组织实名认证）。
-    - 无 OPENAI_API_KEY 但有 OPENROUTER_API_KEY：改走 OpenRouter（模型名自动映射）。
+    端点、key 与模型名映射统一由 agentbook 的 provider 注册表维护。
+    chosen_by_reader=False 表示 "openai" 是本实验的默认值而非读者的显式选择：
+    gpt-5.x 在有 OPENROUTER_API_KEY 时会自动改走 OpenRouter（直连需组织实名
+    认证），没有 OpenRouter key 时仍然直连。
     """
-    api_key = os.environ.get("OPENAI_API_KEY")
-    base_url = os.environ.get("OPENAI_BASE_URL")
-    orkey = os.environ.get("OPENROUTER_API_KEY")
-    prefer_or = bool(orkey) and (model or "").lower().startswith("gpt-5")
-    if prefer_or or (not api_key and orkey):
-        api_key, base_url, model = orkey, OPENROUTER_BASE_URL, _map_to_openrouter_model(model)
-    kw = {}
-    if api_key:
-        kw["api_key"] = api_key
-    if base_url:
-        kw["base_url"] = base_url
-    return OpenAI(**kw), model
+    from agentbook.providers import resolve_backend
+
+    backend = resolve_backend("openai", model=model, chosen_by_reader=False)
+    return OpenAI(api_key=backend.api_key, base_url=backend.base_url), backend.model
+
 
 SYSTEM_PROMPT = """你是一个「自然语言转 SQL」的 ERP 数据助手。
 用户给你一个中文问题，你只输出一条可直接执行的 **SQLite** SQL 查询，不要任何解释、不要 markdown 代码块。

--- a/chapter5/paper-to-ppt/agents.py
+++ b/chapter5/paper-to-ppt/agents.py
@@ -27,7 +27,6 @@ TEXT_MODEL = os.environ.get("TEXT_MODEL", "gpt-5.6-luna")
 # 视觉审查用的模型（Reviewer / 单 Agent 的看图部分），必须支持图像
 VISION_MODEL = os.environ.get("VISION_MODEL", "gpt-5.6-luna")
 
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 PROVIDER = os.environ.get("PPT_PROVIDER", "auto")
 
 
@@ -35,23 +34,6 @@ def configure_provider(provider: str) -> None:
     global PROVIDER
     PROVIDER = provider
 
-
-def map_model_to_openrouter(model: str) -> str:
-    """把直连模型名映射为 OpenRouter 上的 id（非可映射 id 统一兜底到当前廉价旗舰）。"""
-    if not model or "/" in model:
-        return model or "openai/gpt-5.6-luna"
-    m = model.lower()
-    if m.startswith(("gpt-", "o1", "o3", "o4")):
-        return "openai/" + model
-    if m.startswith("claude"):
-        if "haiku" in m:
-            return "anthropic/claude-haiku-4.5"
-        if "sonnet" in m:
-            return "anthropic/claude-sonnet-4.6"
-        return "anthropic/claude-opus-4.8"
-    if m.startswith("gemini"):
-        return "google/" + model
-    return "openai/gpt-5.6-luna"
 
 # 发送给 Vision 前把截图缩放到该宽度，兼顾“看得清文字溢出”与“控制 token 成本”
 VISION_IMAGE_WIDTH = 1280
@@ -125,34 +107,39 @@ class TokenMeter:
 
 
 def _client() -> OpenAI:
-    # 通用 OpenRouter 兜底：无直连 key，或默认 gpt-5.x（直连需组织实名认证）时改走 OpenRouter。
+    """构造 OpenAI 客户端。端点、key 与模型名映射统一由 agentbook 的 provider
+    注册表维护。
+
+    PPT_PROVIDER / --provider 是读者的显式选择，注册表会原样尊重；auto 只是本
+    实验的默认策略，因此 chosen_by_reader=False，gpt-5.x 在有 OPENROUTER_API_KEY
+    时会自动改走 OpenRouter（直连需组织实名认证，且不允许 function tools 与推理
+    并存）。文本与视觉共用一个客户端，所以只要有一个模型是 gpt-5.x 就一起改道。
+    """
     global TEXT_MODEL, VISION_MODEL
-    if PROVIDER == "ark":
-        api_key = os.environ.get("ARK_API_KEY")
-        base_url = "https://ark.cn-beijing.volces.com/api/v3"
-    elif PROVIDER == "moonshot":
-        api_key = os.environ.get("MOONSHOT_API_KEY")
-        base_url = "https://api.moonshot.cn/v1"
-    elif PROVIDER == "openrouter":
-        api_key = os.environ.get("OPENROUTER_API_KEY")
-        base_url = OPENROUTER_BASE_URL
-    else:
-        api_key = os.environ.get("OPENAI_API_KEY")
-        base_url = os.environ.get("OPENAI_BASE_URL")
-    orkey = os.environ.get("OPENROUTER_API_KEY")
-    prefer_or = PROVIDER == "auto" and bool(orkey) and (
-        (TEXT_MODEL or "").lower().startswith("gpt-5") or (VISION_MODEL or "").lower().startswith("gpt-5")
+    from agentbook.providers import map_model_to_openrouter, resolve_backend
+
+    trigger = next(
+        (m for m in (TEXT_MODEL, VISION_MODEL) if (m or "").lower().startswith("gpt-5")),
+        TEXT_MODEL,
     )
-    if PROVIDER == "openrouter" or prefer_or or (PROVIDER == "auto" and not api_key and orkey):
-        api_key, base_url = orkey, OPENROUTER_BASE_URL
-        # 走 OpenRouter 时把模型名映射为其 id（幂等：已带前缀的 id 原样返回）。
-        TEXT_MODEL = map_model_to_openrouter(TEXT_MODEL)
-        VISION_MODEL = map_model_to_openrouter(VISION_MODEL)
-    if not api_key:
+    try:
+        backend = resolve_backend(
+            PROVIDER if PROVIDER != "auto" else "openai",
+            model=trigger,
+            chosen_by_reader=PROVIDER != "auto",
+        )
+    except ValueError as exc:
         raise SystemExit(
             "❌ 未检测到 OPENAI_API_KEY（或 OPENROUTER_API_KEY 兜底）。请先 `cp env.example .env` 并填入有效的 "
             "OpenAI API Key（或 `export OPENAI_API_KEY=your-openai-api-key` / `export OPENROUTER_API_KEY=...`）后再运行。"
-        )
+        ) from exc
+    if backend.using_openrouter:
+        # 与注册表同一条规则：读者显式选了聚合器时，无法映射的 id 换成可用的默认
+        # 模型；只是因为缺凭据被动改道时，保留读者点名的 id 让 OpenRouter 按名报错。
+        substitute = PROVIDER == "openrouter"
+        TEXT_MODEL = map_model_to_openrouter(TEXT_MODEL, substitute_unknown=substitute)
+        VISION_MODEL = map_model_to_openrouter(VISION_MODEL, substitute_unknown=substitute)
+    api_key, base_url = backend.api_key, backend.base_url
     # timeout + max_retries：单次网络抖动/SSL 中断会自动重试，而不是让整条流水线崩溃。
     return OpenAI(
         api_key=api_key,

--- a/chapter5/paper-to-video/demo.py
+++ b/chapter5/paper-to-video/demo.py
@@ -54,26 +54,6 @@ DEFAULT_TEXT_MODEL = os.getenv("TEXT_MODEL", "gpt-5.6-luna")
 DEFAULT_TTS_MODEL = os.getenv("TTS_MODEL", "tts-1")
 DEFAULT_TTS_VOICE = os.getenv("TTS_VOICE", "alloy")
 
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-
-
-def map_model_to_openrouter(model: str) -> str:
-    """把直连模型名映射为 OpenRouter 上的 id（非可映射 id 统一兜底到当前廉价旗舰）。"""
-    if not model or "/" in model:
-        return model or "openai/gpt-5.6-luna"
-    m = model.lower()
-    if m.startswith(("gpt-", "o1", "o3", "o4")):
-        return "openai/" + model
-    if m.startswith("claude"):
-        if "haiku" in m:
-            return "anthropic/claude-haiku-4.5"
-        if "sonnet" in m:
-            return "anthropic/claude-sonnet-4.6"
-        return "anthropic/claude-opus-4.8"
-    if m.startswith("gemini"):
-        return "google/" + model
-    return "openai/gpt-5.6-luna"
-
 # 离线占位音轨的中文语速估算（字/秒），用于把讲解词长度换算成展示时长。
 OFFLINE_CHARS_PER_SEC = 4.5
 
@@ -449,13 +429,16 @@ def main(cfg: Config) -> None:
                      "或用 --offline 在无 API 时验证合成流水线。")
         from openai import OpenAI  # 延迟导入：--offline 时无需安装/联网 openai
 
-        # 文本客户端：无直连 key，或默认 gpt-5.x（直连需组织实名认证）时改走 OpenRouter。
-        prefer_or = bool(orkey) and (cfg.text_model or "").lower().startswith("gpt-5")
-        if prefer_or or (not api_key and orkey):
-            client = OpenAI(api_key=orkey, base_url=OPENROUTER_BASE_URL, timeout=120.0, max_retries=3)
-            cfg.text_model = map_model_to_openrouter(cfg.text_model)
-        else:
-            client = OpenAI(base_url=base_url, timeout=120.0, max_retries=3)
+        # 文本客户端：端点、key 与模型名映射统一交给 agentbook 的 provider 注册表。
+        # chosen_by_reader=False 表示 "openai" 是本实验的默认值而非读者的显式选择：
+        # gpt-5.x 在有 OPENROUTER_API_KEY 时改走 OpenRouter（直连需组织实名认证）。
+        from agentbook.providers import resolve_backend
+
+        backend = resolve_backend("openai", model=cfg.text_model, chosen_by_reader=False)
+        cfg.text_model = backend.model
+        client = OpenAI(
+            api_key=backend.api_key, base_url=backend.base_url, timeout=120.0, max_retries=3
+        )
 
         # TTS 客户端：只能用直连 OPENAI_API_KEY；缺失则音频降级为离线静音占位
         #（讲解词仍由文本客户端真实生成）。

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -322,6 +322,13 @@ def test_fallback_key_is_not_reusable_as_a_provider_key(monkeypatch):
         ("gpt-4o", "openai/gpt-4o"),
         ("claude-sonnet-4", "anthropic/claude-sonnet-4.6"),
         ("deepseek-v4-flash", "deepseek/deepseek-v4-flash"),
+        # Vendors the chapter-local mappers knew and this one has to keep:
+        # a Gemini id sent unmapped is rejected by OpenRouter, and the o-series
+        # ships bare ids with no dash to anchor on.
+        ("gemini-3.5-flash", "google/gemini-3.5-flash"),
+        ("o3", "openai/o3"),
+        ("o4-mini", "openai/o4-mini"),
+        ("chatgpt-4o-latest", "openai/chatgpt-4o-latest"),
         # Already namespaced ids pass through untouched.
         ("google/gemma-4-26b-a4b-it:free", "google/gemma-4-26b-a4b-it:free"),
     ],
@@ -331,6 +338,17 @@ def test_direct_openrouter_maps_bare_model_ids(monkeypatch, override, expected):
     override is mapped the same way as on the fallback path."""
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-direct-key")
     assert resolve_backend("openrouter", model=override).model == expected
+
+
+def test_gemini_fallback_is_namespaced_for_openrouter(monkeypatch):
+    """The reroute path maps too: an unmapped ``gemini-*`` id reaches OpenRouter
+    under a name it does not host and is rejected."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-gemini-key")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    backend = resolve_backend("gemini", model="gemini-3.5-flash")
+    assert backend.using_openrouter is True
+    assert backend.model == "google/gemini-3.5-flash"
 
 
 def test_keyless_provider_resolves_without_any_key():


### PR DESCRIPTION
接着 #980（已合并）做的收尾，已 rebase 到 main 上，base 就是 main。

#980 修的是 chapter2/agent-skills-ppt 一处。第四、五章还有六处各自抄了一份同样的 `prefer_or` + `map_model_to_openrouter`，这次一起收敛到共享注册表：

| 实验 | 之前 |
| --- | --- |
| `chapter4/multimodal-agent` | 本地 `_openrouter_model_id` + `_prefer_or` |
| `chapter5/erp-agent` | 本地 mapper + `prefer_or` |
| `chapter5/code-for-math` | 本地 mapper + **从未被调用的** `resolve_llm` |
| `chapter5/conversational-ui` | `agent.py` 与 `backend/main.py` 各一份（后者还是简化版，gemini/claude 都被换成 gpt-5.6-luna） |
| `chapter5/paper-to-ppt` | 本地 mapper + `prefer_or`（含 `PPT_PROVIDER` 选择器） |
| `chapter5/paper-to-video` | 本地 mapper + `prefer_or` |

## 顺手修掉的一个真 bug

`chapter5/code-for-math` 那份 `resolve_llm()` 定义了却**从未被调用**——`build_client_and_model()` 里根本没有 gpt-5 判断。所以它今天和 #967 报的是同一个坑：默认 `gpt-5.6-luna` + `OPENAI_API_KEY` 直连，而它的 `code` 模式正是 function calling，必然 400。改用注册表后自动改道，顺带修好。

## 共享侧

`map_model_to_openrouter` 补上各实验本地版本有、它却没有的三条规则：

- `gemini*` → `google/*`：缺了它，`resolve_backend("gemini")` 的 OpenRouter 兜底会把 OpenRouter 不认识的裸 id 发出去；
- `chatgpt*` → `openai/*`；
- 不带连字符的 `o1`/`o3`/`o4`（`o3` 本身就是合法 id，原来只匹配 `o3-`）。

## 行为核对

写了一个 old-vs-new 对照脚本，按 {无 key / 只有 `OPENAI_API_KEY` / 只有 `OPENROUTER_API_KEY` / 两者都有 / 各家直连 key} × {`gpt-5.6-luna`, `gpt-4o`, `kimi-k3`, `gemini-3.5-flash`, `doubao-1.6`} × {`PPT_PROVIDER` 五种} 逐格比对解析出的 `(endpoint, key, model)`。绝大多数格完全一致，差异只有四类，都是有意的：

1. **走 OpenRouter 且 id 映射不到时**：旧代码一律换成 `openai/gpt-5.6-luna`，现在按读者写的名字原样发出、由 OpenRouter 报错——这是注册表既有的策略（悄悄换成别家的模型作答比失败更糟）。`kimi-k3` 则从「被换成 gpt-5.6-luna」变成正确的 `moonshotai/kimi-k2.6`。
2. **显式选了某家却没有它的 key**：从 `SystemExit` 变成走 OpenRouter 通用兜底（注册表第 3 步），与全书其它实验一致。
3. **chapter4 的 gemini 模型 + `GEMINI_API_KEY`**：不再被送去 `api.openai.com`（且带着 OpenAI 的 key），而是走 Google 的 OpenAI 兼容端点。
4. **缺 key 的报错**：从 `OpenAIError` 变成注册表那条点名环境变量的 `ValueError`。chapter4 例外——那里保留了原来的「不抛异常、让 API 调用去报错」路径，免得打断它自己的降级逻辑。

`OPENROUTER_MODEL` 在 chapter4 仍然「即使 id 可映射也优先生效」（env.example 把它文档化为强制指定模型的开关），这一点没有改。

## CI

`provider-adoption-tests` 的 paths 与 matrix 扩到五个 chapter5 实验，并加装 `media` 组（`paper-to-ppt/agents.py` 与 `paper-to-video/demo.py` 在模块级 `import PIL`，否则连收集都过不了）。

`chapter4/multimodal-agent` 没有加进 matrix：它的 `test_extract_image_to_text` 需要至少一个真 key 才能过，把 key 清空时在 main 上也一样红（已验证），与路由无关。

## 测试

六个实验各自的测试全过（clean env）；`tests/test_providers.py` 新增 5 例（三条新映射规则 + gemini 兜底命名）。

**未做线上验证**：两个 key 都没额度（OpenAI `429`、OpenRouter `402`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKUAoLDhVDcw4e24yaJJra
