### PR TITLE
feat: add Atlas Cloud provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,10 @@ OPENROUTER_MODEL=google/gemma-4-31b-it:free
 # KRILL_API_KEY=your-krill-key
 # KRILL_BASE_URL=https://api.krill-code.net/v1
 
+# Atlas Cloud
+# ATLASCLOUD_API_KEY=your-atlascloud-key
+# ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1
+
 # Zhipu (GLM)
 # ZHIPU_API_KEY=your-zhipu-key
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ uv run python chapter1/context/main.py
 | **智谱 GLM** | <https://open.bigmodel.cn/> | GLM-5.2 等，Coding、Agent 能力强 | 中国大陆 |
 | **Siliconflow** | <https://siliconflow.cn/> | 各种开源模型（DeepSeek、Qwen 等），中国大陆访问速度快 | 中国大陆 |
 | **DeepSeek** | <https://platform.deepseek.com/> | DeepSeek 官方 API | 全球 + 中国大陆 |
+| **Atlas Cloud** | <https://www.atlascloud.ai/> | 通过 OpenAI 兼容接口访问多个厂商的模型 | 全球 |
 | **Krill AI** | [www.krill-code.com](https://www.krill-code.com/register?invite=Q8D3L35725) | 一站式访问全球及国内主流模型（OpenAI、Claude、Gemini、Grok、Kimi、GLM、DeepSeek、Qwen、Minimax） | 全球 + 中国大陆 |
 | **OpenRouter** | <https://openrouter.ai/> | 一站式访问全球及国内主流模型（GPT、Claude、Gemini、Kimi、GLM、DeepSeek、Qwen 等） | 全球 |
 

--- a/agentbook/providers/registry.py
+++ b/agentbook/providers/registry.py
@@ -76,6 +76,15 @@ PROVIDERS: dict[str, Provider] = {
         key_vars=("KRILL_API_KEY",),
         base_url_var="KRILL_BASE_URL",
     ),
+    "atlascloud": Provider(
+        name="atlascloud",
+        base_url="https://api.atlascloud.ai/v1",
+        default_model="openai/gpt-4.1-mini",
+        key_vars=("ATLASCLOUD_API_KEY",),
+        base_url_var="ATLASCLOUD_BASE_URL",
+        # Atlas Cloud serves models from multiple vendors under namespaced ids.
+        namespaces_models=True,
+    ),
     "openrouter": Provider(
         name="openrouter",
         base_url=OPENROUTER_BASE_URL,

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -107,6 +107,7 @@ It is recommended to apply for API keys from several platforms for convenient le
 | **Zhipu GLM** | <https://open.bigmodel.cn/> | GLM-4.6 etc., strong Chinese ability, cost-effective | Mainland China |
 | **Siliconflow** | <https://siliconflow.cn/> | Various open-source models (DeepSeek, Qwen, etc.), fast access from mainland China | Mainland China |
 | **DeepSeek** | <https://platform.deepseek.com/> | Official DeepSeek API | Global + Mainland China |
+| **Atlas Cloud** | <https://www.atlascloud.ai/> | Access models from multiple vendors through an OpenAI-compatible API | Global |
 | **Krill AI** | [www.krill-code.com](https://www.krill-code.com/register?invite=Q8D3L35725) | One-stop access to major global and China-domestic models (OpenAI, Claude, Gemini, Grok, Kimi, GLM, DeepSeek, Qwen, Minimax) | Global + Mainland China |
 | **OpenRouter** | <https://openrouter.ai/> | One-stop access to major global and China-domestic models (GPT, Claude, Gemini, Kimi, GLM, DeepSeek, Qwen, etc.) | Global |
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -22,6 +22,8 @@ from agentbook.providers.registry import supported_providers
 from agentbook.providers.resolution import build_openrouter_backend
 
 PROVIDER_KEY_VARS = [
+    "ATLASCLOUD_API_KEY",
+    "ATLASCLOUD_BASE_URL",
     "DASHSCOPE_API_KEY",
     "DASHSCOPE_BASE_URL",
     "SILICONFLOW_API_KEY",
@@ -174,6 +176,27 @@ def test_krill_base_url_override(monkeypatch):
     monkeypatch.setenv("KRILL_API_KEY", "test-krill-key")
     monkeypatch.setenv("KRILL_BASE_URL", "https://krill-gateway.example/v1")
     assert resolve_backend("krill").base_url == "https://krill-gateway.example/v1"
+
+
+def test_atlascloud_key_uses_multi_model_gateway_directly(monkeypatch):
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-atlascloud-key")
+    backend = resolve_backend("atlascloud")
+    assert backend.api_key == "test-atlascloud-key"
+    assert backend.base_url == "https://api.atlascloud.ai/v1"
+    assert backend.model == "openai/gpt-4.1-mini"
+    assert backend.provider == "atlascloud"
+    assert backend.using_openrouter is False
+
+
+def test_atlascloud_namespaces_bare_model_ids(monkeypatch):
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-atlascloud-key")
+    assert resolve_backend("atlascloud", model="gpt-4o").model == "openai/gpt-4o"
+
+
+def test_atlascloud_base_url_override(monkeypatch):
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-atlascloud-key")
+    monkeypatch.setenv("ATLASCLOUD_BASE_URL", "https://atlas.example/v1")
+    assert resolve_backend("atlascloud").base_url == "https://atlas.example/v1"
 
 
 def test_explicit_krill_provider_is_not_hijacked_for_gpt5(monkeypatch):
@@ -350,6 +373,7 @@ def test_supported_providers_covers_registry_and_aliases():
     assert "openai" in SUPPORTED_PROVIDERS
     assert "gemini" in SUPPORTED_PROVIDERS
     assert "krill" in SUPPORTED_PROVIDERS
+    assert "atlascloud" in SUPPORTED_PROVIDERS
 
 
 def test_fallback_key_is_not_reusable_as_a_provider_key(monkeypatch):


### PR DESCRIPTION
## Summary

- register Atlas Cloud as an optional OpenAI-compatible multi-model provider
- document the API key and base URL settings in the environment template
- cover direct resolution, model namespacing, and endpoint overrides with tests
- list the provider in the Chinese and English API-key tables

## Testing

- `uv run --extra dev python -m pytest tests/test_providers.py -q` (80 passed)
- `uv run --extra dev ruff check agentbook/providers/registry.py tests/test_providers.py`
- one live OpenAI-compatible chat smoke against `openai/gpt-4.1-mini`

The repository-wide pytest collection currently exits from `chapter3/agentic-rag-for-user-memory/test_enhanced_logging.py` when `KIMI_API_KEY` is absent, before the full suite can run.