### PR TITLE
fix(ch1): 实验 1-2 默认超时从 30 秒提到 180 秒，并区分速率限制与超时

### DIFF
--- a/chapter1/web-search-agent/README.md
+++ b/chapter1/web-search-agent/README.md
@@ -241,7 +241,7 @@ Includes:
 | `KIMI_BASE_URL` | API base URL | `https://api.moonshot.cn/v1` |
 | `DEFAULT_MODEL` | Default model | `kimi-k3` |
 | `MAX_SEARCH_ITERATIONS` | Max search iterations (in Config) | 5 |
-| `SEARCH_TIMEOUT` | Search timeout (seconds) | 30 |
+| `SEARCH_TIMEOUT` | Per-request timeout in seconds, for both the Formula tool call and the chat completion | 180 |
 | `temperature` | Generation creativity | 0.6 |
 
 ### Technical Notes
@@ -276,8 +276,9 @@ Includes:
 
 1. **API limits**: respect Kimi quotas and rate limits
 2. **Search quality**: depends on Kimi’s search capability
-3. **Latency**: web search can take time
-4. **Accuracy**: double-check critical facts; the agent may still err
+3. **Latency**: web search can take time, and `kimi-k3` runs with `reasoning_effort=max`, so a single completion often takes one to a few minutes — hence the 180 s default `SEARCH_TIMEOUT`
+4. **Rate limits**: on a 429 the SDK retries automatically; if the retries use up the timeout budget you will see a timeout rather than a rate-limit error, so check the log for `429` before raising `SEARCH_TIMEOUT`
+5. **Accuracy**: double-check critical facts; the agent may still err
 
 ### Usage tips
 
@@ -518,7 +519,7 @@ python examples.py
 | `KIMI_BASE_URL` | API 基础 URL | `https://api.moonshot.cn/v1` |
 | `DEFAULT_MODEL` | 默认模型 | `kimi-k3` |
 | `MAX_SEARCH_ITERATIONS` | 最大搜索迭代次数（Config 中设置） | 5 |
-| `SEARCH_TIMEOUT` | 搜索超时时间（秒） | 30 |
+| `SEARCH_TIMEOUT` | 单次请求超时（秒），同时作用于 Formula 工具调用与 chat completion | 180 |
 | `temperature` | 控制生成内容的创造性 | 0.6 |
 
 ### 技术特点
@@ -553,8 +554,9 @@ python examples.py
 
 1. **API 限制**: 请注意 Kimi API 的调用限制和配额
 2. **搜索质量**: 搜索结果质量依赖于 Kimi 的搜索能力
-3. **响应时间**: 网络搜索可能需要一定时间，请耐心等待
-4. **内容准确性**: Agent 会尽力提供准确信息，但建议对重要信息进行二次验证
+3. **响应时间**: 网络搜索本身需要时间，而 `kimi-k3` 以 `reasoning_effort=max` 运行，单次调用常需一到数分钟，因此 `SEARCH_TIMEOUT` 默认为 180 秒
+4. **速率限制**: 遇到 429 时 SDK 会自动重试，重试若把超时预算耗完，最终报出的是超时而不是速率限制；调大 `SEARCH_TIMEOUT` 之前，先看日志里有没有 `429`
+5. **内容准确性**: Agent 会尽力提供准确信息，但建议对重要信息进行二次验证
 
 ### 使用建议
 

--- a/chapter1/web-search-agent/agent.py
+++ b/chapter1/web-search-agent/agent.py
@@ -5,7 +5,7 @@ Kimi Web Search Agent
 
 import json
 from typing import List, Dict, Any, Optional
-from openai import OpenAI
+from openai import APITimeoutError, OpenAI, RateLimitError
 from openai.types.chat.chat_completion import Choice
 import logging
 import os
@@ -74,6 +74,25 @@ def search_impl(arguments: Dict[str, Any]) -> Any:
 SEARCH_ERROR_PREFIX = "搜索过程中出现错误"
 MAX_ITERATIONS_MESSAGE = "抱歉，搜索过程超过了最大迭代次数，请稍后重试。"
 NO_INFO_MESSAGE = "抱歉，我无法获取足够的信息来回答您的问题。"
