### PR TITLE
fix(deps): install LiteLLM from Windows wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,9 @@ providers = [
     "anthropic>=0.40.0",
     "google-genai>=0.3",
     "mistralai>=1.2.0",
-    "litellm>=1.41.0",
+    # LiteLLM 1.92.0-1.93.0 shipped no Windows wheels, so uv fell back to a
+    # Rust/MSVC source build. 1.94.1 restores prebuilt wheels for Python 3.11-3.13.
+    "litellm>=1.94.1",
     "ollama>=0.5.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -757,7 +757,7 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'integrations'", specifier = ">=0.1" },
     { name = "langchain-openai", marker = "extra == 'orchestration'", specifier = ">=0.1" },
     { name = "librosa", marker = "extra == 'audio'", specifier = ">=0.10" },
-    { name = "litellm", marker = "extra == 'providers'", specifier = ">=1.41.0" },
+    { name = "litellm", marker = "extra == 'providers'", specifier = ">=1.94.1" },
     { name = "loguru", marker = "extra == 'rag'", specifier = ">=0.7.2" },
     { name = "lxml", marker = "extra == 'web'", specifier = ">=5.1.0" },
     { name = "markdown", marker = "extra == 'dev'", specifier = ">=3.5,<4" },
@@ -3575,7 +3575,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.93.0"
+version = "1.94.1"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -3591,11 +3591,14 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/93/e1/4f05ca4cbb4efb739c9e66a182ecd5c816bc05bf3665ec8e0fb4ab408379/litellm-1.93.0.tar.gz", hash = "sha256:140bf215e264c71601bca9c06d2436c5451bb59e1e195ea23fc2d3d87b6929ec", size = 15948866, upload-time = "2026-07-19T03:01:24.389Z" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a1/d6/6995fbc8cc4a22c9a1346981dd62348cf563e9285e17587703ad235f1fc0/litellm-1.94.1.tar.gz", hash = "sha256:e9effe4c1e9206740b4bb4c98142ea1f71bae57e49df007cd25ef24b0ce4563f", size = 16264730, upload-time = "2026-07-30T23:14:22.682Z" }
 wheels = [
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7d/15/52ee5e4743ad656a4d408ca6fcd8bca844b572b6a8e9776f1232bd7d9d8d/litellm-1.93.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:460001b7c88c5b6675ad482ae3cecba96e21f890604b4febb1a67807ace1c750", size = 20161646, upload-time = "2026-07-19T03:01:02.827Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/db/6af798603c6e2cf21ad7f2edf7e95019bd859dda82284b94014d608fcd85/litellm-1.93.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0784172435de48f66ef7ad89d421604db1ad0db1321ef7f39dbcfe6b20111417", size = 20156724, upload-time = "2026-07-19T03:01:09.037Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/64/49/2db5757f7e284eb12618b547cb62dab49687ffaf1d749ca048210e3d0dbd/litellm-1.93.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:98c15e84d32e922a821c105308bf9ddae8700de9ed396530bee2cbb1cacf4cbb", size = 20157288, upload-time = "2026-07-19T03:01:15.395Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/25/91/1b79a585c836eb6eb6db5c2b3524cb285d4de2439002757c7e3f8b7f04b5/litellm-1.94.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b0145d6b9fb718d12b7242ce5c975123f4dbfecd7b8ed1eb6a6939b0e506c946", size = 20673362, upload-time = "2026-07-30T23:13:45.506Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d9/bf/7cde618559d00c94945f92d21b4e1b44aca2efcbc08b00cb904e18631e46/litellm-1.94.1-cp311-cp311-win_amd64.whl", hash = "sha256:07c1771315d7d26e242ef90b9336bcbc49a52158ff72ee640b4f8160cc963147", size = 20273833, upload-time = "2026-07-30T23:13:48.443Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/03/3c/f75a840c3a1b6466e138f5833e1623fcbf32a63bae8a56efc31a4265f8b6/litellm-1.94.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:66bc95498af3ab687ce7570704cb274bcf1d78049afa87a9f5f64db45b72847d", size = 20664250, upload-time = "2026-07-30T23:13:55.007Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/89/cd/ab61853dc3699a96997dd731bd005f2c511235f695cb32c11209d55201c6/litellm-1.94.1-cp312-cp312-win_amd64.whl", hash = "sha256:44e55a55270dee8bb85e063940c368d32040e6db66765c55db4b884fc002d4ef", size = 20268551, upload-time = "2026-07-30T23:13:58.222Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4e/51/6923345e9584e6855cbc182af99efcd4de5d5aea75330dfcb53eaa2e3131/litellm-1.94.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1b0bc4a2373e54f2bd4c13f8ef9fda3839bfb2e1173fb4bcea3150b07d4c59bc", size = 20665189, upload-time = "2026-07-30T23:14:04.562Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/28/b6/bc53595152faad2275fcbd4106a9d9bfe6133b704b2be3b4fdae31090598/litellm-1.94.1-cp313-cp313-win_amd64.whl", hash = "sha256:d14e5812b5f36af2ab45461ee0c925251bc07daf65c33b8f2ce3fd3ec1235eae", size = 20266790, upload-time = "2026-07-30T23:14:08.139Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- raise the LiteLLM provider floor from 1.41.0 to 1.94.1
- refresh the lock entry with prebuilt Windows wheels for Python 3.11, 3.12, and 3.13
- prevent the documented native-Windows Chapter 2 install from falling back to a Rust/MSVC source build

Chapter 2 still includes LiteLLM because the prompt-engineering examples import it; using the first upstream release confirmed to restore Windows wheels fixes the full chapter environment without splitting its dependency coverage.

## Verification

- `uv lock --check`
- `uv sync --locked --dry-run --python 3.12 --python-platform x86_64-pc-windows-msvc --extra ch2 --no-build-package litellm`
- downloaded and SHA-256-verified the locked CPython 3.12 Windows wheel; confirmed it contains the precompiled native `.pyd`
- `python -m pytest -q chapter2/local_llm_serving/test_platform_detection.py` (4 passed)
- `git diff --check origin/main...HEAD`

Fixes #988