### PR TITLE
fix(ch8): 还原图 8-16 被 fig8-18 副本覆盖的内容

### DIFF
--- a/book/images/fig8-16.svg
+++ b/book/images/fig8-16.svg
@@ -1,73 +1,32 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 780 525" width="780" height="525" style="background:#ffffff">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 40 850 390" width="850" height="390" style="background:#ffffff">
 <defs><marker id="ah" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#333333"/></marker><marker id="ah-light" markerWidth="12" markerHeight="8" refX="12" refY="4" orient="auto"><polygon points="0 0, 12 4, 0 8" fill="#999999"/></marker></defs>
 
-<rect x="30" y="60" width="165" height="120" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="112" y="82" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">① 环境配置</text>
-<text x="112" y="105" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">MCP Server 沙盒</text>
-<text x="112" y="127" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">26 个服务器</text>
-<text x="112" y="149" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">126 个工具函数</text>
-<rect x="220" y="60" width="165" height="120" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="302" y="82" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">② Agent 构建</text>
-<text x="302" y="105" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">AgentLoop 决策</text>
-<text x="302" y="127" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">系统提示 + 工具</text>
-<text x="302" y="149" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">多轮对话 (≤32轮)</text>
-<rect x="410" y="60" width="165" height="120" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="492" y="82" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">③ 适配器层</text>
-<text x="492" y="105" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">VeRL 接口统一</text>
-<text x="492" y="127" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Rollout 收集</text>
-<text x="492" y="149" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">奖励计算</text>
-<rect x="600" y="60" width="165" height="120" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
-<text x="682" y="82" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">④ 训练框架</text>
-<text x="682" y="105" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">GRPO / PPO</text>
-<text x="682" y="127" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">策略梯度更新</text>
-<text x="682" y="149" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">131K 上下文</text>
-<line x1="197" y1="120" x2="218" y2="120" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="387" y1="120" x2="408" y2="120" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<line x1="577" y1="120" x2="598" y2="120" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
-<rect x="30" y="200" width="720" height="250" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
-<text x="390" y="222" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">MCP 工具生态（GAIA 评测环境）</text>
-<rect x="60" y="255" width="216" height="84" rx="3" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="168" y="273" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Web 交互 (3)</text>
-<text x="168" y="293" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Google 搜索</text>
-<text x="168" y="309" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">智能浏览器</text>
-<text x="168" y="325" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Playwright</text>
-<rect x="286" y="255" width="216" height="84" rx="3" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="394" y="273" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">文档处理 (4)</text>
-<text x="394" y="293" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">CSV/DOCX</text>
-<text x="394" y="309" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">PPTX/PDF</text>
-<text x="394" y="325" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">结构化提取</text>
-<rect x="512" y="255" width="216" height="84" rx="3" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="620" y="273" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">多媒体 (3)</text>
-<text x="620" y="293" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">音频转写</text>
-<text x="620" y="309" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">OCR 识别</text>
-<text x="620" y="325" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">视频摘要</text>
-<rect x="60" y="354" width="216" height="84" rx="3" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="168" y="372" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">代码执行 (3)</text>
-<text x="168" y="392" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">终端命令</text>
-<text x="168" y="408" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">E2B 沙箱</text>
-<text x="168" y="424" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">文件管理</text>
-<rect x="286" y="354" width="216" height="84" rx="3" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="394" y="372" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">Excel (1)</text>
-<text x="394" y="392" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">29 个操作</text>
-<text x="394" y="408" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">公式/图表</text>
-<text x="394" y="424" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">数据透视</text>
-<rect x="512" y="354" width="216" height="84" rx="3" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="620" y="372" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">知识检索 (3)</text>
-<text x="620" y="392" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Wikipedia</text>
-<text x="620" y="408" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">ArXiv 论文</text>
-<text x="620" y="424" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Wayback</text>
-<rect x="30" y="460" width="720" height="100" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text x="390" y="482" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">分布式 Rollout 架构</text>
-<text x="137" y="508" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">数据收集</text>
-<text x="137" y="528" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">14.6× 加速</text>
-<text x="137" y="546" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">(7天→12小时)</text>
-<text x="312" y="508" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">模型</text>
-<text x="312" y="528" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">Qwen3-4B（本实验）</text>
-<text x="312" y="546" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">8×A100 集群</text>
-<text x="487" y="508" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">训练配置</text>
-<text x="487" y="528" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">batch=32 · 16 resp/prompt</text>
-<text x="487" y="546" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">GRPO · lr=1e-6</text>
-<text x="662" y="508" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">评测</text>
-<text x="662" y="528" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">GAIA benchmark</text>
-<text x="662" y="546" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">参考: 大模型约 32%</text>
+<rect x="80" y="120" width="160" height="80" rx="6" fill="#d0d0d0" stroke="#333333" stroke-width="2"/>
+<text x="160" y="140" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">策略模型 πθ</text>
+<text x="160" y="160" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">生成 action:</text>
+<text x="160" y="178" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">思考/搜索/代码/回答</text>
+<rect x="320" y="70" width="160" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="400" y="90" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">工具执行</text>
+<text x="400" y="110" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">API 调用 / 代码沙箱</text>
+<rect x="320" y="200" width="160" height="60" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
+<text x="400" y="220" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">结果解析</text>
+<text x="400" y="240" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">成功/失败/错误信息</text>
+<rect x="560" y="120" width="170" height="80" rx="6" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
+<text x="645" y="140" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">奖励计算</text>
+<text x="645" y="160" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">正确: +1</text>
+<text x="645" y="178" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">错误: −1</text>
+<line x1="242" y1="140" x2="318" y2="100" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="482" y1="100" x2="558" y2="140" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="480" y1="230" x2="558" y2="180" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<line x1="355" y1="132" x2="355" y2="198" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<path d="M 645,200 Q 400,151 160,202" fill="none" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
+<text x="400" y="275" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="14" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">策略梯度更新</text>
+<rect x="40" y="300" width="770" height="110" rx="4" fill="#f5f5f5" stroke="#333333" stroke-width="2"/>
+<text x="390" y="330" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="20" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">工具使用 RL 的三层挑战</text>
+<text x="140" y="367" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">第一层：单工具掌握</text>
+<text x="140" y="392" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">何时调用 + 如何调用 + 错误处理</text>
+<text x="390" y="367" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">第二层：多工具选择</text>
+<text x="390" y="392" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">搜索 / 代码 / 文档解析 三选一</text>
+<text x="640" y="367" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="16" fill="#333333" text-anchor="middle" dominant-baseline="central" font-weight="bold">第三层：工具链编排</text>
+<text x="640" y="392" font-family="Arial, 'Helvetica Neue', Helvetica, 'PingFang SC', 'Microsoft YaHei', sans-serif" font-size="15" fill="#666666" text-anchor="middle" dominant-baseline="central" font-weight="normal">依赖管理 + 互斥约束 + 成本优化</text>
 </svg>


