### PR TITLE
fix(ch2): 修正图 2-10 KV Cache 前缀复用机制图的语义与排版问题

### DIFF
--- a/book/images/fig2-10.svg
+++ b/book/images/fig2-10.svg
@@ -1,39 +1,45 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 820 440" width="820" height="440" style="background:#ffffff">
-<defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 44 820 443" width="820" height="443" style="background:#ffffff">
+<title>图 2-10 KV Cache 前缀复用机制</title>
+<desc>三次请求对比 KV Cache 的前缀复用：请求 1 建立缓存，请求 2 因前缀不变而命中缓存，请求 3 把动态时间戳放在系统提示词最前面，导致变动点之后的全部 token 重新计算与计费。</desc>
+<defs><marker id="ah-light" markerUnits="userSpaceOnUse" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#999999"/></marker></defs>
 <text x="40" y="70" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">请求 1</text>
-<rect x="40" y="85" width="380" height="40" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="230" y="105" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">System Prompt + Tools (1200 tokens)</text>
-<rect x="425" y="85" width="180" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="515" y="105" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">user: &quot;天气如何？&quot;</text>
-<rect x="610" y="85" width="170" height="40" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="695" y="105" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ 生成回答</text>
+<rect x="40" y="85" width="455" height="40" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="267.5" y="105" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">System Prompt + Tools (1200 token)</text>
+<rect x="500" y="85" width="155" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="577.5" y="105" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">user: &quot;天气如何？<tspan dx="-6">&quot;</tspan></text>
+<rect x="660" y="85" width="120" height="40" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
+<text x="720" y="105" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ 生成回答</text>
 <text x="40" y="155" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">请求 2</text>
-<rect x="40" y="170" width="380" height="40" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="230" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">System Prompt + Tools（缓存命中 ✓）</text>
-<rect x="425" y="170" width="180" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="515" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">user: &quot;时间几点？&quot;</text>
-<rect x="610" y="170" width="170" height="40" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="695" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ 生成回答</text>
-<line x1="230" y1="127" x2="230" y2="168" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
-<text x="230.0" y="137.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="middle">KV 复用</text>
-<text x="40" y="245" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">请求 3</text>
-<text x="125" y="245" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central" font-weight="normal">（系统提示变了）</text>
-<rect x="40" y="260" width="400" height="40" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
-<text x="240" y="280" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">System + Tools + &quot;Time: 10:30:45&quot;</text>
-<rect x="445" y="260" width="160" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="525" y="280" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">user: &quot;天气如何？&quot;</text>
-<rect x="610" y="260" width="170" height="40" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
-<text x="695" y="280" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ 后缀重算 ✗</text>
-<rect x="80" y="330" width="660" height="130" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
-<text x="410" y="355" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">性能对比（3000 token 总上下文）</text>
-<line x1="100" y1="370" x2="720" y2="370" stroke="#999999" stroke-width="2"/>
-<text x="230" y="390" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">缓存命中</text>
-<text x="490" y="390" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">后缀缓存失效</text>
-<line x1="100" y1="405" x2="720" y2="405" stroke="#999999" stroke-width="2"/>
-<text x="130" y="425" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">TTFT</text>
-<text x="230" y="425" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">~0.5 秒</text>
-<text x="490" y="425" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">3 - 5 秒</text>
-<text x="130" y="450" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">成本</text>
-<text x="230" y="450" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">仅新 token 计费</text>
-<text x="490" y="450" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">变动点后的 token 重新处理</text>
+<rect x="40" y="170" width="455" height="40" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="267.5" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">System Prompt + Tools（缓存命中 ✓）</text>
+<rect x="500" y="170" width="155" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="577.5" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">user: &quot;时间几点？<tspan dx="-6">&quot;</tspan></text>
+<rect x="660" y="170" width="120" height="40" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
+<text x="720" y="190" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ 生成回答</text>
+<line x1="267.5" y1="127" x2="267.5" y2="168" stroke="#999999" stroke-width="2" marker-end="url(#ah-light)"/>
+<text x="279.5" y="147.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central">KV 复用</text>
+<line x1="267.5" y1="212" x2="267.5" y2="253" stroke="#999999" stroke-width="2" stroke-dasharray="6,5" marker-end="url(#ah-light)"/>
+<text x="255.5" y="232.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="end" dominant-baseline="central">系统提示变了</text>
+<text x="279.5" y="232.5" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#666666" text-anchor="start" dominant-baseline="central">KV 复用中断</text>
+<text x="40" y="240" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="bold">请求 3</text>
+<rect x="40" y="255" width="455" height="40" rx="6" fill="#ffffff" stroke="#333333" stroke-width="2" stroke-dasharray="8,4"/>
+<text x="267.5" y="275" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">&quot;Time: 10:30:45&quot; + System Prompt + Tools（缓存失效 ✗）</text>
+<text x="267.5" y="308" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#666666" text-anchor="middle" dominant-baseline="central">变动点在最前 → 其后全部重算</text>
+<rect x="500" y="255" width="155" height="40" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="577.5" y="275" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">user: &quot;天气如何？<tspan dx="-6">&quot;</tspan></text>
+<rect x="660" y="255" width="120" height="40" rx="6" fill="#e8e8e8" stroke="#333333" stroke-width="2"/>
+<text x="720" y="275" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">→ 生成回答</text>
+<rect x="80" y="330" width="660" height="143" rx="4" fill="#f5f5f5" stroke="#999999" stroke-width="2"/>
+<text x="410" y="352" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">性能对比（3000 token 总上下文）</text>
+<line x1="100" y1="366" x2="720" y2="366" stroke="#999999" stroke-width="2"/>
+<text x="340" y="384" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">缓存命中</text>
+<text x="580" y="384" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">缓存失效</text>
+<line x1="100" y1="398" x2="720" y2="398" stroke="#999999" stroke-width="2"/>
+<text x="130" y="416" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">TTFT *</text>
+<text x="340" y="416" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">~0.5 秒</text>
+<text x="580" y="416" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">3 - 5 秒</text>
+<text x="130" y="439" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="start" dominant-baseline="central" font-weight="normal">成本</text>
+<text x="340" y="439" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">仅新 token 计费</text>
+<text x="580" y="439" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="normal">变动点后的 token 全部重新计费</text>
+<text x="410" y="460" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="13" fill="#666666" text-anchor="middle" dominant-baseline="central">* TTFT 为示意值，随模型、硬件与部署方式而变，此处仅用于说明相对量级差异</text>
 </svg>


