### PR TITLE
fix(ch2): 修复 Ollama 工具调用消息历史顺序

### DIFF
--- a/chapter2/local_llm_serving/ollama_native.py
+++ b/chapter2/local_llm_serving/ollama_native.py
@@ -146,21 +146,25 @@ class OllamaNativeAgent:
             if 'tool_calls' in message_content:
                 tool_calls = message_content['tool_calls']
                 logger.info(f"Model requested {len(tool_calls)} tool call(s)")
-                
+
                 # Add assistant's message with tool calls to history
-                self.conversation_history.append({
+                assistant_message = {
                     "role": "assistant",
                     "content": message_content.get('content', ''),
                     "tool_calls": tool_calls
-                })
-                
+                }
+                if message_content.get('thinking'):
+                    assistant_message["thinking"] = message_content['thinking']
+                self.conversation_history.append(assistant_message)
+
                 # Execute the tool calls (independent calls run in parallel)
                 results = self._execute_tool_calls(tool_calls)
-                
+
                 # Add tool results to conversation
-                for result in results:
+                for tool_call, result in zip(tool_calls, results):
                     self.conversation_history.append({
                         "role": "tool",
+                        "tool_name": tool_call.get('function', {}).get('name', 'unknown'),
                         "content": result
                     })
                 
@@ -172,27 +176,34 @@ class OllamaNativeAgent:
                     options={"temperature": temperature},
                 )
                 
-                final_content = final_response.get('message', {}).get('content', '')
+                final_message = final_response.get('message', {})
+                final_content = final_message.get('content', '')
                 
                 # Clean response (remove <think> tags if present)
                 import re
                 final_content = re.sub(r'<think>.*?</think>', '', final_content, flags=re.DOTALL).strip()
                 
                 # Add final response to history
-                self.conversation_history.append({
+                assistant_message = {
                     "role": "assistant",
                     "content": final_content
-                })
+                }
+                if final_message.get('thinking'):
+                    assistant_message["thinking"] = final_message['thinking']
+                self.conversation_history.append(assistant_message)
                 
                 return final_content
             
             else:
                 # No tool calls, just return the response
                 content = message_content.get('content', '')
-                self.conversation_history.append({
+                assistant_message = {
                     "role": "assistant",
                     "content": content
-                })
+                }
+                if message_content.get('thinking'):
+                    assistant_message["thinking"] = message_content['thinking']
+                self.conversation_history.append(assistant_message)
                 return content
                 
         except Exception as e:
@@ -233,9 +244,9 @@ class OllamaNativeAgent:
                     options={"temperature": temperature},
                     stream=True,
                 )
-                
+
                 collected_content = []
-                tool_calls_detected = False
+                collected_thinking = []
                 pending_tool_calls = []
                 thinking_buffer = ""
                 in_thinking = False
@@ -246,8 +257,9 @@ class OllamaNativeAgent:
                     message_chunk = chunk.get('message', {})
                     thinking_chunk = message_chunk.get('thinking', '')
                     content_chunk = message_chunk.get('content', '')
-                    
+
                     if thinking_chunk:
+                        collected_thinking.append(thinking_chunk)
                         yield {"type": "thinking", "content": thinking_chunk}
                     
                     if content_chunk:
@@ -305,8 +317,6 @@ class OllamaNativeAgent:
                     
                     # Check for tool calls in the chunk
                     if 'tool_calls' in message_chunk:
-                        tool_calls_detected = True
-                        
                         for tool_call in message_chunk['tool_calls']:
                             function = tool_call.get('function', {})
                             tool_name = function.get('name')
@@ -330,37 +340,44 @@ class OllamaNativeAgent:
                             ):
                                 pending_tool_calls.append(tool_call)
                                 yield {"type": "tool_call", "content": {"name": tool_name, "arguments": tool_args}}
-                
-                # Execute all tool calls from this turn in parallel
-                if pending_tool_calls:
-                    results = self._execute_tool_calls(pending_tool_calls)
-                    for result in results:
-                        # Yield tool result
-                        yield {"type": "tool_result", "content": result}
-                        
-                        # Add tool result to conversation
-                        self.conversation_history.append({
-                            "role": "tool",
-                            "content": result
-                        })
-                
+
                 # Save complete response to history
                 complete_response = ''.join(collected_content)
-                
-                if tool_calls_detected:
-                    # Add assistant's message to history
-                    self.conversation_history.append({
+                complete_thinking = ''.join(collected_thinking)
+
+                if pending_tool_calls:
+                    # Preserve the complete assistant turn before its tool
+                    # results, matching Ollama's multi-turn message contract.
+                    assistant_message = {
                         "role": "assistant",
-                        "content": complete_response if complete_response else ""
-                    })
+                        "content": complete_response,
+                        "tool_calls": pending_tool_calls
+                    }
+                    if complete_thinking:
+                        assistant_message["thinking"] = complete_thinking
+                    self.conversation_history.append(assistant_message)
+
+                    # Execute all tool calls from this turn in parallel.
+                    results = self._execute_tool_calls(pending_tool_calls)
+                    for tool_call, result in zip(pending_tool_calls, results):
+                        yield {"type": "tool_result", "content": result}
+                        self.conversation_history.append({
+                            "role": "tool",
+                            "tool_name": tool_call.get('function', {}).get('name', 'unknown'),
+                            "content": result
+                        })
+
                     # Continue the ReAct loop - let the model decide what to do next
                     # The loop will continue and get the next response
                 else:
                     # No tool calls - we have a final response