### PR DESCRIPTION
## 问题

第 8 章的 `book/images/fig8-16.svg` 与 `book/images/fig8-18.svg` **字节完全相同**（同一 blob `151e8c50`，14947 字节），导致中文版正文中同一张图出现两次：

- 第 588 行 `![图8-16 工具调用 RL 奖励循环](images/fig8-16.svg)`
- 第 604 行 `![图8-18 AWorld-train MCP 沙盒训练架构与工具生态](images/fig8-18.svg)`

两处渲染出的都是 AWorld-train 架构图（MCP Server 沙盒 / AgentLoop / VeRL 适配器 / GRPO 训练 / GAIA 工具生态），即 fig8-18 的内容。图 8-16 原本的「工具调用 RL 奖励循环」丢失，与正文标题不符。

两图的 viewBox 也本不相同（fig8-16 为 `0 40 850 390`，fig8-18 为 `0 40 780 525`），进一步说明这是复制事故而非有意复用。

## 根因

| 提交 | fig8-16.svg 的 blob | 状态 |
|---|---|---|
| `efbde98a` refactor(book): 新增第六章「交互」并顺延评估/后训练/进化三章 (#856) | `9e886dcc` | ✅ 正确 |
| `823f2d91` docs(i18n): align experiment/figure/table numbering across all 12 translations (#858) | `151e8c50` | ❌ 被覆盖为 fig8-18 副本 |

#856 的章节顺延（fig7-16 → fig8-16）是正确的。问题出在随后的 #858：在对齐 12 个译本的图表编号时，**译本侧全部改对了，唯独中文母版的 fig8-16.svg 被误覆盖**。这也解释了为何该问题此前未被发现 —— 仅中文版受影响。

## 改动

将 `book/images/fig8-16.svg` 还原为 #858 之前的原始内容。恢复后的 blob 为 `9e886dcc1d0bc81173930522dea29464b8ae0a68`，与 `823f2d91^` 中的完全一致 —— 是原图还原，不是重新绘制。

图内容：

- 主循环：策略模型 πθ（生成 action：思考/搜索/代码/回答）→ 工具执行（API 调用 / 代码沙箱）→ 结果解析（成功/失败/错误信息）→ 奖励计算（正确 +1 / 错误 −1）→ 策略梯度更新
- 附「工具使用 RL 的三层挑战」：单工具掌握 / 多工具选择 / 工具链编排

## 已核对范围

为免遗漏同类问题，对全部 14 个版本做了扫描：

- **12 个译本的 fig8-16 均未受影响**，与各自的 fig8-18 互不相同，且内容确为奖励循环（已抽样核对 en / ja 的图内文字语义），无需改动
- 全仓被正文引用的 SVG 中，重复 blob **仅此一例**
- md 图片引用无断链（0 处缺失）

## 测试计划

- [x] 恢复后 `fig8-16.svg` 与 `fig8-18.svg` 不再重复
- [x] 提交后的 blob 与 `823f2d91^` 中的原始 blob 逐字节一致
- [x] SVG 为合法 XML，viewBox `0 40 850 390`
- [x] 行尾遵循仓库 `core.autocrlf=true` 约定，diff 无整文件噪声（+29 / −70）
- [ ] 建议在站点渲染后目视确认图 8-16 与图 8-18 显示为两张不同的图

## 说明

本 PR 保持单一职责，只修这一个文件。仓库中另有若干未被 md 引用的语义命名副本（如 `fig8-reward-density.svg`、`fig8-reward-paradigms.svg`、`fig1-wf-*.svg`），推测为有意保留的别名，本次未作改动。
