### PR TITLE
feat(providers): add Krill AI gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,10 @@ OPENROUTER_MODEL=google/gemma-4-31b-it:free
 # DEEPSEEK_API_KEY=your-deepseek-key
 # DEEPSEEK_BASE_URL=https://api.deepseek.com
 
+# Krill AI
+# KRILL_API_KEY=your-krill-key
+# KRILL_BASE_URL=https://api.krill-code.net/v1
+
 # Zhipu (GLM)
 # ZHIPU_API_KEY=your-zhipu-key
 

--- a/agentbook/providers/registry.py
+++ b/agentbook/providers/registry.py
@@ -69,6 +69,13 @@ PROVIDERS: dict[str, Provider] = {
         default_model="glm-5.2",
         key_vars=("ZHIPU_API_KEY",),
     ),
+    "krill": Provider(
+        name="krill",
+        base_url="https://api.krill-code.net/v1",
+        default_model="gpt-5.6-luna",
+        key_vars=("KRILL_API_KEY",),
+        base_url_var="KRILL_BASE_URL",
+    ),
     "openrouter": Provider(
         name="openrouter",
         base_url=OPENROUTER_BASE_URL,

--- a/agentbook/providers/resolution.py
+++ b/agentbook/providers/resolution.py
@@ -87,11 +87,11 @@ def _needs_openrouter_for_gpt5(
     only with ``reasoning_effort="none"``, which is the one thing an agent
     experiment cannot give up. OpenRouter has neither restriction.
 
-    The exception is a reader who named ``openai`` themselves: sending their
-    prompts and their spend to a third party against an explicit instruction is
-    worse than the failure it avoids. A caller whose provider name is its own
-    built-in default rather than the reader's choice passes
-    ``chosen_by_reader=False`` and is rerouted like any other provider.
+    The exception is a reader who named ``openai`` or ``krill`` themselves:
+    sending their prompts and their spend to a different provider against an
+    explicit instruction is worse than the failure it avoids. A caller whose
+    provider name is its own built-in default rather than the reader's choice
+    passes ``chosen_by_reader=False`` and is rerouted like any other provider.
 
     Args:
         spec: The provider that was requested.
@@ -104,7 +104,7 @@ def _needs_openrouter_for_gpt5(
     """
     if not model.lower().startswith("gpt-5"):
         return False
-    return not (spec.name == "openai" and chosen_by_reader)
+    return not (spec.name in {"openai", "krill"} and chosen_by_reader)
 
 
 def _missing_key_error(spec: Provider) -> ValueError:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -29,6 +29,7 @@ PROVIDER_KEY_VARS = [
     "MOONSHOT_API_KEY",
     "KIMI_API_KEY",
     "DEEPSEEK_API_KEY",
+    "KRILL_API_KEY",
     "ZHIPU_API_KEY",
     "OPENAI_API_KEY",
     "GEMINI_API_KEY",
@@ -38,6 +39,7 @@ PROVIDER_KEY_VARS = [
     "OPENROUTER_MODEL",
     "OPENROUTER_BASE_URL",
     "DEEPSEEK_BASE_URL",
+    "KRILL_BASE_URL",
     "KIMI_BASE_URL",
     "OLLAMA_BASE_URL",
     "OPENAI_BASE_URL",
@@ -150,6 +152,59 @@ def test_dashscope_international_region_override(monkeypatch):
     )
     backend = resolve_backend("dashscope")
     assert backend.base_url == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+
+
+def test_krill_key_uses_multi_model_gateway_directly(monkeypatch):
+    monkeypatch.setenv("KRILL_API_KEY", "test-krill-key")
+    backend = resolve_backend("krill")
+    assert backend.api_key == "test-krill-key"
+    assert backend.base_url == "https://api.krill-code.net/v1"
+    assert backend.model == "gpt-5.6-luna"
+    assert backend.provider == "krill"
+    assert backend.using_openrouter is False
+
+
+def test_krill_keeps_bare_model_ids(monkeypatch):
+    monkeypatch.setenv("KRILL_API_KEY", "test-krill-key")
+    backend = resolve_backend("krill", model="gemini-3.5-flash")
+    assert backend.model == "gemini-3.5-flash"
+
+
+def test_krill_base_url_override(monkeypatch):
+    monkeypatch.setenv("KRILL_API_KEY", "test-krill-key")
+    monkeypatch.setenv("KRILL_BASE_URL", "https://krill-gateway.example/v1")
+    assert resolve_backend("krill").base_url == "https://krill-gateway.example/v1"
+
+
+def test_explicit_krill_provider_is_not_hijacked_for_gpt5(monkeypatch):
+    monkeypatch.setenv("KRILL_API_KEY", "test-krill-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+    backend = resolve_backend("krill", model="gpt-5.6-luna")
+    assert backend.api_key == "test-krill-key"
+    assert backend.base_url == "https://api.krill-code.net/v1"
+    assert backend.model == "gpt-5.6-luna"
+    assert backend.using_openrouter is False
+
+
+def test_default_krill_provider_is_rerouted_for_gpt5(monkeypatch):
+    monkeypatch.setenv("KRILL_API_KEY", "test-krill-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+    backend = resolve_backend(
+        "krill", model="gpt-5.6-luna", chosen_by_reader=False
+    )
+    assert backend.api_key == "test-openrouter-key"
+    assert backend.base_url == "https://openrouter.ai/api/v1"
+    assert backend.model == "openai/gpt-5.6-luna"
+    assert backend.using_openrouter is True
+
+
+def test_krill_still_falls_back_when_its_key_is_missing(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+    backend = resolve_backend("krill")
+    assert backend.api_key == "test-openrouter-key"
+    assert backend.base_url == "https://openrouter.ai/api/v1"
+    assert backend.model == "openai/gpt-5.6-luna"
+    assert backend.using_openrouter is True
 
 
 def test_falls_back_to_openrouter_when_provider_key_missing(monkeypatch):
@@ -294,6 +349,7 @@ def test_supported_providers_covers_registry_and_aliases():
     assert "ollama" in SUPPORTED_PROVIDERS
     assert "openai" in SUPPORTED_PROVIDERS
     assert "gemini" in SUPPORTED_PROVIDERS
+    assert "krill" in SUPPORTED_PROVIDERS
 
 
 def test_fallback_key_is_not_reusable_as_a_provider_key(monkeypatch):


### PR DESCRIPTION
## Summary

- register Krill AI as an OpenAI-compatible provider
- add `KRILL_API_KEY` and optional `KRILL_BASE_URL` configuration
- keep bare Krill model IDs and default to `gpt-5.6-luna`
- honor an explicit Krill selection in the existing GPT-5/OpenRouter routing policy
- add coverage for direct resolution, URL overrides, model IDs, and fallback behavior

## Verification

- `uv run --with ruff ruff check agentbook/providers tests/test_providers.py`
- `uv run --with pytest python -m pytest tests/test_providers.py tests/test_resolve_backend_whitespace_model.py -q` (`78 passed`)
- live OpenAI-compatible Chat Completions smoke test against the Krill endpoint