-                    self.conversation_history.append({
+                    assistant_message = {
                         "role": "assistant",
                         "content": complete_response
-                    })
+                    }
+                    if complete_thinking:
+                        assistant_message["thinking"] = complete_thinking
+                    self.conversation_history.append(assistant_message)
                     # Exit the ReAct loop
                     break
                     

--- a/chapter2/local_llm_serving/test_ollama_thinking.py
+++ b/chapter2/local_llm_serving/test_ollama_thinking.py
@@ -21,6 +21,29 @@ class FakeOllamaClient:
         ])
 
 
+class FakeToolCallingClient:
+    def __init__(self, stream):
+        self.stream = stream
+        self.calls = 0
+        self.message_snapshots = []
+
+    def chat(self, **kwargs):
+        self.calls += 1
+        self.message_snapshots.append([message.copy() for message in kwargs["messages"]])
+        if self.calls == 1:
+            message = {
+                "thinking": "I need two tools.",
+                "content": "",
+                "tool_calls": [
+                    {"function": {"name": "first_tool", "arguments": {"value": 1}}},
+                    {"function": {"name": "second_tool", "arguments": {"value": 2}}},
+                ],
+            }
+        else:
+            message = {"thinking": "Both results are ready.", "content": "Done."}
+        return iter([{"message": message}]) if self.stream else {"message": message}
+
+
 def test_streaming_yields_ollama_thinking_field():
     agent = OllamaNativeAgent(model="qwen3:0.6b")
     fake_client = FakeOllamaClient()
@@ -40,6 +63,64 @@ def test_streaming_yields_ollama_thinking_field():
     assert chunks.index(thinking_event) < chunks.index(content_event), \
         f"thinking (at index {chunks.index(thinking_event)}) should come " \
         f"before content (at index {chunks.index(content_event)})"
+
+
+def test_streaming_history_preserves_assistant_turn_before_tool_results():
+    agent = OllamaNativeAgent(model="qwen3:0.6b")
+    agent.client = FakeToolCallingClient(stream=True)
+    agent._execute_tool_calls = lambda _calls: ["first result", "second result"]
+
+    chunks = list(agent.chat_stream("use both tools"))
+
+    assert [message["role"] for message in agent.conversation_history] == [
+        "user", "assistant", "tool", "tool", "assistant"
+    ]
+    assert agent.conversation_history[1] == {
+        "role": "assistant",
+        "content": "",
+        "thinking": "I need two tools.",
+        "tool_calls": [
+            {"function": {"name": "first_tool", "arguments": {"value": 1}}},
+            {"function": {"name": "second_tool", "arguments": {"value": 2}}},
+        ],
+    }
+    assert agent.conversation_history[2:4] == [
+        {"role": "tool", "tool_name": "first_tool", "content": "first result"},
+        {"role": "tool", "tool_name": "second_tool", "content": "second result"},
+    ]
+    assert agent.conversation_history[4] == {
+        "role": "assistant",
+        "content": "Done.",
+        "thinking": "Both results are ready.",
+    }
+    assert agent.client.message_snapshots[1] == agent.conversation_history[:4]
+    assert [chunk["content"] for chunk in chunks if chunk["type"] == "tool_result"] == [
+        "first result", "second result"
+    ]
+
+
+def test_non_streaming_history_preserves_thinking_and_tool_names():
+    agent = OllamaNativeAgent(model="qwen3:0.6b")
+    agent.client = FakeToolCallingClient(stream=False)
+    agent._execute_tool_calls = lambda _calls: ["first result", "second result"]
+
+    response = agent.chat("use both tools")
+
+    assert response == "Done."
+    assert [message["role"] for message in agent.conversation_history] == [
+        "user", "assistant", "tool", "tool", "assistant"
+    ]
+    assert agent.conversation_history[1]["thinking"] == "I need two tools."
+    assert len(agent.conversation_history[1]["tool_calls"]) == 2
+    assert [message["tool_name"] for message in agent.conversation_history[2:4]] == [
+        "first_tool", "second_tool"
+    ]
+    assert agent.conversation_history[4] == {
+        "role": "assistant",
+        "content": "Done.",
+        "thinking": "Both results are ready.",
+    }
+    assert agent.client.message_snapshots[1] == agent.conversation_history[:4]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 修改内容

- 在流式工具调用中，先保存包含 `thinking`、`content` 和 `tool_calls` 的完整 assistant 消息，再写入工具结果
- 为工具结果补充 `tool_name`，并让流式与非流式路径统一保留 thinking
- 新增 fake-client 双工具调用回归测试，覆盖消息顺序、字段保留和下一轮请求上下文

## 问题原因

`chat_stream()` 原先会先把 tool 消息写入历史，再补写 assistant 消息，同时丢失 assistant 的 `thinking` 和 `tool_calls`，最终产生：

`user → tool → assistant → assistant`

修复后的消息顺序为：

`user → assistant(tool_calls) → tool → assistant`

Ollama 当前会通过独立的 `message.thinking` 字段返回推理内容，因此本次修复也会保留该字段，而不依赖正文中的 `<think>` 标签。

Fixes #1027

## 验证

- 目标回归测试：3 passed
- Chapter 2 离线测试组：56 passed
- Ollama Python SDK 0.6.2 `ChatRequest` 消息结构验证通过
- `compileall` 通过
- `git diff --check` 通过
- 未新增 Ruff 告警

本地没有可用的 Ollama 服务，因此真实模型调用留给项目 CI 或维护者环境验证；流式和非流式路径已通过确定性 fake client 覆盖。