### PR TITLE
fix(ch2,ch3): 统一适配新版 ollama 的 client.list() 返回类型

### DIFF
--- a/chapter2/local_llm_serving/demo_streaming.py
+++ b/chapter2/local_llm_serving/demo_streaming.py
@@ -68,7 +68,12 @@ def demo_ollama_streaming():
     try:
         # Check available models
         client = ollama.Client()
-        models = [m['name'] for m in client.list()['models']]
+        # ollama >= 0.4 returns a ListResponse whose entries are Model objects
+        # (field ``model``); older versions returned plain dicts (key ``name``).
+        models = [
+            getattr(m, "model", None) or m.get("name", "")
+            for m in client.list()["models"]
+        ]
         
         # Use qwen3:0.6b as the default model
         model = "qwen3:0.6b"

--- a/chapter2/local_llm_serving/ollama_native.py
+++ b/chapter2/local_llm_serving/ollama_native.py
@@ -549,8 +549,13 @@ def test_native_tools():
         try:
             # Check if model is available
             client = ollama.Client()
-            # available_models = [m['name'] for m in client.list()['models']]
-            available_models = [getattr(m, 'model', None) or m.get('name') for m in client.list().models] 
+            # ollama >= 0.4 returns a ListResponse whose entries are Model objects
+            # (field ``model``); older versions returned plain dicts (key ``name``).
+            available_models = [
+                getattr(m, "model", None) or m.get("name", "")
+                for m in client.list()["models"]
+            ]
+
             if not any(model_name in m for m in available_models):
                 print(f"⚠️  Model {model_name} not installed")
                 print(f"   Install with: ollama pull {model_name}")
@@ -601,8 +606,12 @@ def demo():
         # Check for best available model
         try:
             client = ollama.Client()
-            # models = [m['name'] for m in client.list()['models']]
-            models = [getattr(m, 'model', None) or m.get('name') for m in client.list().models]
+            # ollama >= 0.4 returns a ListResponse whose entries are Model objects
+            # (field ``model``); older versions returned plain dicts (key ``name``).
+            models = [
+                getattr(m, "model", None) or m.get("name", "")
+                for m in client.list()["models"]
+            ]
             
             # Use qwen3:0.6b as the default model
             model = "qwen3:0.6b"

--- a/chapter3/log-sanitization/agent.py
+++ b/chapter3/log-sanitization/agent.py
@@ -50,13 +50,12 @@ class LogSanitizationAgent:
         # Try the local Ollama backend first.
         try:
             self.client = ollama.Client()
-            models = self.client.list()
-            # models is a dict with 'models' key containing a list
-            if isinstance(models, dict) and 'models' in models:
-                available_models = [m.get('name', '') for m in models['models']]
-            else:
-                # If it's a direct list (older API versions)
-                available_models = [m.get('name', '') for m in models] if isinstance(models, list) else []
+            # ollama >= 0.4 returns a ListResponse whose entries are Model objects
+            # (field ``model``); older versions returned plain dicts (key ``name``).
+            available_models = [
+                getattr(m, "model", None) or m.get("name", "")
+                for m in self.client.list()["models"]
+            ]
 
             if not any(self.model in m for m in available_models):
                 print(f"⚠️  Model {self.model} not found. Pulling it now...")


### PR DESCRIPTION
#1041 的后续清理。

## 背景

@Wang-Ray 在 #1041 中修复了 `chapter2/local_llm_serving/ollama_native.py` 里两处 `m['name']` 的 `KeyError`。ollama 0.4+ 的 `client.list()` 返回 `ListResponse`，其 `models` 元素是 `ListResponse.Model`（字段为 `model / modified_at / digest / size / details`），已经没有 `name` 字段了。

## 本 PR 做了三件事

1. **清理 #1041 留下的注释掉的旧代码和行尾空格**——这是书里的示例代码，读者会照着读。

2. **改用 `client.list()["models"]` 下标访问，而非 `.models` 属性访问。** `ListResponse` 继承自 `SubscriptableBaseModel`，两种写法对新版都成立；但下标写法对旧版返回 dict 的情况同样成立，兼容性更好。

3. **补上 #1041 漏掉的两处相同问题：**
   - `chapter2/local_llm_serving/demo_streaming.py:71`——和 `ollama_native.py` 完全一样的 `KeyError`。
   - `chapter3/log-sanitization/agent.py:56`——这处更隐蔽：它用 `isinstance(models, dict)` / `isinstance(models, list)` 分支判断，而新版 `ListResponse` 两者都不是，于是静默 fallback 到空列表，导致 `any()` 恒为 False，**每次启动都会重新 `pull` 一遍模型**。

三处现在统一为同一个写法：

```python
# ollama >= 0.4 returns a ListResponse whose entries are Model objects
# (field ``model``); older versions returned plain dicts (key ``name``).
models = [
    getattr(m, "model", None) or m.get("name", "")
    for m in client.list()["models"]
]
```

## 验证

在本地 ollama 0.5.1 上验证了新旧两种返回值形态都能正确解析：

```
new: ['qwen3:0.6b', 'llama3:8b']
old: ['qwen3:0.6b', 'llama3:8b']
```

三个文件均通过 `py_compile`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8yPLHf3N9aP8nKAqFXL6S