### PR TITLE
fix(epub): unblock PT-BR artifact publication

### DIFF
--- a/book-he/images/fig7-1.svg
+++ b/book-he/images/fig7-1.svg
@@ -10,57 +10,56 @@
 .m{font-size:13px}
 .n{font-size:11px;fill:#666666}
 
-.t,.l{direction:rtl;unicode-bidi:plaintext}
-.c{font-family:'SF Mono',Menlo,Consolas,monospace;direction:ltr;unicode-bidi:plaintext}
+.c{font-family:'SF Mono',Menlo,Consolas,monospace}
 
 </style>
 
 <rect x="100" y="20" width="690" height="56" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text class="t h" x="445" y="40">① הגדרת ההצלחה</text>
-<text class="t s" x="445" y="61">Pass@k מודד תקרת יכולת · Pass^k מודד אמינות</text>
+<text class="t h" x="445" y="40" direction="rtl" unicode-bidi="plaintext">① הגדרת ההצלחה</text>
+<text class="t s" x="445" y="61" direction="rtl" unicode-bidi="plaintext">Pass@k מודד תקרת יכולת · Pass^k מודד אמינות</text>
 <line x1="445" y1="76" x2="445" y2="94" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
 
 <rect x="100" y="96" width="690" height="102" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text class="t h" x="445" y="116">② מקור המשימות</text>
+<text class="t h" x="445" y="116" direction="rtl" unicode-bidi="plaintext">② מקור המשימות</text>
 <rect x="116" y="130" width="206" height="54" rx="5" fill="#ffffff" stroke="#666666" stroke-width="1.5"/>
-<text class="t m" x="219" y="147">מבחני ייחוס ציבוריים</text>
-<text class="t n" x="219" y="167">שאילת שיטות · סינון גס</text>
+<text class="t m" x="219" y="147" direction="rtl" unicode-bidi="plaintext">מבחני ייחוס ציבוריים</text>
+<text class="t n" x="219" y="167" direction="rtl" unicode-bidi="plaintext">שאילת שיטות · סינון גס</text>
 <rect x="342" y="130" width="206" height="54" rx="5" fill="#ffffff" stroke="#666666" stroke-width="1.5"/>
-<text class="t m" x="445" y="147">מערך עסקי עצמי</text>
-<text class="t n" x="445" y="167">התפלגות משימות אמיתית</text>
+<text class="t m" x="445" y="147" direction="rtl" unicode-bidi="plaintext">מערך עסקי עצמי</text>
+<text class="t n" x="445" y="167" direction="rtl" unicode-bidi="plaintext">התפלגות משימות אמיתית</text>
 <rect x="568" y="130" width="206" height="54" rx="5" fill="#ffffff" stroke="#666666" stroke-width="1.5"/>
-<text class="t m" x="671" y="147">זרימה חוזרת מהייצור</text>
-<text class="t n" x="671" y="167">תוצר ייחוס הכשלים</text>
+<text class="t m" x="671" y="147" direction="rtl" unicode-bidi="plaintext">זרימה חוזרת מהייצור</text>
+<text class="t n" x="671" y="167" direction="rtl" unicode-bidi="plaintext">תוצר ייחוס הכשלים</text>
 <line x1="445" y1="198" x2="445" y2="216" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
 
 <rect x="100" y="218" width="690" height="106" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text class="t h" x="445" y="238">③ אופן האימות</text>
-<text class="t n" x="445" y="257">← לפי מידת יכולת האימות המכנית של המשימה →</text>
+<text class="t h" x="445" y="238" direction="rtl" unicode-bidi="plaintext">③ אופן האימות</text>
+<text class="t n" x="445" y="257" direction="rtl" unicode-bidi="plaintext">← לפי מידת יכולת האימות המכנית של המשימה →</text>
 <rect x="116" y="268" width="142" height="44" rx="5" fill="#ffffff" stroke="#666666" stroke-width="1.5"/>
-<text class="t m" x="187" y="282">דטרמיניסטי</text>
-<text class="t n" x="187" y="300">SWE-bench</text>
+<text class="t m" x="187" y="282" direction="rtl" unicode-bidi="plaintext">דטרמיניסטי</text>
+<text class="t n" x="187" y="300" direction="rtl" unicode-bidi="plaintext">SWE-bench</text>
 <line x1="262" y1="290" x2="284" y2="290" stroke="#666666" stroke-width="1.5" marker-end="url(#ah-s)"/>
 <rect x="288" y="268" width="142" height="44" rx="5" fill="#ffffff" stroke="#666666" stroke-width="1.5"/>
-<text class="t m" x="359" y="282">רשימת בדיקות</text>
-<text class="t n" x="359" y="300">τ²-bench</text>
+<text class="t m" x="359" y="282" direction="rtl" unicode-bidi="plaintext">רשימת בדיקות</text>
+<text class="t n" x="359" y="300" direction="rtl" unicode-bidi="plaintext">τ²-bench</text>
 <line x1="434" y1="290" x2="456" y2="290" stroke="#666666" stroke-width="1.5" marker-end="url(#ah-s)"/>
 <rect x="460" y="268" width="142" height="44" rx="5" fill="#ffffff" stroke="#666666" stroke-width="1.5"/>
-<text class="t m" x="531" y="282">Rubric + שיפוט LLM</text>
-<text class="t n" x="531" y="300">משימות פתוחות</text>
+<text class="t m" x="531" y="282" direction="rtl" unicode-bidi="plaintext">Rubric + שיפוט LLM</text>
+<text class="t n" x="531" y="300" direction="rtl" unicode-bidi="plaintext">משימות פתוחות</text>
 <line x1="606" y1="290" x2="628" y2="290" stroke="#666666" stroke-width="1.5" marker-end="url(#ah-s)"/>
 <rect x="632" y="268" width="142" height="44" rx="5" fill="#ffffff" stroke="#666666" stroke-width="1.5"/>
-<text class="t m" x="703" y="282">השוואה זוגית</text>
-<text class="t n" x="703" y="300">Chatbot Arena</text>
+<text class="t m" x="703" y="282" direction="rtl" unicode-bidi="plaintext">השוואה זוגית</text>
+<text class="t n" x="703" y="300" direction="rtl" unicode-bidi="plaintext">Chatbot Arena</text>
 <line x1="445" y1="324" x2="445" y2="342" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
 
 <rect x="100" y="344" width="690" height="62" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text class="t h" x="445" y="364">④ שימוש בתוצאות</text>
-<text class="t s" x="445" y="388">מובהקות ← ייחוס כשלים ← רגרסיה ← בחירת מודל ואיטרציית Harness</text>
+<text class="t h" x="445" y="364" direction="rtl" unicode-bidi="plaintext">④ שימוש בתוצאות</text>
+<text class="t s" x="445" y="388" direction="rtl" unicode-bidi="plaintext">מובהקות ← ייחוס כשלים ← רגרסיה ← בחירת מודל ואיטרציית Harness</text>
 
 <path d="M100 375 L52 375 L52 147 L96 147" fill="none" stroke="#333333" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#ah)"/>
-<text class="t n" x="52" y="262" transform="rotate(-90 52 262)">משימות רגרסיה הופכות למקרים חדשים</text>
+<text class="t n" x="52" y="262" transform="rotate(-90 52 262)" direction="rtl" unicode-bidi="plaintext">משימות רגרסיה הופכות למקרים חדשים</text>
 
 <rect x="100" y="424" width="690" height="46" rx="6" fill="#f3f0e8" stroke="#333333" stroke-width="2"/>
-<text class="t m" x="445" y="440" font-weight="bold">תשתית תומכת</text>
-<text class="t n" x="445" y="458">נצפוּת · תשתית הערכה פנימית (אבלציה / AB / דגלים) · סביבת סימולציה (פרק 8)</text>
+<text class="t m" x="445" y="440" font-weight="bold" direction="rtl" unicode-bidi="plaintext">תשתית תומכת</text>
+<text class="t n" x="445" y="458" direction="rtl" unicode-bidi="plaintext">נצפוּת · תשתית הערכה פנימית (אבלציה / AB / דגלים) · סביבת סימולציה (פרק 8)</text>
 </svg>

--- a/book-he/images/fig7-3.svg
+++ b/book-he/images/fig7-3.svg
@@ -12,69 +12,68 @@
 .n{font-size:10.5px;fill:#666666}
 .c{font-size:10.5px;fill:#666666;font-family:'SF Mono',Menlo,Consolas,monospace}
 
-.t,.l{direction:rtl;unicode-bidi:plaintext}
-.c{font-family:'SF Mono',Menlo,Consolas,monospace;direction:ltr;unicode-bidi:plaintext}
+.c{font-family:'SF Mono',Menlo,Consolas,monospace}
 
 </style>
 
 <!-- user simulator -->
 <rect x="40" y="20" width="270" height="86" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text class="t h" x="175" y="40">סימולטור משתמש (LLM)</text>
-<text class="l n" x="56" y="62">known_info: John Smith / 555-123-2002 / בצרפת</text>
-<text class="l n" x="56" y="80">task_instructions: חשיפה הדרגתית · רגש · עיגון</text>
-<text class="l n" x="56" y="96">קבלה: רק excellent נחשב פתור</text>
+<text class="t h" x="175" y="40" direction="rtl" unicode-bidi="plaintext">סימולטור משתמש (LLM)</text>
+<text class="l n" x="56" y="62" direction="rtl" unicode-bidi="plaintext">known_info: John Smith / 555-123-2002 / בצרפת</text>
+<text class="l n" x="56" y="80" direction="rtl" unicode-bidi="plaintext">task_instructions: חשיפה הדרגתית · רגש · עיגון</text>
+<text class="l n" x="56" y="96" direction="rtl" unicode-bidi="plaintext">קבלה: רק excellent נחשב פתור</text>
 
 <!-- Agent -->
 <rect x="570" y="20" width="270" height="86" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text class="t h" x="705" y="40">Agent (בהערכה)</text>
-<text class="l n" x="586" y="62">קלט: כרטיס + מדיניות התחום</text>
-<text class="l n" x="586" y="80">לא נראה: המצב האמיתי של המכשיר</text>
-<text class="l n" x="586" y="96">רק מנחה, אינו פועל במקומו</text>
+<text class="t h" x="705" y="40" direction="rtl" unicode-bidi="plaintext">Agent (בהערכה)</text>
+<text class="l n" x="586" y="62" direction="rtl" unicode-bidi="plaintext">קלט: כרטיס + מדיניות התחום</text>
+<text class="l n" x="586" y="80" direction="rtl" unicode-bidi="plaintext">לא נראה: המצב האמיתי של המכשיר</text>
+<text class="l n" x="586" y="96" direction="rtl" unicode-bidi="plaintext">רק מנחה, אינו פועל במקומו</text>
 
 <!-- dialogue -->
 <line x1="316" y1="63" x2="560" y2="63" stroke="#666666" stroke-width="1.5" marker-end="url(#ah-s)" marker-start="url(#ah-r)"/>
-<text class="t n" x="438" y="50">דיאלוג רב‑תורי</text>
-<text class="t n" x="438" y="80">גילוי מידע הדרגתי</text>
+<text class="t n" x="438" y="50" direction="rtl" unicode-bidi="plaintext">דיאלוג רב‑תורי</text>
+<text class="t n" x="438" y="80" direction="rtl" unicode-bidi="plaintext">גילוי מידע הדרגתי</text>
 
 <!-- shared environment -->
 <rect x="40" y="146" width="800" height="150" rx="6" fill="#f3f0e8" stroke="#333333" stroke-width="2"/>
-<text class="t h" x="440" y="166">סביבה משותפת (בקרה כפולה: שני הצדדים משנים מצב)</text>
+<text class="t h" x="440" y="166" direction="rtl" unicode-bidi="plaintext">סביבה משותפת (בקרה כפולה: שני הצדדים משנים מצב)</text>
 <rect x="60" y="182" width="370" height="98" rx="5" fill="#ffffff" stroke="#666666" stroke-width="1.5"/>
-<text class="t m" x="245" y="200" font-weight="bold">מצב בצד המכשיר</text>
-<text class="l n" x="76" y="222">מצב טיסה ON · נדידה OFF · חיסכון · יתרת נפח</text>
-<text class="l c" x="76" y="246">כלי המשתמש: toggle_airplane_mode / toggle_roaming</text>
-<text class="l c" x="76" y="266">      check_status_bar / run_speed_test</text>
+<text class="t m" x="245" y="200" font-weight="bold" direction="rtl" unicode-bidi="plaintext">מצב בצד המכשיר</text>
+<text class="l n" x="76" y="222" direction="rtl" unicode-bidi="plaintext">מצב טיסה ON · נדידה OFF · חיסכון · יתרת נפח</text>
+<text class="l c" x="76" y="246" direction="ltr" unicode-bidi="plaintext">כלי המשתמש: toggle_airplane_mode / toggle_roaming</text>
+<text class="l c" x="76" y="266" direction="ltr" unicode-bidi="plaintext">      check_status_bar / run_speed_test</text>
 <rect x="450" y="182" width="370" height="98" rx="5" fill="#ffffff" stroke="#666666" stroke-width="1.5"/>
-<text class="t m" x="635" y="200" font-weight="bold">מסד הנתונים של המפעיל</text>
-<text class="l n" x="466" y="222">לקוח C1001 · קווים L1001/L1002/L1003 · חבילות · חשבוניות</text>
-<text class="l c" x="466" y="246">כלי ה‑Agent: get_customer_by_phone / get_data_usage</text>
-<text class="l c" x="466" y="266">      enable_roaming / refuel_data</text>
+<text class="t m" x="635" y="200" font-weight="bold" direction="rtl" unicode-bidi="plaintext">מסד הנתונים של המפעיל</text>
+<text class="l n" x="466" y="222" direction="rtl" unicode-bidi="plaintext">לקוח C1001 · קווים L1001/L1002/L1003 · חבילות · חשבוניות</text>
+<text class="l c" x="466" y="246" direction="ltr" unicode-bidi="plaintext">כלי ה‑Agent: get_customer_by_phone / get_data_usage</text>
+<text class="l c" x="466" y="266" direction="ltr" unicode-bidi="plaintext">      enable_roaming / refuel_data</text>
 
 <line x1="175" y1="106" x2="175" y2="178" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
 <line x1="705" y1="106" x2="705" y2="178" stroke="#333333" stroke-width="2" marker-end="url(#ah)"/>
 
 <!-- re-read note -->
 <rect x="40" y="306" width="800" height="34" rx="5" fill="#ffffff" stroke="#666666" stroke-width="1.5" stroke-dasharray="5 4"/>
-<text class="t n" x="440" y="323">toggle_roaming של המשתמש שינה את הסביבה; על ה‑Agent לקרוא שוב לכלי — האימות מכסה קריאה חוזרת זו</text>
+<text class="t n" x="440" y="323" direction="rtl" unicode-bidi="plaintext">toggle_roaming של המשתמש שינה את הסביבה; על ה‑Agent לקרוא שוב לכלי — האימות מכסה קריאה חוזרת זו</text>
 
 <!-- verification -->
 <rect x="40" y="356" width="800" height="136" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text class="t h" x="440" y="376">בתום המשימה: ארבע שכבות בדיקה + כלל צבירה</text>
+<text class="t h" x="440" y="376" direction="rtl" unicode-bidi="plaintext">בתום המשימה: ארבע שכבות בדיקה + כלל צבירה</text>
 <rect x="56" y="392" width="182" height="62" rx="5" fill="#ffffff" stroke="#666666" stroke-width="1.5"/>
-<text class="t m" x="147" y="408">env_assertions</text>
-<text class="t n" x="147" y="428">נתונים סלולריים זמינים</text>
-<text class="t n" x="147" y="444">מהירות ≥ 200 / excellent</text>
+<text class="t m" x="147" y="408" direction="rtl" unicode-bidi="plaintext">env_assertions</text>
+<text class="t n" x="147" y="428" direction="rtl" unicode-bidi="plaintext">נתונים סלולריים זמינים</text>
+<text class="t n" x="147" y="444" direction="rtl" unicode-bidi="plaintext">מהירות ≥ 200 / excellent</text>
 <rect x="254" y="392" width="182" height="62" rx="5" fill="#ffffff" stroke="#666666" stroke-width="1.5"/>
-<text class="t m" x="345" y="408">actions</text>
-<text class="t n" x="345" y="428">toggle_airplane_mode</text>
-<text class="t n" x="345" y="444">requestor חייב להיות user</text>
+<text class="t m" x="345" y="408" direction="rtl" unicode-bidi="plaintext">actions</text>
+<text class="t n" x="345" y="428" direction="rtl" unicode-bidi="plaintext">toggle_airplane_mode</text>
+<text class="t n" x="345" y="444" direction="rtl" unicode-bidi="plaintext">requestor חייב להיות user</text>
 <rect x="452" y="392" width="182" height="62" rx="5" fill="#ffffff" stroke="#666666" stroke-width="1.5"/>
-<text class="t m" x="543" y="408">communicate_info</text>
-<text class="t n" x="543" y="428">האם נמסר המידע ההכרחי</text>
-<text class="t n" x="543" y="444">במשימה זו null</text>
+<text class="t m" x="543" y="408" direction="rtl" unicode-bidi="plaintext">communicate_info</text>
+<text class="t n" x="543" y="428" direction="rtl" unicode-bidi="plaintext">האם נמסר המידע ההכרחי</text>
+<text class="t n" x="543" y="444" direction="rtl" unicode-bidi="plaintext">במשימה זו null</text>
 <rect x="650" y="392" width="182" height="62" rx="5" fill="#ffffff" stroke="#666666" stroke-width="1.5"/>
-<text class="t m" x="741" y="408">nl_assertions</text>
-<text class="t n" x="741" y="428">שיפוט ברמת שפה טבעית</text>
-<text class="t n" x="741" y="444">במשימה זו null</text>
-<text class="t n" x="440" y="474">reward_basis = ["ENV_ASSERTION"]  ←  רק השכבה הראשונה נחשבת; היתר נרשמות ואינן נכנסות לתגמול</text>
+<text class="t m" x="741" y="408" direction="rtl" unicode-bidi="plaintext">nl_assertions</text>
+<text class="t n" x="741" y="428" direction="rtl" unicode-bidi="plaintext">שיפוט ברמת שפה טבעית</text>
+<text class="t n" x="741" y="444" direction="rtl" unicode-bidi="plaintext">במשימה זו null</text>
+<text class="t n" x="440" y="474" direction="rtl" unicode-bidi="plaintext">reward_basis = ["ENV_ASSERTION"]  ←  רק השכבה הראשונה נחשבת; היתר נרשמות ואינן נכנסות לתגמול</text>
 </svg>

--- a/book-he/images/fig7-4.svg
+++ b/book-he/images/fig7-4.svg
@@ -10,49 +10,48 @@
 .n{font-size:11px;fill:#333333}
 .a{font-size:12px;fill:#333333}
 
-.t,.l{direction:rtl;unicode-bidi:plaintext}
-.c{font-family:'SF Mono',Menlo,Consolas,monospace;direction:ltr;unicode-bidi:plaintext}
+.c{font-family:'SF Mono',Menlo,Consolas,monospace}
 
 </style>
 
 <line x1="40" y1="26" x2="846" y2="26" stroke="#333333" stroke-width="2" marker-end="url(#ax)"/>
-<text class="t a" x="130" y="12">יכולת האימות המכנית של המשימה: גבוהה</text>
-<text class="t a" x="790" y="12">נמוכה</text>
+<text class="t a" x="130" y="12" direction="rtl" unicode-bidi="plaintext">יכולת האימות המכנית של המשימה: גבוהה</text>
+<text class="t a" x="790" y="12" direction="rtl" unicode-bidi="plaintext">נמוכה</text>
 
 <rect x="18" y="52" width="190" height="112" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text class="t h" x="113" y="76">דטרמיניסטי</text>
-<text class="t m" x="113" y="100">מצב סופי יחיד וניתן לשאילתה</text>
-<text class="t m" x="113" y="120">עובר / נכשל</text>
-<text class="t n" x="113" y="146">SWE-bench מריץ בדיקות</text>
+<text class="t h" x="113" y="76" direction="rtl" unicode-bidi="plaintext">דטרמיניסטי</text>
+<text class="t m" x="113" y="100" direction="rtl" unicode-bidi="plaintext">מצב סופי יחיד וניתן לשאילתה</text>
+<text class="t m" x="113" y="120" direction="rtl" unicode-bidi="plaintext">עובר / נכשל</text>
+<text class="t n" x="113" y="146" direction="rtl" unicode-bidi="plaintext">SWE-bench מריץ בדיקות</text>
 <line x1="212" y1="108" x2="232" y2="108" stroke="#666666" stroke-width="1.5" marker-end="url(#ah-s)"/>
 
 <rect x="236" y="52" width="190" height="112" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text class="t h" x="331" y="76">רשימת בדיקות</text>
-<text class="t m" x="331" y="100">כמה בדיקות דטרמיניסטיות</text>
-<text class="t m" x="331" y="120">נצבר לפי הבסיס המוצהר</text>
-<text class="t n" x="331" y="146">ארבע השכבות של τ²-bench</text>
+<text class="t h" x="331" y="76" direction="rtl" unicode-bidi="plaintext">רשימת בדיקות</text>
+<text class="t m" x="331" y="100" direction="rtl" unicode-bidi="plaintext">כמה בדיקות דטרמיניסטיות</text>
+<text class="t m" x="331" y="120" direction="rtl" unicode-bidi="plaintext">נצבר לפי הבסיס המוצהר</text>
+<text class="t n" x="331" y="146" direction="rtl" unicode-bidi="plaintext">ארבע השכבות של τ²-bench</text>
 <line x1="430" y1="108" x2="450" y2="108" stroke="#666666" stroke-width="1.5" marker-end="url(#ah-s)"/>
 
 <rect x="454" y="52" width="190" height="112" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text class="t h" x="549" y="76">Rubric + שיפוט LLM</text>
-<text class="t m" x="549" y="100">יש ממדים, אין הכרעה בקוד</text>
-<text class="t m" x="549" y="120">ניקוד לפי ממד עם נימוק</text>
-<text class="t n" x="549" y="146">איכות שירות, כתיבת דוחות</text>
+<text class="t h" x="549" y="76" direction="rtl" unicode-bidi="plaintext">Rubric + שיפוט LLM</text>
+<text class="t m" x="549" y="100" direction="rtl" unicode-bidi="plaintext">יש ממדים, אין הכרעה בקוד</text>
+<text class="t m" x="549" y="120" direction="rtl" unicode-bidi="plaintext">ניקוד לפי ממד עם נימוק</text>
+<text class="t n" x="549" y="146" direction="rtl" unicode-bidi="plaintext">איכות שירות, כתיבת דוחות</text>
 <line x1="648" y1="108" x2="668" y2="108" stroke="#666666" stroke-width="1.5" marker-end="url(#ah-s)"/>
 
 <rect x="672" y="52" width="190" height="112" rx="6" fill="#f0f0f0" stroke="#333333" stroke-width="2"/>
-<text class="t h" x="767" y="76">השוואה זוגית</text>
-<text class="t m" x="767" y="100">קשה אפילו לנסח ממדים</text>
-<text class="t m" x="767" y="120">שופט רק בין A ל‑B</text>
-<text class="t n" x="767" y="146">Chatbot Arena</text>
+<text class="t h" x="767" y="76" direction="rtl" unicode-bidi="plaintext">השוואה זוגית</text>
+<text class="t m" x="767" y="100" direction="rtl" unicode-bidi="plaintext">קשה אפילו לנסח ממדים</text>
+<text class="t m" x="767" y="120" direction="rtl" unicode-bidi="plaintext">שופט רק בין A ל‑B</text>
+<text class="t n" x="767" y="146" direction="rtl" unicode-bidi="plaintext">Chatbot Arena</text>
 
 <rect x="18" y="192" width="408" height="66" rx="6" fill="#f3f0e8" stroke="#333333" stroke-width="2"/>
-<text class="t h" x="222" y="212">אימות דטרמיניסטי</text>
-<text class="t m" x="222" y="234">ניתן לשחזור מלא, מתאים ל‑CI, זול</text>
-<text class="t m" x="222" y="250">המחיר: אומר נכון או לא, לא היכן הכשל</text>
+<text class="t h" x="222" y="212" direction="rtl" unicode-bidi="plaintext">אימות דטרמיניסטי</text>
+<text class="t m" x="222" y="234" direction="rtl" unicode-bidi="plaintext">ניתן לשחזור מלא, מתאים ל‑CI, זול</text>
+<text class="t m" x="222" y="250" direction="rtl" unicode-bidi="plaintext">המחיר: אומר נכון או לא, לא היכן הכשל</text>
 
 <rect x="454" y="192" width="408" height="66" rx="6" fill="#f3f0e8" stroke="#333333" stroke-width="2"/>
-<text class="t h" x="658" y="212">שיפוט מודל</text>
-<text class="t m" x="658" y="234">נותן ממדים אבחוניים ומכסה את מה שלא ניתן לניסוח</text>
-<text class="t m" x="658" y="250">המחיר: הטיה ותנודתיות בשיפוט, יקר יותר</text>
+<text class="t h" x="658" y="212" direction="rtl" unicode-bidi="plaintext">שיפוט מודל</text>
+<text class="t m" x="658" y="234" direction="rtl" unicode-bidi="plaintext">נותן ממדים אבחוניים ומכסה את מה שלא ניתן לניסוח</text>
+<text class="t m" x="658" y="250" direction="rtl" unicode-bidi="plaintext">המחיר: הטיה ותנודתיות בשיפוט, יקר יותר</text>
 </svg>


### PR DESCRIPTION
## Summary

- unblocks publication of the newly merged Brazilian Portuguese PDF and EPUB
- replaces EPUB-forbidden `direction` and `unicode-bidi` CSS declarations in three Hebrew SVGs with equivalent SVG presentation attributes
- preserves RTL text, LTR code identifiers, fonts, content, and layout

## Root cause

The rolling artifact workflow builds `AI-Agents-in-Depth-ptbr.pdf` successfully, then stops during Hebrew EPUB validation with 12 `CSS-001` errors. Because the release upload step comes later, neither PT-BR artifact reaches the `latest` release and both public links return 404.

## Verification

- reproduced the 12 EPUBCheck errors with the affected SVGs
- reconstructed Hebrew EPUB passes EPUBCheck 5.3.0 with 0 errors and 0 warnings after the change
- all three before/after SVG renders are pixel-identical
- `python3 scripts/check_i18n_consistency.py` passes
- all edited SVGs parse as valid XML
- `git diff --check` passes

## Scope

No PT-BR source content is changed. The three Hebrew SVG edits remove the upstream failure that prevents the already generated PT-BR files from being uploaded.