### PR DESCRIPTION
读 2.3.2 节的时候发现图 2-10 有个问题，会让读者得出跟正文相反的结论，并且修了同一张图的几处排版。

### 1. 请求 3 把反面例子画成了正确做法

原图请求 3 是 `System + Tools + "Time: 10:30:45"`，时间戳在**末尾**。

按正文说的“缓存只能保留到首个不同 token 之前”，时间戳放最后，前面那 1200 token 的 System Prompt + Tools 其实是完整命中缓存的——而这是工程上推荐的写法：动态内容后置，把稳定前缀留给缓存。这张图想演示“系统提示词塞了动态内容 → 缓存失效”这个坑，画出来的却是这个坑的解法。

改成时间戳前置：`"Time: 10:30:45" + System Prompt + Tools`。

### 2. 一并要改的三处

- 第三列请求 1、2 是 `→ 生成回答`（输出），请求 3 却是 `→ 后缀重算 ✗`（成本），同一列混了两种语义。三行统一成 `→ 生成回答`，缓存状态挪进前缀框，和请求 2 的 `（缓存命中 ✓）` 对称，写成 `（缓存失效 ✗）`，框下补一句「变动点在最前 → 其后全部重算」。
- 性能表表头“后缀缓存失效”→“缓存失效”。变动点前置之后，失效的是整个前缀，不是后缀了。
- 成本行左边讲计费、右边讲处理，右边改成”变动点后的 token 全部重新计费“。

### 3. TTFT 加了个脚注

`~0.5 秒` 和 `3-5 秒` 是绝对值，没说是什么模型、什么硬件、怎么部署的，而正文给的是“实测可达数倍”这种相对量级。加了一行“* TTFT 为示意值，随模型、硬件与部署方式而变，此处仅用于说明相对量级差异”。

### 4. 排版

- 两个 `<marker>` 都缺 `markerUnits`，默认按 `strokeWidth` 缩放，`stroke-width="2"` 下箭头实际渲染成 24×16——跟 #943 修的是同一个问题。补上 `markerUnits="userSpaceOnUse"`，尺寸定为 10×7。另外 `ah` 这个 marker 全文没被引用过，一并删了。
- ”KV 复用“四个字原本压在请求 1 框的下边界和箭头上，移到了箭头右边。
- 请求 2 到请求 3 之间原本什么都没有，补了一条虚线箭头，两侧标“系统提示变了”和“KV 复用中断”。两条箭头统一 41px、上下各留 2px，标注放在中点。
- 三行的列边界原本对不齐（请求 3 第一个框比上面两行宽 20px），统一成 40–495 / 500–655 / 660–780。
- 性能表三列重新对齐，行标签左对齐、数据居中。
- `1200 tokens` → `1200 token`，跟正文「2000 个 token」的写法一致。
- 全角问号后面的空隙做了标点挤压。
- 补上 `<title>` / `<desc>`，参照 #947 的做法。

### 验证

26 处文本逐个按字宽算过，没有溢出和重叠，最紧的一处单边还剩 14.8px。新增的字符只有 `*` `，` `、`，都是常用字，PDF 构建不会缺字。画布从 820×440 变成 820×443，宽高比基本没动，也在 `preamble.tex` 里 `0.38\textheight` 的封顶线（451px）以内，还剩 8px。`tests/` 下搜过，没有引用这张图的文本锚点。

### 两点没处理

译版没同步。13 个语言版本此前按各语种收过字号（es/vi 的 fig2-10 是 14px），需要的话我可以另开一个 PR 跟进。

另外图里 System Prompt + Tools 标的是 1200 token，性能对比却按 3000 token 总上下文算，差的 1800 token（对话历史）图上没体现，这个也暂时没改。