+
+
+def _error_hint(exc: Exception, timeout: Optional[float] = None) -> str:
+    """给 provider 故障补一句可操作的提示。
+
+    交互模式下最常见的两种失败是速率限制和请求超时，而且两者常常连在一起：
+    429 会被 SDK 自动重试，重试把超时预算耗完之后，用户只看到一句
+    "Request timed out"，很容易误判成网络问题或模型能力问题。
+    """
+    if isinstance(exc, RateLimitError):
+        return "（触发了服务商的速率限制，请降低请求频率或稍后重试）"
+    if isinstance(exc, APITimeoutError):
+        budget = f"超过 {timeout:.0f} 秒未返回" if timeout else "超时未返回"
+        return (
+            f"（请求{budget}。kimi-k3 以 reasoning_effort=max 运行，"
+            "单次调用可能需要一到数分钟；若持续超时，可调大环境变量 "
+            "SEARCH_TIMEOUT，并检查日志中是否有 429 导致的反复重试）"
+        )
+    return ""
 
 
 def is_failure_answer(answer: str) -> bool:
@@ -495,8 +514,10 @@ class WebSearchAgent:
             return NO_INFO_MESSAGE
                 
         except Exception as e:
-            logger.error(f"{SEARCH_ERROR_PREFIX}: {str(e)}")
-            return f"{SEARCH_ERROR_PREFIX}: {str(e)}"
+            hint = _error_hint(e, getattr(self, "_request_timeout", None))
+            message = f"{SEARCH_ERROR_PREFIX}: {str(e)}{hint}"
+            logger.error(message)
+            return message
     
     def clear_history(self):
         """清空对话历史"""

--- a/chapter1/web-search-agent/config.py
+++ b/chapter1/web-search-agent/config.py
@@ -55,7 +55,12 @@ class Config:
 
     # 搜索配置
     MAX_SEARCH_ITERATIONS: int = 5  # 最大搜索迭代次数（与 agent 默认值保持一致）
-    SEARCH_TIMEOUT: float = float(os.getenv("SEARCH_TIMEOUT", "30"))
+    # 这个超时同时作用于 Formula 工具调用和 chat completion。kimi-k3 以
+    # reasoning_effort=max 运行，单次 completion 常需 1-3 分钟（validation/
+    # 目录里保留的真实运行记录中有 161 秒、121 秒的调用），30 秒会让交互模式
+    # 反复 "Request timed out"。默认值与 run_experiment_1_2.py 的 --timeout
+    # 保持一致，确保 README 里的交互入口与验收脚本跑在同一配置下。
+    SEARCH_TIMEOUT: float = float(os.getenv("SEARCH_TIMEOUT", "180"))
     
     # 日志配置
     LOG_LEVEL: str = "INFO"

--- a/chapter1/web-search-agent/env.example
+++ b/chapter1/web-search-agent/env.example
@@ -6,7 +6,7 @@ MOONSHOT_API_KEY=your-api-key-here
 # KIMI_BASE_URL=https://api.moonshot.cn/v1
 # DEFAULT_MODEL=kimi-k3
 # MAX_SEARCH_ITERATIONS=5
-# SEARCH_TIMEOUT=30
+# SEARCH_TIMEOUT=180
 
 # 通用兜底：当 MOONSHOT_API_KEY 缺失时，若设置了 OPENROUTER_API_KEY，
 # 请求会自动改走 OpenRouter。注意：Kimi 内置 $web_search 工具在 OpenRouter

--- a/chapter1/web-search-agent/tests/test_agent.py
+++ b/chapter1/web-search-agent/tests/test_agent.py
@@ -2,7 +2,15 @@
 
 from unittest.mock import Mock
 
-from agent import WebSearchAgent, _reasoning_safe_temperature, format_trace_step
+import httpx
+from openai import APITimeoutError, RateLimitError
+
+from agent import (
+    WebSearchAgent,
+    _error_hint,
+    _reasoning_safe_temperature,
+    format_trace_step,
+)
 
 
 class FakeResponse:
@@ -282,3 +290,52 @@ def test_agent_loop_survives_malformed_tool_arguments_json(make_choice):
         "web_search", '{"query": "moonshot",}'
     )
     assert any(step["type"] == "action" for step in instance.get_trace())
