### PR TITLE
Fix Browser Use RPA quickstart path

### DIFF
--- a/chapter9/browser-use-rpa/README.md
+++ b/chapter9/browser-use-rpa/README.md
@@ -85,7 +85,7 @@ source .venv/bin/activate
 # 未安装 uv 时可用 pip 兜底：
 # python -m pip install -e ".[ch8]"
 
-cd chapter8/browser-use-rpa
+cd chapter9/browser-use-rpa
 
 # 迁移期间仍支持单项目兼容路径（playwright-stealth 等历史可选依赖）：
 # python -m pip install -r requirements.txt


### PR DESCRIPTION
The Browser Use RPA example lives in `chapter9/browser-use-rpa`, but its quickstart currently sends readers to `chapter8/browser-use-rpa`, which does not exist.

This changes the `cd` command to the directory that contains `demo_email.py` and `requirements.txt`.

Checks:
- reproduced the old command failing from the repository root
- verified the new directory and both referenced smoke-test files exist
- `python scripts/check_i18n_consistency.py`
- `git diff --check`