### PR TITLE
Compatible with the new version of Ollama

### DIFF
--- a/chapter2/local_llm_serving/ollama_native.py
+++ b/chapter2/local_llm_serving/ollama_native.py
@@ -532,8 +532,8 @@ def test_native_tools():
         try:
             # Check if model is available
             client = ollama.Client()
-            available_models = [m['name'] for m in client.list()['models']]
-            
+            # available_models = [m['name'] for m in client.list()['models']]
+            available_models = [getattr(m, 'model', None) or m.get('name') for m in client.list().models] 
             if not any(model_name in m for m in available_models):
                 print(f"⚠️  Model {model_name} not installed")
                 print(f"   Install with: ollama pull {model_name}")
@@ -584,7 +584,8 @@ def demo():
         # Check for best available model
         try:
             client = ollama.Client()
-            models = [m['name'] for m in client.list()['models']]
+            # models = [m['name'] for m in client.list()['models']]
+            models = [getattr(m, 'model', None) or m.get('name') for m in client.list().models]
             
             # Use qwen3:0.6b as the default model
             model = "qwen3:0.6b"


### PR DESCRIPTION
ollama 库升级后， client.list() 返回的不再是 dict ，而是一个 ListResponse 对象 ，里面的 models 字段也不是 dict 而是 Model 对象。所以不能用 m['name'] 字典下标访问。

正确的属性访问方式应该是 m.model 或 m.name 。