+
+
+def _timeout_error():
+    request = httpx.Request("POST", "https://api.moonshot.cn/v1/chat/completions")
+    return APITimeoutError(request=request)
+
+
+def _rate_limit_error():
+    request = httpx.Request("POST", "https://api.moonshot.cn/v1/chat/completions")
+    response = httpx.Response(429, request=request)
+    return RateLimitError("rate limit reached", response=response, body=None)
+
+
+def test_timeout_answer_names_the_budget_and_the_429_suspect():
+    """"Request timed out." alone reads like a network fault; the reader has
+    to be told which knob to turn and that 429 retries can burn the budget."""
+    instance = build_agent()
+    instance._request_timeout = 180
+    instance._chat = Mock(side_effect=_timeout_error())
+
+    answer = instance.search_and_answer("question")
+
+    assert answer.startswith("搜索过程中出现错误")
+    assert "180 秒" in answer
+    assert "SEARCH_TIMEOUT" in answer
+    assert "429" in answer
+
+
+def test_rate_limit_answer_says_it_is_a_rate_limit():
+    instance = build_agent()
+    instance._request_timeout = 180
+    instance._chat = Mock(side_effect=_rate_limit_error())
+
+    answer = instance.search_and_answer("question")
+
+    assert "速率限制" in answer
+
+
+def test_error_hint_without_a_known_timeout_still_reads():
+    """The hint is built inside an error path, so a partially constructed
+    agent must not turn a provider failure into an AttributeError."""
+    hint = _error_hint(_timeout_error())
+
+    assert "SEARCH_TIMEOUT" in hint
+    assert "秒" not in hint.split("kimi-k3")[0]
+
+
+def test_error_hint_is_empty_for_unrelated_failures():
+    assert _error_hint(RuntimeError("provider unavailable"), 180) == ""


### PR DESCRIPTION
Fixes #1032

@BruceZhang0808 反馈的三次运行里有两次以 `Request timed out` 收尾。查下来这确实是仓库的问题，不是网络问题。

## 根因

`Config.SEARCH_TIMEOUT` 默认 **30 秒**，并被直接当作 OpenAI 客户端的整体 timeout：

```python
self.client = OpenAI(..., timeout=Config.SEARCH_TIMEOUT)   # agent.py:124
```

而 `kimi-k3` 是以 `reasoning_effort="max"`、`max_tokens=32768` 调用的，单次 completion 本来就慢。**本目录自己保留的真实运行证据**就说明了这一点：

```
validation/real_20260729T163003Z/  chat_completion 耗时：161.0s / 121.7s / 64.1s / 20.0s / 12.4s
validation/real_20260729T163623Z/  chat_completion 耗时：41.0s / 39.1s / 31.0s / 22.3s / 15.1s
```

这些运行之所以能跑通，是因为验收脚本 `run_experiment_1_2.py` 的 `--timeout` 默认是 **180 秒**（`run_experiment_1_2.py:209`），运行前会写进 `os.environ["SEARCH_TIMEOUT"]`。也就是说：

| 入口 | 有效超时 | 结果 |
|---|---|---|
| `run_experiment_1_2.py`（验收） | 180 s | 通过 |
| `main.py` 交互模式（README 让读者用的） | 30 s | 经常超时 |

两条入口跑在不同配置下，读者按 README 走必然踩坑。

另外，日志里的 `429 Too Many Requests` 会被 SDK 自动重试，重试把 30 秒预算耗完后抛出的是 `APITimeoutError`，读者只看到一句 `Request timed out`，看不出真正的原因是限流。

## 改动

1. `Config.SEARCH_TIMEOUT` 默认 **30 → 180**，与验收脚本对齐，并在注释里写明理由。
2. 新增 `_error_hint()`：`RateLimitError` 直说是速率限制；`APITimeoutError` 报出超时预算、说明 `kimi-k3` 单次调用的量级、提示调大 `SEARCH_TIMEOUT` 并去日志里查 `429`。

   ```
   搜索过程中出现错误: Request timed out.（请求超过 180 秒未返回。kimi-k3 以
   reasoning_effort=max 运行，单次调用可能需要一到数分钟；若持续超时，可调大
   环境变量 SEARCH_TIMEOUT，并检查日志中是否有 429 导致的反复重试）
   ```

3. README（中英两版）配置表与注意事项、`env.example` 同步；新增 4 个单元测试（共 42 passed）。

`is_failure_answer()` 依赖的 `SEARCH_ERROR_PREFIX` 前缀语义不变，`examples.batch_search` 等调用方不受影响。

## 关于 SpaceX 那个答案

顺带说明：那次成功运行给出的答案本身是**对的**——SpaceX 至今没有上市，没有公开股价，Agent 报的 2024 年 12 月 185 美元/股的 tender offer 价格是私募市场的成交参考价。Kimi 网页端给出「8 月 26 日的股价」反而更可能是把某个同名代码或二级市场报价当成了官方股价。这类问题上，Agent 明确说明「没有公开股价」比编一个数字更可取。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iSm7JBWoy87hxSpUkJ49T