### PR TITLE
fix(site): 修复章节页「编辑此页」「查看源代码」按钮 404

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,10 @@ hooks:
   # `_web/` is an ignored staging tree, so map each staged page back to its
   # tracked source before the revision-date plugin asks Git for timestamps.
   - scripts/git_revision_dates.py
+  # `_web/` promotes book/chapterN.md to book/chapterN/index.md, a path that
+  # does not exist in the repository. Retarget the "edit this page" / "view
+  # source" buttons at the tracked source so they don't 404 (issue #1019).
+  - scripts/site_edit_urls.py
   # Validates every configured language and generates the browser-side
   # translation catalog from Material's locales + our book navigation labels.
   - scripts/site_i18n.py

--- a/scripts/site_edit_urls.py
+++ b/scripts/site_edit_urls.py
@@ -1,0 +1,34 @@
+"""Point the "edit this page" / "view source" buttons at the tracked source.
+
+``scripts/build_site.sh`` assembles the site into the ignored ``_web/``
+directory, and promotes ``book/chapterN.md`` to ``book/chapterN/index.md`` so
+``navigation.indexes`` can attach the chapter prose to its nav section.  MkDocs
+derives the header buttons from the *staged* path, so both buttons on every
+chapter page pointed at ``book/chapterN/index.md`` — a path that does not exist
+in the repository, hence a 404 (issue #1019).
+
+Rewriting ``File.edit_uri`` (documented as overwritable) is enough: Material
+builds the "view source" link from ``page.edit_url`` too, so both buttons
+follow.  Pages with no counterpart in the repository get ``None``, which drops
+the buttons instead of rendering a link that cannot resolve.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from mkdocs.plugins import event_priority
+
+from site_source_paths import repo_relative_source
+
+
+@event_priority(100)
+def on_files(files: Iterable[Any], config: Any, **_: Any) -> None:
+    """Retarget every documentation page at its repository source."""
+    for file in files:
+        if not getattr(file, "is_documentation_page", None) or not file.is_documentation_page():
+            continue
+        src_uri = getattr(file, "src_uri", None)
+        if not src_uri:
+            continue
+        file.edit_uri = repo_relative_source(str(src_uri))

--- a/scripts/site_source_paths.py
+++ b/scripts/site_source_paths.py
@@ -31,6 +31,22 @@ def source_path_for_page(src_uri: str, root: Path = REPO_ROOT) -> Path:
     return root.joinpath(*parts)
 
 
+def repo_relative_source(src_uri: str, root: Path = REPO_ROOT) -> str | None:
+    """Return the repository path backing an assembled page, or ``None``.
+
+    ``None`` means the page has no counterpart in the repository, so links
+    that point at the source (the "edit this page" / "view source" buttons)
+    would 404 and are better left out entirely.
+    """
+    source = source_path_for_page(src_uri, root)
+    if not source.is_file():
+        return None
+    try:
+        return source.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return None
+
+
 def original_source_map(files: Iterable[Any], root: Path = REPO_ROOT) -> dict[str, str]:
     """Map staged absolute paths to existing source files in the repository."""
     sources: dict[str, str] = {}

--- a/tests/test_site_edit_urls.py
+++ b/tests/test_site_edit_urls.py
@@ -1,0 +1,79 @@
+"""Regression tests for the source links in the assembled online-reading site.
+
+Issue #1019: the "edit this page" and "view source" buttons on every chapter
+page pointed at `book/chapterN/index.md`, a path that only exists inside the
+generated `_web/` tree, so both buttons 404'd on GitHub.
+"""
+
+from pathlib import Path
+import sys
+
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.structure.files import File
+from mkdocs.structure.pages import Page
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import site_edit_urls  # noqa: E402
+from site_source_paths import repo_relative_source  # noqa: E402
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _config(tmp_path: Path) -> MkDocsConfig:
+    config = MkDocsConfig()
+    config.load_dict(
+        {
+            "site_name": "test",
+            "docs_dir": str(tmp_path),
+            "repo_url": "https://github.com/bojieli/ai-agent-book",
+            "edit_uri": "edit/main",
+        }
+    )
+    assert not config.validate()[0]
+    return config
+
+
+def _page(src_uri: str, tmp_path: Path) -> Page:
+    staged = tmp_path / src_uri
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    staged.touch()
+    config = _config(tmp_path)
+    file = File(src_uri, str(tmp_path), str(tmp_path / "_site"), use_directory_urls=True)
+    site_edit_urls.on_files([file], config)
+    return Page(None, file, config)
+
+
+def test_promoted_chapter_page_links_to_the_tracked_chapter_source(tmp_path: Path):
+    page = _page("book/chapter9/index.md", tmp_path)
+
+    assert page.edit_url == (
+        "https://github.com/bojieli/ai-agent-book/edit/main/book/chapter9.md"
+    )
+    # Material derives the "view source" button from the same URL.
+    assert page.edit_url.replace("edit", "raw") == (
+        "https://github.com/bojieli/ai-agent-book/raw/main/book/chapter9.md"
+    )
+
+
+def test_regular_page_keeps_its_own_path(tmp_path: Path):
+    page = _page("book-en/chapter9.md", tmp_path)
+
+    assert page.edit_url == (
+        "https://github.com/bojieli/ai-agent-book/edit/main/book-en/chapter9.md"
+    )
+
+
+def test_page_without_a_repository_source_gets_no_buttons(tmp_path: Path):
+    page = _page("generated/nowhere.md", tmp_path)
+
+    assert page.edit_url is None
+
+
+def test_every_promoted_chapter_resolves_to_a_real_source():
+    for chapter in range(1, 11):
+        assert repo_relative_source(f"book/chapter{chapter}/index.md") == (
+            f"book/chapter{chapter}.md"
+        )


### PR DESCRIPTION
## 问题

https://bojieli.github.io/ai-agent-book/book/chapter9/ 顶部的「编辑此页」（铅笔）和「查看本页的源代码」（眼睛）两个按钮都 404。

## 原因

`scripts/build_site.sh` 会把 `book/chapterN.md` 提升为 `_web/book/chapterN/index.md`，好让 `navigation.indexes` 把章节正文挂到侧边栏的章节标题上。MkDocs 由这个**暂存路径**推导 `page.edit_url`，Material 的两个按钮又都源自它：

```html
<a href=".../edit/main/book/chapter9/index.md" title="编辑此页" ...>
<a href=".../raw/main/book/chapter9/index.md"  title="查看本页的源代码" ...>
```

`book/chapter9/index.md` 只存在于生成的 `_web/` 里，仓库中并没有这个路径，所以两个按钮一起 404。修订日期钩子早就有针对这次提升的 `source_path_for_page()` 映射，只是 edit_url 从来没用上它。

## 改动

- `scripts/site_source_paths.py`：新增 `repo_relative_source()`，返回页面对应的仓库相对路径；仓库中没有对应源文件时返回 `None`。
- `scripts/site_edit_urls.py`（新增钩子）：改写每个文档页的 `File.edit_uri`（MkDocs 文档明确说明可覆盖）。只改 `edit_url` 就够了——Material 的「查看源代码」链接是 `page.edit_url | replace("edit", "raw")`，两个按钮一起修好。没有仓库源文件的页面置为 `None`，直接不渲染按钮，而不是给出打不开的链接。
- `mkdocs.yml`：注册钩子。
- `tests/test_site_edit_urls.py`：基于真实 MkDocs `File`/`Page` 对象的回归测试，并校验 10 章都能映射到真实源文件。

## 验证

用该钩子跑真实 `mkdocs build`，章节页按钮变为：

```
edit: https://github.com/bojieli/ai-agent-book/edit/main/book/chapter9.md
view: https://github.com/bojieli/ai-agent-book/raw/main/book/chapter9.md
```

HTTP 复核：旧的 `raw/main/book/chapter9/index.md` 返回 404，新的 `raw/main/book/chapter9.md` 返回 200。`book-en/chapter9.md` 这类平铺译本页面链接不变。

中文版 10 章全部受影响，不只是第九章。

Closes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ihudnjwyEnAaEC3yzQkmw