### PR TITLE
fix(pedo/eval): let the timeout handler run in execute_test_case

### DIFF
--- a/chapter5/permission-embedded-data-objects/pedo/eval/benchmark_spec_errors_v2.py
+++ b/chapter5/permission-embedded-data-objects/pedo/eval/benchmark_spec_errors_v2.py
@@ -285,6 +285,8 @@ def execute_test_case(code: str, test_case: dict) -> dict:
             else:
                 return {"status": "pass", "result": f"rejected: {result}"}
 
+    except TimeoutError:
+        return {"status": "timeout", "error": "timed out"}
     except (ValueError, PermissionError, Exception) as e:
         signal.alarm(0)
         err = str(e)
@@ -292,8 +294,6 @@ def execute_test_case(code: str, test_case: dict) -> dict:
             return {"status": "pass", "result": f"rejected via exception: {err[:80]}"}
         else:
             return {"status": "fail", "result": f"should allow but raised: {err[:80]}"}
-    except TimeoutError:
-        return {"status": "timeout", "error": "timed out"}
     finally:
         signal.signal(signal.SIGALRM, old_handler)
         signal.alarm(0)


### PR DESCRIPTION
`chapter5/permission-embedded-data-objects/pedo/eval/benchmark_spec_errors_v2.py` guards each generated test case with a 5-second `SIGALRM`, whose handler raises the module's own `TimeoutError`:

```python
class TimeoutError(Exception):
    pass

def _timeout_handler(signum, frame):
    raise TimeoutError("timed out")
```

But in `execute_test_case` the broad handler is listed first:

```python
    except (ValueError, PermissionError, Exception) as e:
        ...
        if expected == "reject":
            return {"status": "pass", "result": f"rejected via exception: {err[:80]}"}
        else:
            return {"status": "fail", "result": f"should allow but raised: {err[:80]}"}
    except TimeoutError:
        return {"status": "timeout", "error": "timed out"}
```

`TimeoutError` subclasses `Exception`, so the tuple already caught it and the timeout handler never ran. Two consequences:

- A generated function that hangs on an `expected: "reject"` case scored **pass** — `"rejected via exception: timed out"`. An infinite loop counted as a correct rejection.
- `print_spec_v2_results` computes its "Error" column as `sum(1 for t in tests if t["status"] in ("compile_error", "timeout"))`, so that column could only ever count compile errors.

Moving the handler above the broad one is enough. `benchmark_final_comprehensive.py`, in the same `eval/` directory, already has the working shape — `except (ValueError, PermissionError)` (no `Exception`) followed by `except TimeoutError` — which is what the ordering here was meant to be.

### Verification

`TimeoutError`, `_timeout_handler` and `execute_test_case` were lifted out of the file by line range (nothing retyped) and exercised on Linux with a real `SIGALRM`, using a test expression that sleeps past the 5-second alarm:

| case | before | after |
|---|---|---|
| times out, `expected: allow` | `{'status': 'fail', 'result': 'should allow but raised: timed out'}` | `{'status': 'timeout', 'error': 'timed out'}` |
| times out, `expected: reject` | `{'status': 'pass', 'result': 'rejected via exception: timed out'}` | `{'status': 'timeout', 'error': 'timed out'}` |
| returns `True`, `expected: allow` | `pass` | unchanged |
| returns a string, `expected: reject` | `pass` | unchanged |
| raises `PermissionError`, `expected: reject` | `pass` | unchanged |
| raises `PermissionError`, `expected: allow` | `fail` | unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
